### PR TITLE
修复了预设管理里面，预设条目没有正常显示的bug

### DIFF
--- a/src/ui/stores/settings-store.ts
+++ b/src/ui/stores/settings-store.ts
@@ -311,6 +311,14 @@ export const useSettingsStore = defineStore('settings', () => {
         if (!settings.value.activePresetId) {
           settings.value.activePresetId = entry.presetId
         }
+        // Fix D：如果 activePresetId 指向的预设不存在于内存中，回落至项目默认
+        if (entry.presetId && settings.value.activePresetId !== entry.presetId) {
+          const currentId = settings.value.activePresetId as string
+          const exists = (settings.value.presets as PresetItem[]).find(p => p.id === currentId)
+          if (!exists) {
+            settings.value.activePresetId = entry.presetId
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
fix(settings): activePresetId指向不存在预设时自动回落至项目默认

seed流程仅在activePresetId为空时才会设置默认值，导致设置页预设管理下拉列表为空。

Fix D: 在loadAgentProjectDefaults()中追加校验若activePresetId指向的预设不在s.presets内存中，自动回落至agent-config.json的项目默认presetId。

文件 ： src/ui/stores/settings-store.ts

问题 ： loadAgentProjectDefaults() 中， activePresetId 仅在为空时设置，但如果 localStorage 残留了指向不存在预设的旧 ID，seed 流程不会修正它，导致设置页「预设管理」下拉为空。

修复（Fix D） ：在种子逻辑追加了 8 行校验——如果 activePresetId 指向的预设不在 s.presets 内存中，自动回落至项目默认 presetId ：

```
if (entry.presetId && settings.
value.activePresetId !== entry.
presetId) {
  const currentId = settings.value.
  activePresetId as string
  const exists = (settings.value.
  presets as PresetItem[]).find(p 
  => p.id === currentId)
  if (!exists) {
    settings.value.activePresetId = 
    entry.presetId
  }
}
```
覆盖的场景 ：

- ✅ 旧 ID 指向不存在的预设 → 自动修正
- ✅ 用户选的有效预设 → 保留不变
- ✅ 首次运行 activePresetId="" → 走既有的空值分支，不受影响
- ✅ 所有 218 项测试通过