### PR TITLE
战斗 v3 M0 — 地基：分通道骰带 + replay harness + 纯函数签名改造

### DIFF
--- a/.claude/agent-memory/code-writer/MEMORY.md
+++ b/.claude/agent-memory/code-writer/MEMORY.md
@@ -13,3 +13,4 @@
 - [真机走查页面换不了视图](browser-pane-raf-blocks-transitions.md) — Browser pane 不显示则无 rAF，Vue transition mode="out-in" 永远卡首屏；先 reload 再打 rAF 补丁再切视图
 - [prettier 基线本来就是红的](prettier-baseline-dirty.md) — CI 跑 format:check 但 HEAD 就有 423 文件不合格；只校自己动过的文件，千万别跑 npm run format
 - [.bat stderr 噪音要换姿势才测得出](bat-stderr-harness-dependent.md) — Start-Process 恒报 0；只有 Git Bash 的 `cmd.exe /c 全路径 2> e.txt < /dev/null` 复现得出。测 dev.bat 先把端口改等长安全值，别碰 5173
+- [v3 M0 签名改造落点](combat-v3-m0-signature-refactor.md) — performAttackCheck 改 rolls[]、morale d20 必传、AppSettings.combatEngineVersion；调用点传同值保 v2 行为；M1 起内核从 DiceTape 取真骰

--- a/.claude/agent-memory/code-writer/combat-v3-m0-signature-refactor.md
+++ b/.claude/agent-memory/code-writer/combat-v3-m0-signature-refactor.md
@@ -1,0 +1,20 @@
+---
+name: combat-v3-m0-signature-refactor
+description: 战斗 v3 M0「v2 纯函数签名改造」落点 — performAttackCheck 改 rolls[]、morale d20 必传、AppSettings.combatEngineVersion、resolveIntention 调用点铺路
+metadata:
+  type: project
+---
+
+战斗 v3 M0 地基的「v2 纯函数签名改造」于 2026-08-01 完成。把 v2 战斗纯函数里内部自产的骰值改为调用方显式传入，铁律是 v2 行为零变化。
+
+**Why:** 这是差分测试（contract test）的地基——v3 内核（combat-v3/）必须能用同输入复现 v2 纯函数结果。v2 用 Math.random() 内部伪造第二颗骰（M-5）、意图对抗攻守共用一颗骰（C5）、士气骰恒 10（M-4），这些都让 replay 不可能。M0 只改签名铺路，真正双骰由 M1 内核从 DiceTape 分通道取。
+
+**How to apply:**
+- `performAttackCheck`（combat-damage.ts）：`AttackCheckInput.d20Roll: number` → `rolls: [number, number?]`。优势取 max、劣势取 min、同层级用 rolls[0]；rolls[1] 缺省退化为单骰。两处 Math.random() 已删。
+- 调用点传 `[d20, d20]`（同值，等效 v2 行为结构）：combat-pipeline.ts:256、combat-resolver.ts:143。
+- `resolveIntention`（combat-intention.ts）签名**未改**——`IntentionCheckInput` 早有 attackerD20/defenderD20 两字段，C5 bug 在调用点。M0 把两个调用点（pipeline:215、resolver:125）统一为攻守同值双喂（resolver 原本是攻方定值+守方 Math.random()，现已对齐 pipeline）。
+- `runMoraleCheckPipeline`（combat-morale-pipeline.ts）：`d20Roll?: number` + `?? 10` 默认值 → 必传 `d20Roll: number`。调用点（combat-pipeline.ts:345）显式传 10。
+- `AppSettings.combatEngineVersion: 'v2' | 'v3'`（types.ts）+ DEFAULT_SETTINGS 默认 'v2'。分支点唯一（game-pipeline.handleCombatTrigger），M5 才翻 v3。
+- 测试调整：combat-damage.test.ts 的 6 个 performAttackCheck 用例字段名改 rolls（同层级传 [n]，优劣势传 [n,n]）；combat-integration-scenario.test.ts:269 同改；combat-morale-pipeline.test.ts 6 处省略实参的调用补传 10。所有断言未改（容差断言 >= / <= 在传同值后仍成立）。
+
+**边界：** 本任务**绝对不碰** src/sillytavern/combat-v3/（另一个 agent 并行做 DiceTape/replay/types）和 src/ui/（M0 不动前端）。no-nondeterminism.test.ts 的 node:fs 报错是另一个 agent 的，不归本任务。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,7 +312,7 @@ bash scripts/notify.sh "<Phase名称> 完成!" "<关键指标>"
 | Audio     | 音频系统 v1.0（双通道+三后端+按名寻址+场景配乐）       | ✅                  |
 | 素材      | 素材管理系统 v1.0（渲染面+大画像+裁剪台+画像弹窗）     | ✅                  |
 | 战斗 v2   | 战斗系统架构 v2（管道+中间件+6大类+19event+独立面板）  | ✅ M5完成 待M6真机  |
-| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 🔄 M0完成 待M1     |
+| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 🔄 M0完成 待M1      |
 | 工坊 P0   | 世界书迁出 localStorage → Dexie v14（+ 进 FullBackup） | ✅                  |
 | 工坊 P0b  | 美化规则迁出 localStorage → Dexie v15                  | ✅                  |
 | 工坊 P1   | 创意工坊（浏览/安装/更新/卸载/启用，= 7f）             | ✅ 真机已过         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,7 +312,7 @@ bash scripts/notify.sh "<Phase名称> 完成!" "<关键指标>"
 | Audio     | 音频系统 v1.0（双通道+三后端+按名寻址+场景配乐）       | ✅                  |
 | 素材      | 素材管理系统 v1.0（渲染面+大画像+裁剪台+画像弹窗）     | ✅                  |
 | 战斗 v2   | 战斗系统架构 v2（管道+中间件+6大类+19event+独立面板）  | ✅ M5完成 待M6真机  |
-| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 📋 架构+plan 已定稿 |
+| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 🔄 M0完成 待M1     |
 | 工坊 P0   | 世界书迁出 localStorage → Dexie v14（+ 进 FullBackup） | ✅                  |
 | 工坊 P0b  | 美化规则迁出 localStorage → Dexie v15                  | ✅                  |
 | 工坊 P1   | 创意工坊（浏览/安装/更新/卸载/启用，= 7f）             | ✅ 真机已过         |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,30 @@
 
 ## 进行中 / 近期交付（按交付时间倒序）
 
+### 战斗 v3 M0 — 地基：分通道骰带 + replay harness + 纯函数签名改造 ｜ ✅ 完成（2026-08-01）
+
+架构真源: `docs/reference/combat-system-architecture-v3.md`（§四 DiceTape / §1.4 五处代码修正）；实施计划: `docs/planning/2026-07-31-combat-v3-implementation-plan.md` §2。把 v2 的「Agent 主持流程」翻转为「代码内核主持流程」的地基——所有新代码落 `src/sillytavern/combat-v3/`（deep module，唯一公共出口 `index.ts` 留待 M1），v2 代码 M5 前一行不删，靠 feature flag 整场切换。
+
+**新建 `combat-v3/` deep module:**
+
+- `types.ts` — DiceChannel / DiceEpoch / DiceTapeState / CombatProvenance + CombatFixture 全类型 + `DEFAULT_CHANNEL_SPLIT`（attackHit 32 / initiative 10 / intentCheck 7 / statusContest 6 / procCheck 5，D6 实测加权，RFC §5.7「各 12 颗均分」被推翻）+ CHANNEL_ORDER
+- `dice-tape.ts` — `createTape` / `draw` / `beginEpoch` / `splitSixty` 纯函数（不可变更新）。draw 只推进目标通道 cursor，耗尽不推进任何 cursor；beginEpoch 旧 epoch 进 exhausted、cursor 归零；**不做通道间借用**（架构 §一 1.6 否决项，保 replay 干净）
+- `replay.ts` — `replayCombat(fixture, reducer?)` 纯函数：validateFixture 结构校验 + buildTape 验证骰带可建 + hashFixture 规范化 djb2（忽略 `_synthetic`/`_provenance` 元数据）+ reducer 注入缝（M1 起驱动 commands）
+- `fixtures/case-06-summon.fixture.json` / `case-24-reflection.fixture.json` — 两场简版 fixture，含 `_provenance` 骰值对照表（样本行号→fixture 骰值）+ `_synthetic` 标记
+
+**v2 纯函数签名改造（差分测试地基，v2 行为零变化）:**
+
+- `performAttackCheck`: `d20Roll: number` → `rolls: [number, number?]`，删除两处 `Math.random()` 模拟第二骰（修复架构 §1.4 M-5）
+- `runMoraleCheckPipeline`: `d20Roll` 改必传（修复 M-4 战意骰恒 10）
+- `combat-pipeline.ts` / `combat-resolver.ts` 调用点补传 `rolls:[d20,d20]` / `d20Roll:10`（v2 行为等价）；额外修复 `combat-resolver.ts:134` 守方意图骰的 `Math.random()` 统一为同值双喂
+- `AppSettings.combatEngineVersion: 'v2'|'v3'` 默认 `'v2'`（feature flag，分支点唯一 `game-pipeline.handleCombatTrigger`，M5 才翻 v3）
+
+**反非确定性守卫:** `no-nondeterminism.test.ts` 用 `import.meta.glob` + `?raw` 扫描 `combat-v3/` 全部 `.ts`（排除 test），断言零 `Math.random` / `new Function` / `eval`（铁律 1/2，全链路根除审查报告 C1）。
+
+**验收:** A0-1 ~ A0-8 全过。全量 4757 测试 / 144 文件全绿；typecheck 零错误。combat-v3 新增 57 测试（dice-tape 35 + no-nondeterminism 4 + replay 22，含两场 fixture milestone 断言）；v2 战斗测试 177 个零行为变化。
+
+**已知遗留（M1 对齐）:** fixture command kind 用了 `UseSkill`（非架构 §二 2.2 枚举），M0 replay 不校验 command kind，M1 内核 dispatch 时改 fixture 为 `DeclareAction`。
+
 ### 工坊 P1 — 创意工坊（= Phase 7f） ｜ ✅ 真机走查已过（2026-07-31）
 
 设计: `docs/planning/2026-07-31-creative-workshop-compat-design.md`（v2，D1-D17）；实施计划: `docs/planning/2026-07-31-workshop-phase0-1-implementation-plan.md`。上游是【命定之诗】创意工坊（角色卡内嵌酒馆助手脚本 + Cloudflare Worker 后端），本引擎**不嵌 iframe、不跑上游 JS**，只直连其公开 REST。

--- a/src/sillytavern/combat-damage.test.ts
+++ b/src/sillytavern/combat-damage.test.ts
@@ -309,7 +309,7 @@ describe('runDamagePipeline', () => {
 describe('performAttackCheck', () => {
   it('同层级: 1d20 正常检定', () => {
     const result = performAttackCheck({
-      d20Roll: 15,
+      rolls: [15],
       attackerTier: 3,
       defenderTier: 3,
       hitBonus: 5,
@@ -326,7 +326,10 @@ describe('performAttackCheck', () => {
 
   it('高T对低T: 优势 (2d20取高)', () => {
     const result = performAttackCheck({
-      d20Roll: 10,
+      // v3 M0: 显式传两颗骰（架构 §1.4 M-5）。传同值 10 等效 v2 行为下界，
+      // max(10,10)=10。原 v2 用 Math.random() 伪造第二骰，断言用 >=10 容差，
+      // 改造后 diceUsed 确定为 10，断言仍成立。
+      rolls: [10, 10],
       attackerTier: 5,
       defenderTier: 3,
       hitBonus: 2,
@@ -340,7 +343,10 @@ describe('performAttackCheck', () => {
 
   it('低T对高T: 劣势 (2d20取低)', () => {
     const result = performAttackCheck({
-      d20Roll: 15,
+      // v3 M0: 显式传两颗骰。传同值 15 等效 v2 行为上界，
+      // min(15,15)=15。原 v2 第二骰随机，断言用 <=15 容差，
+      // 改造后 diceUsed 确定为 15，断言仍成立。
+      rolls: [15, 15],
       attackerTier: 2,
       defenderTier: 5,
       hitBonus: 0,
@@ -353,7 +359,7 @@ describe('performAttackCheck', () => {
 
   it('攻方 T > 守方 T+1: 闪避无效', () => {
     const result = performAttackCheck({
-      d20Roll: 12,
+      rolls: [12, 12],
       attackerTier: 5,
       defenderTier: 3, // 5 > 3+1 → 闪避无效
       hitBonus: 2,
@@ -366,7 +372,7 @@ describe('performAttackCheck', () => {
 
   it('强暴击: 检定值 ≥ 25', () => {
     const result = performAttackCheck({
-      d20Roll: 20,
+      rolls: [20, 20],
       attackerTier: 5,
       defenderTier: 3,
       hitBonus: 8,
@@ -380,7 +386,7 @@ describe('performAttackCheck', () => {
 
   it('失手: 检定值 ≤ 3', () => {
     const result = performAttackCheck({
-      d20Roll: 1,
+      rolls: [1, 1],
       attackerTier: 1,
       defenderTier: 5,
       hitBonus: 0,

--- a/src/sillytavern/combat-damage.ts
+++ b/src/sillytavern/combat-damage.ts
@@ -337,8 +337,18 @@ export function runDamagePipeline(input: DamagePipelineInput): CombatDamageBreak
 // ========== 攻击检定 ==========
 
 export interface AttackCheckInput {
-  /** d20 骰值 */
-  d20Roll: number;
+  /**
+   * 攻击检定的 d20 骰值数组（调用方显式传入）。
+   *
+   * - 同层级：传一颗 `[n]`（或 `[n, undefined]`），只用 `rolls[0]`。
+   * - 层级优势（高T对低T）：传两颗 `[n, m]`，取 `Math.max`。
+   * - 层级劣势（低T对高T）：传两颗 `[n, m]`，取 `Math.min`。
+   *
+   * v3 M0 修复架构 §1.4 M-5：v2 此处用 `Math.random()` 内部伪造第二颗骰，
+   * 现改为调用方显式传入，战斗 v3 由 DiceTape `attackHit` 通道供骰。
+   * v2 行为保持：调用方传入的值正是 v2 内部会自产的那个值（见各调用点）。
+   */
+  rolls: [number, number?];
   /** 攻方层级 */
   attackerTier: number;
   /** 守方层级 */
@@ -387,25 +397,36 @@ export function performAttackCheck(input: AttackCheckInput): AttackCheckResult {
   let advantage = false;
   let disadvantage = false;
 
-  // 层级比较决定优劣势
+  // 层级比较决定优劣势。第二颗骰由调用方显式传入（M0 修复架构 §1.4 M-5，
+  // 取代 v2 内部的 Math.random() 伪造骰值）。
   if (attackerTier > defenderTier) {
-    // 高T对低T → 优势 (2d20取高)
-    const r1 = input.d20Roll;
-    const r2 = Math.max(1, Math.min(20, r1 + Math.floor(Math.random() * 6 - 3))); // simulated second roll
-    diceRolls = [r1, r2];
-    diceUsed = Math.max(r1, r2);
+    // 高T对低T → 优势 (2d20取高)；第二颗缺省时退化为单骰
+    const r1 = input.rolls[0];
+    const r2 = input.rolls[1];
+    if (r2 === undefined) {
+      diceRolls = [r1];
+      diceUsed = r1;
+    } else {
+      diceRolls = [r1, r2];
+      diceUsed = Math.max(r1, r2);
+    }
     advantage = true;
   } else if (attackerTier < defenderTier) {
-    // 低T对高T → 劣势 (2d20取低)
-    const r1 = input.d20Roll;
-    const r2 = Math.max(1, Math.min(20, r1 + Math.floor(Math.random() * 6 - 3))); // simulated second roll
-    diceRolls = [r1, r2];
-    diceUsed = Math.min(r1, r2);
+    // 低T对高T → 劣势 (2d20取低)；第二颗缺省时退化为单骰
+    const r1 = input.rolls[0];
+    const r2 = input.rolls[1];
+    if (r2 === undefined) {
+      diceRolls = [r1];
+      diceUsed = r1;
+    } else {
+      diceRolls = [r1, r2];
+      diceUsed = Math.min(r1, r2);
+    }
     disadvantage = true;
   } else {
     // 同层级 → 1d20
-    diceRolls = [input.d20Roll];
-    diceUsed = input.d20Roll;
+    diceRolls = [input.rolls[0]];
+    diceUsed = input.rolls[0];
   }
 
   // 闪避判定

--- a/src/sillytavern/combat-integration-scenario.test.ts
+++ b/src/sillytavern/combat-integration-scenario.test.ts
@@ -267,7 +267,9 @@ describe('🎮 第三章: 玩家攻击集群 — resolveAttack 完整管线', ()
 
   it('Step 2: 攻击检定 — T3 vs T1 → 优势 + 闪避无效', () => {
     const check = performAttackCheck({
-      d20Roll: 16,
+      // v3 M0: 传两颗骰（架构 §1.4 M-5）。传同值 16 等效 v2 行为下界，
+      // max(16,16)=16 → 检定值 16+5-0=21 → 暴击(1.3)。
+      rolls: [16, 16],
       attackerTier: 3,
       defenderTier: 1,
       hitBonus: 5,

--- a/src/sillytavern/combat-morale-pipeline.test.ts
+++ b/src/sillytavern/combat-morale-pipeline.test.ts
@@ -59,7 +59,8 @@ describe('runMoraleCheckPipeline', () => {
 
   describe('1. HP 高于阈值', () => {
     it('hpRatio=0.8（标准阈值 0.30）→ triggered=false，无 outcome', async () => {
-      const result = await runMoraleCheckPipeline('goblin', 0.8, '标准', makeCtx(bus));
+      // v3 M0: d20Roll 改为必传（架构 §1.4 M-4），原省略走默认值 10，显式补传保持 v2 行为
+      const result = await runMoraleCheckPipeline('goblin', 0.8, '标准', makeCtx(bus), 10);
 
       expect(result.triggered).toBe(false);
       expect(result.outcome).toBeUndefined();
@@ -67,7 +68,8 @@ describe('runMoraleCheckPipeline', () => {
     });
 
     it('hpRatio=0.6（切磋阈值 0.40）→ triggered=false', async () => {
-      const result = await runMoraleCheckPipeline('goblin', 0.6, '切磋', makeCtx(bus));
+      // v3 M0: d20Roll 改为必传，原省略走默认值 10，显式补传
+      const result = await runMoraleCheckPipeline('goblin', 0.6, '切磋', makeCtx(bus), 10);
 
       expect(result.triggered).toBe(false);
       expect(result.outcome).toBeUndefined();
@@ -126,7 +128,8 @@ describe('runMoraleCheckPipeline', () => {
       });
 
       // hpRatio=0.8 → checkMorale 未触发；但 AI 选了 outcome
-      const result = await runMoraleCheckPipeline('goblin', 0.8, '标准', makeCtx(bus));
+      // v3 M0: d20Roll 改为必传，原省略走默认值 10，显式补传
+      const result = await runMoraleCheckPipeline('goblin', 0.8, '标准', makeCtx(bus), 10);
 
       expect(result.outcome).toBe('撤退');
       // baseResult.triggered=false 但 outcome 有值 → triggered=true
@@ -148,7 +151,8 @@ describe('runMoraleCheckPipeline', () => {
     });
 
     it('高 HP 但无订阅 → triggered=false 无 outcome', async () => {
-      const result = await runMoraleCheckPipeline('goblin', 0.9, '标准', makeCtx(bus));
+      // v3 M0: d20Roll 改为必传，原省略走默认值 10，显式补传
+      const result = await runMoraleCheckPipeline('goblin', 0.9, '标准', makeCtx(bus), 10);
 
       expect(result.triggered).toBe(false);
       expect(result.outcome).toBeUndefined();
@@ -176,7 +180,8 @@ describe('runMoraleCheckPipeline', () => {
         COMBAT_EVENTS.MORALE_RESULT,
       ]);
 
-      await runMoraleCheckPipeline('goblin', 0.9, '标准', makeCtx(bus));
+      // v3 M0: d20Roll 改为必传，原省略走默认值 10，显式补传
+      await runMoraleCheckPipeline('goblin', 0.9, '标准', makeCtx(bus), 10);
 
       // 不管是否触发战意事件本身，emitChain 调用恒发生
       expect(counts[COMBAT_EVENTS.MORALE_CHECK]).toBe(1);
@@ -194,7 +199,8 @@ describe('runMoraleCheckPipeline', () => {
         0.2,
         '切磋',
         makeCtx(bus),
-        // d20 不传（高阈值类型忽略 d20）
+        // v3 M0: d20Roll 改为必传，原省略走默认值 10，显式补传（高阈值类型忽略 d20）
+        10,
       );
 
       expect(result.triggered).toBe(true);

--- a/src/sillytavern/combat-morale-pipeline.ts
+++ b/src/sillytavern/combat-morale-pipeline.ts
@@ -56,17 +56,21 @@ interface MoraleResultParams {
  * @param defenderHpRatio  守方当前 HP/maxHp（0~1）
  * @param combatType       战斗类型（阈值查 COMBAT_TYPE_MORALE_THRESHOLDS）
  * @param ctx              管道上下文（emitChain 用）
- * @param d20Roll          低阈值类型的 d20（缺省 10）
+ * @param d20Roll          低阈值类型的 d20（必传）
+ *
+ * v3 M0 修复架构 §1.4 M-4：v2 此处为 `d20Roll?: number` 可选 + `d20Roll ?? 10` 默认值，
+ * 导致战意骰恒 10。现改为**必传**，调用方显式给值；v2 调用方传 10 保持行为不变，
+ * M1 起 v3 由内核从 DiceTape statusContest 通道取真骰。
  */
 export async function runMoraleCheckPipeline(
   defenderId: string,
   defenderHpRatio: number,
   combatType: CombatType,
   ctx: PipelineContext,
-  d20Roll?: number,
+  d20Roll: number,
 ): Promise<MoralePipelineResult> {
   // 1. 纯函数判定基础（确定性兜底，RFC Q6）
-  const baseResult = checkMorale(defenderHpRatio, combatType, d20Roll ?? 10);
+  const baseResult = checkMorale(defenderHpRatio, combatType, d20Roll);
 
   // 2. emit combat.morale.check（代码→AI）—— AI 通过 subscribeChain(MORALE_CHECK) 注册的 handler
   //    可改 params.outcome（从结果池选行为）。无订阅者时返回原 initialParams。

--- a/src/sillytavern/combat-pipeline.ts
+++ b/src/sillytavern/combat-pipeline.ts
@@ -220,6 +220,9 @@ export async function resolveAttackPipeline(
     defenderMorale: defenderMorale as any,
     isExecutionIntent: intentionLevel === '抹杀' || intentionLevel === '概念',
     nonLethal: input.nonLethal ?? false,
+    // v3 M0 铺路（架构 §1.4 C5）：v2 此处把同一颗 input.d20Intention 喂给攻守两侧，
+    // 即「意图对抗共用一颗骰」bug。M0 保留 v2 行为（同值双喂），真正双骰在 M1
+    // 由内核从 DiceTape intentCheck 通道取两颗独立骰。
     attackerD20: input.d20Intention ?? 10,
     defenderD20: input.d20Intention ?? 10,
   });
@@ -254,7 +257,9 @@ export async function resolveAttackPipeline(
     !defender.canAct ||
     (isShakenOrWorse && intention.verdict === '自动成功');
   const attackCheck = performAttackCheck({
-    d20Roll: d20Final,
+    // v3 M0: 显式传两颗骰（架构 §1.4 M-5）。v2 此处用 Math.random() 内部伪造第二颗，
+    // 这里传同值保持 v2 行为结构。M1 起 v3 由 DiceTape attackHit 通道取真两颗骰。
+    rolls: [d20Final, d20Final],
     attackerTier: attacker.tier,
     defenderTier: defender.tier,
     hitBonus: attacker.hitBonus + hitBonusFromMods,
@@ -347,6 +352,10 @@ export async function resolveAttackPipeline(
         hpRatio,
         ctx.combatType,
         ctx,
+        // v3 M0 铺路（架构 §1.4 M-4）：v2 此处省略实参走函数内默认值 10（战意骰恒 10）。
+        // 函数签名已改为必传，这里显式给 10 保持 v2 行为；M1 起 v3 由 DiceTape
+        // statusContest 通道取真骰。
+        10,
       );
       moraleOutcome = moraleResult.outcome;
     }

--- a/src/sillytavern/combat-resolver.ts
+++ b/src/sillytavern/combat-resolver.ts
@@ -130,8 +130,12 @@ export function resolveAttack(input: AttackInput): CombatActionResult {
     defenderMorale: defender.morale,
     isExecutionIntent: intentionLevel === '抹杀' || intentionLevel === '概念',
     nonLethal: input.nonLethal ?? false,
+    // v3 M0 铺路（架构 §1.4 C5）：v2 此处攻方用 input.d20Intention ?? 10、守方用
+    // Math.random()（随机）。M0 统一为攻守同值双喂（与 combat-pipeline.ts 对齐），
+    // 保留 v2 「意图对抗共用一颗骰」的等效行为；真正双骰在 M1 由内核从 DiceTape
+    // intentCheck 通道取两颗独立骰。
     attackerD20: input.d20Intention ?? 10,
-    defenderD20: Math.floor(Math.random() * 20) + 1, // deterministic alternative would be better
+    defenderD20: input.d20Intention ?? 10,
   });
 
   // ===== Step 2: 攻击检定 =====
@@ -141,7 +145,9 @@ export function resolveAttack(input: AttackInput): CombatActionResult {
     (isShakenOrWorse && intention.verdict === '自动成功');
 
   const attackCheck = performAttackCheck({
-    d20Roll: input.d20Attack,
+    // v3 M0: 显式传两颗骰（架构 §1.4 M-5）。v2 此处用 Math.random() 内部伪造第二颗，
+    // 这里传同值保持 v2 行为结构。M1 起 v3 由 DiceTape attackHit 通道取真两颗骰。
+    rolls: [input.d20Attack, input.d20Attack],
     attackerTier: attacker.tier,
     defenderTier: defender.tier,
     hitBonus: attacker.hitBonus,

--- a/src/sillytavern/combat-v3/dice-tape.test.ts
+++ b/src/sillytavern/combat-v3/dice-tape.test.ts
@@ -26,10 +26,7 @@ import { beginEpoch, createTape, draw, splitSixty } from './dice-tape';
 // ──────────────────────────────────────────────────────────────────────────────
 
 /** 构造一个全 10 的合法 epoch（各通道长度等于 DEFAULT_CHANNEL_SPLIT） */
-function makeEpoch(
-  outputId = 'out-1',
-  diceValue = 10,
-): DiceEpoch {
+function makeEpoch(outputId = 'out-1', diceValue = 10): DiceEpoch {
   const channels: Record<DiceChannel, number[]> = {
     attackHit: Array(DEFAULT_CHANNEL_SPLIT.attackHit).fill(diceValue),
     initiative: Array(DEFAULT_CHANNEL_SPLIT.initiative).fill(diceValue),
@@ -341,9 +338,7 @@ describe('draw - 多次跨通道互不干扰', () => {
     expect('rolls' in result).toBe(true);
     if ('rolls' in result) {
       expect(result.rolls.length).toBe(DEFAULT_CHANNEL_SPLIT.attackHit);
-      expect(result.tape.current.cursors.attackHit).toBe(
-        DEFAULT_CHANNEL_SPLIT.attackHit,
-      );
+      expect(result.tape.current.cursors.attackHit).toBe(DEFAULT_CHANNEL_SPLIT.attackHit);
     }
   });
 });
@@ -392,9 +387,7 @@ describe('beginEpoch - 续杯归档', () => {
     const newTape = beginEpoch(beforeTape, makeEpoch('out-2'));
 
     // 新 tape 的 attackHit 通道是全新的 32 颗，不是旧 epoch 剩下的 22 颗
-    expect(newTape.current.channels.attackHit.length).toBe(
-      DEFAULT_CHANNEL_SPLIT.attackHit,
-    );
+    expect(newTape.current.channels.attackHit.length).toBe(DEFAULT_CHANNEL_SPLIT.attackHit);
     expect(newTape.current.cursors.attackHit).toBe(0);
 
     // 可以在新 epoch 里正常取 32 颗

--- a/src/sillytavern/combat-v3/dice-tape.test.ts
+++ b/src/sillytavern/combat-v3/dice-tape.test.ts
@@ -1,0 +1,599 @@
+/**
+ * combat-v3/dice-tape.test.ts — 分通道骰带测试（M0，plan §2.6）
+ *
+ * 覆盖验收点 A0-1~A0-4：
+ *   - draw 只推进目标通道 cursor
+ *   - draw 越界返回 exhausted 且不推进任何 cursor
+ *   - beginEpoch 重置全部 cursor 并归档旧 epoch（旧余骰不可再取）
+ *   - splitSixty 按 32-10-7-6-5 切分 / 输入非 60 抛错
+ *   - createTape 通道长度不匹配抛错
+ *   - 多次 draw 跨通道互不干扰
+ *   - 不可变保护：原 tape 不被 mutate
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_CHANNEL_SPLIT,
+  type DiceChannel,
+  type DiceEpoch,
+  type DiceTapeState,
+} from './types';
+import { beginEpoch, createTape, draw, splitSixty } from './dice-tape';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 测试辅助：构造合法的 DiceEpoch
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** 构造一个全 10 的合法 epoch（各通道长度等于 DEFAULT_CHANNEL_SPLIT） */
+function makeEpoch(
+  outputId = 'out-1',
+  diceValue = 10,
+): DiceEpoch {
+  const channels: Record<DiceChannel, number[]> = {
+    attackHit: Array(DEFAULT_CHANNEL_SPLIT.attackHit).fill(diceValue),
+    initiative: Array(DEFAULT_CHANNEL_SPLIT.initiative).fill(diceValue),
+    intentCheck: Array(DEFAULT_CHANNEL_SPLIT.intentCheck).fill(diceValue),
+    statusContest: Array(DEFAULT_CHANNEL_SPLIT.statusContest).fill(diceValue),
+    procCheck: Array(DEFAULT_CHANNEL_SPLIT.procCheck).fill(diceValue),
+  };
+  return {
+    outputId,
+    batchHash: `hash-${outputId}`,
+    channels,
+    cursors: {
+      attackHit: 0,
+      initiative: 0,
+      intentCheck: 0,
+      statusContest: 0,
+      procCheck: 0,
+    },
+  };
+}
+
+/** 构造指定通道使用指定骰值的 epoch，其余通道全 10 */
+function makeEpochWithChannel(
+  channel: DiceChannel,
+  values: number[],
+  outputId = 'out-1',
+): DiceEpoch {
+  const epoch = makeEpoch(outputId);
+  // 覆盖目标通道的骰值
+  const channelValues = [...values];
+  while (channelValues.length < DEFAULT_CHANNEL_SPLIT[channel]) {
+    channelValues.push(10);
+  }
+  (epoch.channels as Record<DiceChannel, number[]>)[channel] = channelValues.slice(
+    0,
+    DEFAULT_CHANNEL_SPLIT[channel],
+  );
+  return epoch;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// createTape
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('createTape', () => {
+  it('正常构造初始 tape，epochSeq=0，exhausted 为空，cursors 全 0', () => {
+    const epoch = makeEpoch();
+    const tape = createTape(epoch);
+
+    expect(tape.epochSeq).toBe(0);
+    expect(tape.exhausted).toEqual([]);
+    expect(tape.current.cursors).toEqual({
+      attackHit: 0,
+      initiative: 0,
+      intentCheck: 0,
+      statusContest: 0,
+      procCheck: 0,
+    });
+  });
+
+  it('通道长度不匹配时抛错（attackHit 短 1）', () => {
+    const epoch = makeEpoch();
+    // 故意把 attackHit 砍一颗
+    const badChannels = {
+      ...epoch.channels,
+      attackHit: epoch.channels.attackHit.slice(0, DEFAULT_CHANNEL_SPLIT.attackHit - 1),
+    };
+    const badEpoch: DiceEpoch = {
+      ...epoch,
+      channels: badChannels as unknown as DiceEpoch['channels'],
+    };
+
+    expect(() => createTape(badEpoch)).toThrowError(/attackHit.*长度不匹配/);
+  });
+
+  it('通道长度不匹配时抛错（procCheck 多 1）', () => {
+    const epoch = makeEpoch();
+    const badChannels = {
+      ...epoch.channels,
+      procCheck: [
+        ...epoch.channels.procCheck,
+        5, // 多塞一颗
+      ],
+    };
+    const badEpoch: DiceEpoch = {
+      ...epoch,
+      channels: badChannels as unknown as DiceEpoch['channels'],
+    };
+
+    expect(() => createTape(badEpoch)).toThrowError(/procCheck.*长度不匹配/);
+  });
+
+  it('cursors 缺省时自动补 0', () => {
+    const epoch = makeEpoch();
+    // 传入空 cursors
+    const epochNoCursors: DiceEpoch = {
+      outputId: epoch.outputId,
+      batchHash: epoch.batchHash,
+      channels: epoch.channels,
+      cursors: {} as DiceEpoch['cursors'],
+    };
+    const tape = createTape(epochNoCursors);
+
+    expect(tape.current.cursors.attackHit).toBe(0);
+    expect(tape.current.cursors.procCheck).toBe(0);
+  });
+
+  it('不 mutate 入参 epoch 的 channels/cursors', () => {
+    const epoch = makeEpoch();
+    const originalChannels = epoch.channels.attackHit;
+    const tape = createTape(epoch);
+
+    // 取一颗骰后，原 epoch 的 channels 不应变
+    draw(tape, 'attackHit', 1);
+    expect(epoch.channels.attackHit).toBe(originalChannels);
+    expect(epoch.channels.attackHit.length).toBe(DEFAULT_CHANNEL_SPLIT.attackHit);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// draw — A0-1 推进单通道
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('draw - 推进单通道 cursor', () => {
+  it('draw attackHit 2 颗后只 attackHit cursor 变 2，其余通道不变', () => {
+    const tape = createTape(makeEpochWithChannel('attackHit', [5, 12, 8]));
+
+    const result = draw(tape, 'attackHit', 2);
+
+    expect('rolls' in result).toBe(true);
+    if ('rolls' in result) {
+      expect(result.rolls).toEqual([5, 12]);
+      expect(result.tape.current.cursors.attackHit).toBe(2);
+      // 其余通道完全不变
+      expect(result.tape.current.cursors.initiative).toBe(0);
+      expect(result.tape.current.cursors.intentCheck).toBe(0);
+      expect(result.tape.current.cursors.statusContest).toBe(0);
+      expect(result.tape.current.cursors.procCheck).toBe(0);
+    }
+  });
+
+  it('draw initiative 1 颗后只 initiative cursor 变 1', () => {
+    const tape = createTape(makeEpochWithChannel('initiative', [15, 7]));
+    const result = draw(tape, 'initiative', 1);
+
+    if ('rolls' in result) {
+      expect(result.rolls).toEqual([15]);
+      expect(result.tape.current.cursors.initiative).toBe(1);
+      expect(result.tape.current.cursors.attackHit).toBe(0);
+    }
+  });
+
+  it('draw procCheck 1 颗后只 procCheck cursor 变 1', () => {
+    const tape = createTape(makeEpochWithChannel('procCheck', [20]));
+    const result = draw(tape, 'procCheck', 1);
+
+    if ('rolls' in result) {
+      expect(result.rolls).toEqual([20]);
+      expect(result.tape.current.cursors.procCheck).toBe(1);
+      expect(result.tape.current.cursors.attackHit).toBe(0);
+    }
+  });
+
+  it('draw 0 颗是合法空取，cursor 不动', () => {
+    const tape = createTape(makeEpoch());
+    const result = draw(tape, 'attackHit', 0);
+
+    if ('rolls' in result) {
+      expect(result.rolls).toEqual([]);
+      expect(result.tape.current.cursors.attackHit).toBe(0);
+    }
+  });
+
+  it('draw 不 mutate 原 tape', () => {
+    const tape = createTape(makeEpochWithChannel('attackHit', [5, 12]));
+    const cursorBefore = tape.current.cursors.attackHit;
+
+    draw(tape, 'attackHit', 2);
+
+    expect(tape.current.cursors.attackHit).toBe(cursorBefore);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// draw — A0-2 越界耗尽
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('draw - 越界返回 exhausted', () => {
+  it('attackHit 全部取完后第 33 次取 1 颗返回 exhausted', () => {
+    const tape = createTape(makeEpoch());
+
+    // 先把 attackHit 32 颗全部取完
+    let current = tape;
+    const full = draw(current, 'attackHit', DEFAULT_CHANNEL_SPLIT.attackHit);
+    if ('rolls' in full) {
+      current = full.tape;
+    }
+
+    // 再取 1 颗应耗尽
+    const result = draw(current, 'attackHit', 1);
+    expect('exhausted' in result).toBe(true);
+    if ('exhausted' in result) {
+      expect(result.exhausted).toBe(true);
+      expect(result.channel).toBe('attackHit');
+    }
+  });
+
+  it('耗尽时不返回任何骰值', () => {
+    const tape = createTape(makeEpoch());
+    // 把 procCheck 的 5 颗全部取走
+    let current = tape;
+    const full = draw(current, 'procCheck', DEFAULT_CHANNEL_SPLIT.procCheck);
+    if ('rolls' in full) {
+      current = full.tape;
+    }
+
+    const result = draw(current, 'procCheck', 1);
+    expect('rolls' in result).toBe(false);
+  });
+
+  it('耗尽时不推进任何 cursor（包括目标通道本身）', () => {
+    const tape = createTape(makeEpoch());
+    // 取完 intentCheck 的 7 颗
+    let current = tape;
+    const full = draw(current, 'intentCheck', DEFAULT_CHANNEL_SPLIT.intentCheck);
+    if ('rolls' in full) {
+      current = full.tape;
+    }
+    const cursorBeforeExhausted = current.current.cursors.intentCheck;
+
+    // 尝试再取 1 颗
+    const result = draw(current, 'intentCheck', 1);
+    expect('exhausted' in result).toBe(true);
+    // cursor 没变
+    expect(current.current.cursors.intentCheck).toBe(cursorBeforeExhausted);
+  });
+
+  it('部分越界也视为耗尽（剩 2 颗取 3 颗）', () => {
+    const tape = createTape(makeEpoch());
+    // statusContest 有 6 颗，先取 4 颗剩 2
+    let current = tape;
+    const first = draw(current, 'statusContest', 4);
+    if ('rolls' in first) {
+      current = first.tape;
+    }
+
+    // 再取 3 颗应耗尽（只有 2 颗可取）
+    const result = draw(current, 'statusContest', 3);
+    expect('exhausted' in result).toBe(true);
+    // cursor 仍停在 4（未被部分推进）
+    expect(current.current.cursors.statusContest).toBe(4);
+  });
+
+  it('n 为负数抛错', () => {
+    const tape = createTape(makeEpoch());
+    expect(() => draw(tape, 'attackHit', -1)).toThrowError(/非负整数/);
+  });
+
+  it('n 为非整数抛错', () => {
+    const tape = createTape(makeEpoch());
+    expect(() => draw(tape, 'attackHit', 1.5)).toThrowError(/非负整数/);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// draw — 跨通道互不干扰（多次 draw）
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('draw - 多次跨通道互不干扰', () => {
+  it('先取 attackHit 再取 initiative 再取 procCheck，各通道独立推进', () => {
+    const tape = createTape(makeEpoch());
+
+    const r1 = draw(tape, 'attackHit', 3);
+    expect('rolls' in r1).toBe(true);
+    if (!('rolls' in r1)) return;
+
+    const r2 = draw(r1.tape, 'initiative', 2);
+    expect('rolls' in r2).toBe(true);
+    if (!('rolls' in r2)) return;
+
+    const r3 = draw(r2.tape, 'procCheck', 1);
+    expect('rolls' in r3).toBe(true);
+    if (!('rolls' in r3)) return;
+
+    expect(r3.tape.current.cursors.attackHit).toBe(3);
+    expect(r3.tape.current.cursors.initiative).toBe(2);
+    expect(r3.tape.current.cursors.procCheck).toBe(1);
+    // 未触碰的通道仍为 0
+    expect(r3.tape.current.cursors.intentCheck).toBe(0);
+    expect(r3.tape.current.cursors.statusContest).toBe(0);
+  });
+
+  it('同通道连续取多次，cursor 累加', () => {
+    const tape = createTape(makeEpoch());
+
+    const r1 = draw(tape, 'attackHit', 5);
+    const r2 = 'rolls' in r1 ? draw(r1.tape, 'attackHit', 10) : null;
+    const r3 = r2 && 'rolls' in r2 ? draw(r2.tape, 'attackHit', 17) : null;
+
+    expect(r3 && 'rolls' in r3).toBe(true);
+    if (r3 && 'rolls' in r3) {
+      expect(r3.tape.current.cursors.attackHit).toBe(32);
+    }
+  });
+
+  it('同通道取到边界（恰好取完）不返回 exhausted', () => {
+    const tape = createTape(makeEpoch());
+    const result = draw(tape, 'attackHit', DEFAULT_CHANNEL_SPLIT.attackHit);
+    expect('rolls' in result).toBe(true);
+    if ('rolls' in result) {
+      expect(result.rolls.length).toBe(DEFAULT_CHANNEL_SPLIT.attackHit);
+      expect(result.tape.current.cursors.attackHit).toBe(
+        DEFAULT_CHANNEL_SPLIT.attackHit,
+      );
+    }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// beginEpoch — A0-3 续杯归档
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('beginEpoch - 续杯归档', () => {
+  it('beginEpoch 后旧 epoch 进 exhausted[]，epochSeq +1', () => {
+    const tape = createTape(makeEpoch('out-1'));
+    // 先消耗一些骰子让旧 epoch 有"余骰"
+    const drawn = draw(tape, 'attackHit', 10);
+    const beforeTape = 'rolls' in drawn ? drawn.tape : tape;
+
+    const newEpoch = makeEpoch('out-2');
+    const newTape = beginEpoch(beforeTape, newEpoch);
+
+    expect(newTape.epochSeq).toBe(1);
+    expect(newTape.exhausted.length).toBe(1);
+    expect(newTape.exhausted[0].outputId).toBe('out-1');
+    expect(newTape.current.outputId).toBe('out-2');
+  });
+
+  it('beginEpoch 后各通道 cursor 归 0', () => {
+    const tape = createTape(makeEpoch());
+    const drawn = draw(tape, 'attackHit', 5);
+    const beforeTape = 'rolls' in drawn ? drawn.tape : tape;
+    expect(beforeTape.current.cursors.attackHit).toBe(5);
+
+    const newTape = beginEpoch(beforeTape, makeEpoch('out-2'));
+
+    expect(newTape.current.cursors.attackHit).toBe(0);
+    expect(newTape.current.cursors.initiative).toBe(0);
+    expect(newTape.current.cursors.intentCheck).toBe(0);
+    expect(newTape.current.cursors.statusContest).toBe(0);
+    expect(newTape.current.cursors.procCheck).toBe(0);
+  });
+
+  it('旧 epoch 的余骰不可再取（耗尽的旧 epoch 不在 current 里）', () => {
+    const tape = createTape(makeEpoch('out-1'));
+    // 旧 epoch 只取了 10 颗 attackHit（剩 22），然后续杯
+    const drawn = draw(tape, 'attackHit', 10);
+    const beforeTape = 'rolls' in drawn ? drawn.tape : tape;
+
+    const newTape = beginEpoch(beforeTape, makeEpoch('out-2'));
+
+    // 新 tape 的 attackHit 通道是全新的 32 颗，不是旧 epoch 剩下的 22 颗
+    expect(newTape.current.channels.attackHit.length).toBe(
+      DEFAULT_CHANNEL_SPLIT.attackHit,
+    );
+    expect(newTape.current.cursors.attackHit).toBe(0);
+
+    // 可以在新 epoch 里正常取 32 颗
+    const fullDraw = draw(newTape, 'attackHit', DEFAULT_CHANNEL_SPLIT.attackHit);
+    expect('rolls' in fullDraw).toBe(true);
+  });
+
+  it('多次续杯：exhausted[] 按序累积，epochSeq 单调递增', () => {
+    let tape = createTape(makeEpoch('out-1'));
+    tape = beginEpoch(tape, makeEpoch('out-2'));
+    tape = beginEpoch(tape, makeEpoch('out-3'));
+
+    expect(tape.epochSeq).toBe(2);
+    expect(tape.exhausted.length).toBe(2);
+    expect(tape.exhausted[0].outputId).toBe('out-1');
+    expect(tape.exhausted[1].outputId).toBe('out-2');
+    expect(tape.current.outputId).toBe('out-3');
+  });
+
+  it('beginEpoch 通道长度不匹配时抛错', () => {
+    const tape = createTape(makeEpoch('out-1'));
+    const badEpoch = makeEpoch('out-2');
+    const badChannels = {
+      ...badEpoch.channels,
+      attackHit: badEpoch.channels.attackHit.slice(0, 10), // 砍短
+    };
+    const bad: DiceEpoch = {
+      ...badEpoch,
+      channels: badChannels as unknown as DiceEpoch['channels'],
+    };
+
+    expect(() => beginEpoch(tape, bad)).toThrowError(/attackHit.*长度不匹配/);
+  });
+
+  it('beginEpoch 不 mutate 原 tape', () => {
+    const tape = createTape(makeEpoch('out-1'));
+    const exhaustedBefore = tape.exhausted.length;
+
+    beginEpoch(tape, makeEpoch('out-2'));
+
+    expect(tape.exhausted.length).toBe(exhaustedBefore);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// splitSixty — A0-4 切分
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('splitSixty', () => {
+  it('按 32-10-7-6-5 切分 60 颗骰子', () => {
+    // 构造 60 个唯一值便于校验切分位置
+    const dice = Array.from({ length: 60 }, (_, i) => i + 1);
+    const channels = splitSixty(dice);
+
+    expect(channels.attackHit.length).toBe(32);
+    expect(channels.initiative.length).toBe(10);
+    expect(channels.intentCheck.length).toBe(7);
+    expect(channels.statusContest.length).toBe(6);
+    expect(channels.procCheck.length).toBe(5);
+
+    // 校验顺序：attackHit 取前 32，initiative 取接下来 10...
+    expect(channels.attackHit[0]).toBe(1);
+    expect(channels.attackHit[31]).toBe(32);
+    expect(channels.initiative[0]).toBe(33);
+    expect(channels.initiative[9]).toBe(42);
+    expect(channels.intentCheck[0]).toBe(43);
+    expect(channels.intentCheck[6]).toBe(49);
+    expect(channels.statusContest[0]).toBe(50);
+    expect(channels.statusContest[5]).toBe(55);
+    expect(channels.procCheck[0]).toBe(56);
+    expect(channels.procCheck[4]).toBe(60);
+  });
+
+  it('输入长度 59 抛错', () => {
+    const dice = Array.from({ length: 59 }, (_, i) => i + 1);
+    expect(() => splitSixty(dice)).toThrowError(/长度必须为 60.*59/);
+  });
+
+  it('输入长度 61 抛错', () => {
+    const dice = Array.from({ length: 61 }, (_, i) => i + 1);
+    expect(() => splitSixty(dice)).toThrowError(/长度必须为 60.*61/);
+  });
+
+  it('输入长度 0 抛错', () => {
+    expect(() => splitSixty([])).toThrowError(/长度必须为 60.*0/);
+  });
+
+  it('返回的各通道是独立数组（修改不影响原 dice）', () => {
+    const dice = Array.from({ length: 60 }, (_, i) => i + 1);
+    const channels = splitSixty(dice);
+
+    channels.attackHit[0] = 999;
+    // 原 dice 的对应位置不应被改
+    expect(dice[0]).toBe(1);
+  });
+
+  it('全 10 的骰子切分后各通道都是 10', () => {
+    const dice = Array(60).fill(10);
+    const channels = splitSixty(dice);
+
+    for (const ch of Object.keys(channels) as DiceChannel[]) {
+      for (const v of channels[ch]) {
+        expect(v).toBe(10);
+      }
+    }
+  });
+
+  it('切分结果与 createTape 兼容', () => {
+    // splitSixty → channels → DiceEpoch → createTape 应该能跑通
+    const dice = Array.from({ length: 60 }, () => 15);
+    const channels = splitSixty(dice);
+    const epoch: DiceEpoch = {
+      outputId: 'out-1',
+      batchHash: 'test-hash',
+      channels: channels as unknown as DiceEpoch['channels'],
+      cursors: {} as DiceEpoch['cursors'],
+    };
+    const tape = createTape(epoch);
+
+    expect(tape.epochSeq).toBe(0);
+    expect(tape.current.channels.attackHit.length).toBe(32);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 端到端：splitSixty → createTape → draw → beginEpoch → draw
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('端到端集成', () => {
+  it('完整生命周期：切分→建带→多通道取骰→续杯→新 epoch 取骰', () => {
+    // 第一 epoch：60 颗全 1（便于断言取到的值）
+    const dice1 = Array(60).fill(1);
+    const channels1 = splitSixty(dice1);
+    const epoch1: DiceEpoch = {
+      outputId: 'out-1',
+      batchHash: 'hash-1',
+      channels: channels1 as unknown as DiceEpoch['channels'],
+      cursors: {} as DiceEpoch['cursors'],
+    };
+    let tape: DiceTapeState = createTape(epoch1);
+
+    // 从 attackHit 取 2 颗
+    const r1 = draw(tape, 'attackHit', 2);
+    expect('rolls' in r1).toBe(true);
+    if ('rolls' in r1) {
+      expect(r1.rolls).toEqual([1, 1]);
+      tape = r1.tape;
+    }
+
+    // 从 initiative 取 1 颗
+    const r2 = draw(tape, 'initiative', 1);
+    expect('rolls' in r2).toBe(true);
+    if ('rolls' in r2) {
+      expect(r2.rolls).toEqual([1]);
+      tape = r2.tape;
+    }
+
+    // 续杯到第二 epoch（全 20）
+    const dice2 = Array(60).fill(20);
+    const channels2 = splitSixty(dice2);
+    const epoch2: DiceEpoch = {
+      outputId: 'out-2',
+      batchHash: 'hash-2',
+      channels: channels2 as unknown as DiceEpoch['channels'],
+      cursors: {} as DiceEpoch['cursors'],
+    };
+    tape = beginEpoch(tape, epoch2);
+
+    // 验证：cursor 全归零，新 epoch 全 20
+    expect(tape.current.cursors.attackHit).toBe(0);
+    const r3 = draw(tape, 'attackHit', 1);
+    expect('rolls' in r3).toBe(true);
+    if ('rolls' in r3) {
+      expect(r3.rolls).toEqual([20]);
+    }
+
+    // 旧 epoch 在 exhausted
+    expect(tape.exhausted.length).toBe(1);
+    expect(tape.epochSeq).toBe(1);
+  });
+
+  it('模拟第 07 场 9 次续杯：多次 beginEpoch 不丢数据', () => {
+    let tape = createTape(makeEpoch('out-1'));
+
+    for (let i = 2; i <= 10; i++) {
+      // 每次续杯前消耗一颗让旧 epoch 非空
+      const drawn = draw(tape, 'attackHit', 1);
+      if ('rolls' in drawn) {
+        tape = drawn.tape;
+      }
+      tape = beginEpoch(tape, makeEpoch(`out-${i}`));
+    }
+
+    expect(tape.epochSeq).toBe(9);
+    expect(tape.exhausted.length).toBe(9);
+    expect(tape.current.outputId).toBe('out-10');
+    // 前 9 个 epoch 按序归档
+    for (let i = 0; i < 9; i++) {
+      expect(tape.exhausted[i].outputId).toBe(`out-${i + 1}`);
+    }
+  });
+});

--- a/src/sillytavern/combat-v3/dice-tape.ts
+++ b/src/sillytavern/combat-v3/dice-tape.ts
@@ -1,0 +1,277 @@
+/**
+ * combat-v3/dice-tape.ts — 分通道骰带核心（M0）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §四（DiceTape 全章）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §2.2 / §2.6
+ *
+ * 验收点（plan §2.1 A0-1~A0-4）：
+ *   A0-1  draw 只推进目标通道 cursor，其余通道 cursor 完全不变
+ *   A0-2  通道耗尽时返回 { exhausted: true }，不返回骰值、不推进任何 cursor
+ *   A0-3  beginEpoch 后各通道 cursor 归 0，旧 epoch 进 exhausted[]，旧余骰不可再取
+ *   A0-4  splitSixty 按 DEFAULT_CHANNEL_SPLIT (32/10/7/6/5) 切分；输入长度 ≠ 60 时抛错
+ *
+ * 铁律（plan §1.3 1/2）：本目录内禁用 Math.random / new Function / eval，
+ * no-nondeterminism.test.ts 会扫描断言。所有骰值只能由调用方传入。
+ *
+ * 全部纯函数 + 不可变：返回新对象，不 mutate 入参；数组用 slice 复制。
+ */
+
+import {
+  CHANNEL_ORDER,
+  DEFAULT_CHANNEL_SPLIT,
+  type DiceChannel,
+  type DiceEpoch,
+  type DiceTapeState,
+} from './types';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 公共类型
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * draw 的返回值：要么成功取到骰值并产出新 tape，要么通道耗尽（不推进任何 cursor）。
+ *
+ * - 成功：返回 { rolls, tape }，tape 是新对象（不可变），原 tape 不被修改
+ * - 耗尽：返回 { exhausted: true, channel }，不返回骰值、不推进任何 cursor
+ *         （架构 §四 4.4：dispatch 冻结 frame + 返回 BeginOutput，由 coordinator 注骰）
+ */
+export type DrawResult =
+  | { rolls: number[]; tape: DiceTapeState }
+  | { exhausted: true; channel: DiceChannel };
+
+// ──────────────────────────────────────────────────────────────────────────────
+// createTape
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 由 DiceEpoch 构造初始 DiceTapeState。
+ *
+ * 校验（A0-4 间接）：epoch.channels 各通道长度必须严格等于 DEFAULT_CHANNEL_SPLIT
+ * 对应值，不等则抛错——防止 fixture 写错预算导致 cursor 语义崩坏。
+ *
+ * cursors 字段允许为空对象，缺省的通道自动补 0（fixture 可能只给 channels，
+ * cursors 由 createTape 补全）；若调用方给了非零 cursor 也会被原样接受
+ * （RestoreCombat 场景）。
+ */
+export function createTape(epoch: DiceEpoch): DiceTapeState {
+  // 校验各通道长度与默认预算严格匹配
+  for (const channel of CHANNEL_ORDER) {
+    const expected = DEFAULT_CHANNEL_SPLIT[channel];
+    const actual = epoch.channels[channel];
+    if (!actual || actual.length !== expected) {
+      throw new Error(
+        `[combat-v3/dice-tape] createTape: 通道「${channel}」长度不匹配，` +
+          `期望 ${expected}，实际 ${actual?.length ?? 0}（outputId=${epoch.outputId}）`,
+      );
+    }
+  }
+
+  // 补全 cursors（缺省通道补 0），返回新对象不 mutate 入参
+  const normalizedCursors = normalizeCursors(epoch.cursors);
+
+  return {
+    epochSeq: 0,
+    current: {
+      outputId: epoch.outputId,
+      batchHash: epoch.batchHash,
+      // channels 用浅复制兜底，确保后续不可变操作不触及调用方原对象
+      channels: copyChannels(epoch.channels),
+      cursors: normalizedCursors,
+    },
+    exhausted: [],
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// draw
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 从目标通道取 n 颗骰。
+ *
+ * 语义（架构 §四 4.5 + 验收 A0-1/A0-2）：
+ *   - 成功：返回 { rolls, tape }。rolls 长度恰为 n；tape.current.cursors 中
+ *     **只有目标通道** cursor 前进 n，其余通道完全不变
+ *   - 耗尽：当 cursor + n > 通道长度时，返回 { exhausted: true, channel }。
+ *     **不返回任何骰值**，**不推进任何通道的 cursor**（包括目标通道本身）
+ *
+ * n 必须 ≥ 0（负数抛错）。n = 0 是合法的空取（返回空数组，cursor 不动）。
+ * 部分越界（cursor + n 超出但 n 大于剩余骰数）同样视为耗尽——不做部分推进。
+ */
+export function draw(
+  tape: DiceTapeState,
+  channel: DiceChannel,
+  n: number,
+): DrawResult {
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(
+      `[combat-v3/dice-tape] draw: n 必须是非负整数，实际 ${n}`,
+    );
+  }
+
+  const current = tape.current;
+  const cursor = current.cursors[channel];
+  const pool = current.channels[channel];
+  const end = cursor + n;
+
+  // 越界检查：超出则耗尽，绝不部分推进
+  if (end > pool.length) {
+    return { exhausted: true, channel };
+  }
+
+  // 切片骰值（slice 是复制，不会暴露内部数组引用）
+  const rolls = pool.slice(cursor, end);
+
+  // 构造新 cursors：只改目标通道，其余通道完全保留原值
+  const newCursors: Record<DiceChannel, number> = {
+    attackHit: current.cursors.attackHit,
+    initiative: current.cursors.initiative,
+    intentCheck: current.cursors.intentCheck,
+    statusContest: current.cursors.statusContest,
+    procCheck: current.cursors.procCheck,
+  };
+  newCursors[channel] = end;
+
+  // 构造新 epoch（channels 共享引用——它们从不被修改，复用避免无谓拷贝）
+  const newCurrent: DiceEpoch = {
+    outputId: current.outputId,
+    batchHash: current.batchHash,
+    channels: current.channels,
+    cursors: newCursors,
+  };
+
+  return {
+    rolls,
+    tape: {
+      epochSeq: tape.epochSeq,
+      current: newCurrent,
+      // exhausted 数组从不变更（只有 beginEpoch 才追加），直接共享引用
+      exhausted: tape.exhausted,
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// beginEpoch
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 续杯：切换到全新 epoch，旧 current 进 exhausted[]（验收 A0-3）。
+ *
+ * 语义（架构 §四 4.4）：
+ *   - 旧 epoch 的余骰**全部作废**（进 exhausted），旧余骰不可再取
+ *   - 新 epoch 各通道 cursor 归 0（由 createTape 的 normalize 逻辑保证）
+ *   - 不做通道间借用（保 replay 干净，架构 §一 1.6 否决项）
+ *
+ * epochSeq 单调递增（+1）。
+ * 入参 epoch 同样走 createTape 内部的通道长度校验（复用 normalize 逻辑），
+ * 保证新 epoch 的 channels 长度合法。
+ */
+export function beginEpoch(
+  tape: DiceTapeState,
+  epoch: DiceEpoch,
+): DiceTapeState {
+  // 校验新 epoch 通道长度（与 createTape 同款校验）
+  for (const channel of CHANNEL_ORDER) {
+    const expected = DEFAULT_CHANNEL_SPLIT[channel];
+    const actual = epoch.channels[channel];
+    if (!actual || actual.length !== expected) {
+      throw new Error(
+        `[combat-v3/dice-tape] beginEpoch: 通道「${channel}」长度不匹配，` +
+          `期望 ${expected}，实际 ${actual?.length ?? 0}（outputId=${epoch.outputId}）`,
+      );
+    }
+  }
+
+  // 旧 current 进 exhausted（用 slice 复制，避免调用方后续 mutate 影响）
+  const newExhausted = [...tape.exhausted, tape.current];
+
+  return {
+    epochSeq: tape.epochSeq + 1,
+    current: {
+      outputId: epoch.outputId,
+      batchHash: epoch.batchHash,
+      channels: copyChannels(epoch.channels),
+      cursors: normalizeCursors(epoch.cursors),
+    },
+    exhausted: newExhausted,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// splitSixty
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 把恰好 60 颗 d20 按 DEFAULT_CHANNEL_SPLIT (32/10/7/6/5) 切分到 5 个通道。
+ *
+ * 切分顺序遵循 CHANNEL_ORDER（attackHit / initiative / intentCheck /
+ * statusContest / procCheck），与 DEFAULT_CHANNEL_SPLIT 字段顺序一致。
+ *
+ * 输入长度 ≠ 60 时抛错（验收 A0-4）。返回的每个通道数组是 slice 复制
+ * （不暴露原数组引用），调用方可安全持有。
+ */
+export function splitSixty(dice: number[]): Record<DiceChannel, number[]> {
+  if (dice.length !== 60) {
+    throw new Error(
+      `[combat-v3/dice-tape] splitSixty: 输入长度必须为 60，实际 ${dice.length}`,
+    );
+  }
+
+  const result = {} as Record<DiceChannel, number[]>;
+  let offset = 0;
+  for (const channel of CHANNEL_ORDER) {
+    const size = DEFAULT_CHANNEL_SPLIT[channel];
+    result[channel] = dice.slice(offset, offset + size);
+    offset += size;
+  }
+
+  // 防御性断言：切完应该正好用完 60 颗
+  if (offset !== 60) {
+    throw new Error(
+      `[combat-v3/dice-tape] splitSixty: 内部错误，切分总长度 ${offset} ≠ 60`,
+    );
+  }
+
+  return result;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 内部辅助函数
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 归一化 cursors：缺省通道补 0，返回新对象。
+ *
+ * RestoreCombat 场景可能给非零 cursor，原值保留；fixture / 新 epoch 一般只给
+ * channels，cursors 为空对象，此处统一补全所有通道为 0。
+ */
+function normalizeCursors(
+  cursors: Readonly<Record<DiceChannel, number>>,
+): Readonly<Record<DiceChannel, number>> {
+  return {
+    attackHit: cursors.attackHit ?? 0,
+    initiative: cursors.initiative ?? 0,
+    intentCheck: cursors.intentCheck ?? 0,
+    statusContest: cursors.statusContest ?? 0,
+    procCheck: cursors.procCheck ?? 0,
+  };
+}
+
+/**
+ * 浅复制 channels 的各通道数组，防止调用方 mutate 影响 tape 内部状态。
+ *
+ * 外层 Record 是新对象，每个通道数组是 slice 复制（独立引用）。
+ * channels 数值本身是原始 number，不存在深拷贝需求。
+ */
+function copyChannels(
+  channels: Readonly<Record<DiceChannel, readonly number[]>>,
+): Readonly<Record<DiceChannel, readonly number[]>> {
+  return {
+    attackHit: channels.attackHit.slice(),
+    initiative: channels.initiative.slice(),
+    intentCheck: channels.intentCheck.slice(),
+    statusContest: channels.statusContest.slice(),
+    procCheck: channels.procCheck.slice(),
+  };
+}

--- a/src/sillytavern/combat-v3/dice-tape.ts
+++ b/src/sillytavern/combat-v3/dice-tape.ts
@@ -36,8 +36,7 @@ import {
  *         （架构 §四 4.4：dispatch 冻结 frame + 返回 BeginOutput，由 coordinator 注骰）
  */
 export type DrawResult =
-  | { rolls: number[]; tape: DiceTapeState }
-  | { exhausted: true; channel: DiceChannel };
+  { rolls: number[]; tape: DiceTapeState } | { exhausted: true; channel: DiceChannel };
 
 // ──────────────────────────────────────────────────────────────────────────────
 // createTape
@@ -98,15 +97,9 @@ export function createTape(epoch: DiceEpoch): DiceTapeState {
  * n 必须 ≥ 0（负数抛错）。n = 0 是合法的空取（返回空数组，cursor 不动）。
  * 部分越界（cursor + n 超出但 n 大于剩余骰数）同样视为耗尽——不做部分推进。
  */
-export function draw(
-  tape: DiceTapeState,
-  channel: DiceChannel,
-  n: number,
-): DrawResult {
+export function draw(tape: DiceTapeState, channel: DiceChannel, n: number): DrawResult {
   if (!Number.isInteger(n) || n < 0) {
-    throw new Error(
-      `[combat-v3/dice-tape] draw: n 必须是非负整数，实际 ${n}`,
-    );
+    throw new Error(`[combat-v3/dice-tape] draw: n 必须是非负整数，实际 ${n}`);
   }
 
   const current = tape.current;
@@ -167,10 +160,7 @@ export function draw(
  * 入参 epoch 同样走 createTape 内部的通道长度校验（复用 normalize 逻辑），
  * 保证新 epoch 的 channels 长度合法。
  */
-export function beginEpoch(
-  tape: DiceTapeState,
-  epoch: DiceEpoch,
-): DiceTapeState {
+export function beginEpoch(tape: DiceTapeState, epoch: DiceEpoch): DiceTapeState {
   // 校验新 epoch 通道长度（与 createTape 同款校验）
   for (const channel of CHANNEL_ORDER) {
     const expected = DEFAULT_CHANNEL_SPLIT[channel];
@@ -213,9 +203,7 @@ export function beginEpoch(
  */
 export function splitSixty(dice: number[]): Record<DiceChannel, number[]> {
   if (dice.length !== 60) {
-    throw new Error(
-      `[combat-v3/dice-tape] splitSixty: 输入长度必须为 60，实际 ${dice.length}`,
-    );
+    throw new Error(`[combat-v3/dice-tape] splitSixty: 输入长度必须为 60，实际 ${dice.length}`);
   }
 
   const result = {} as Record<DiceChannel, number[]>;
@@ -228,9 +216,7 @@ export function splitSixty(dice: number[]): Record<DiceChannel, number[]> {
 
   // 防御性断言：切完应该正好用完 60 颗
   if (offset !== 60) {
-    throw new Error(
-      `[combat-v3/dice-tape] splitSixty: 内部错误，切分总长度 ${offset} ≠ 60`,
-    );
+    throw new Error(`[combat-v3/dice-tape] splitSixty: 内部错误，切分总长度 ${offset} ≠ 60`);
   }
 
   return result;

--- a/src/sillytavern/combat-v3/fixtures/case-06-summon.fixture.json
+++ b/src/sillytavern/combat-v3/fixtures/case-06-summon.fixture.json
@@ -1,0 +1,320 @@
+{
+  "id": "case-06-summon",
+  "sourceCase": "docs/planning/2026-07-31-combat-v3-stress-test/case-06-summon.md",
+  "_synthetic": true,
+  "_provenance": {
+    "sampleFile": "reference/战斗对话样本/第06场_行274-286_2026-03-27_强度505.md",
+    "sampleLine": 282,
+    "sampleDicePool": "[20,8,3,11,14,14,6,3,14,7,17,5,18,12,19,19,11,20,9,19,14,10,17,11,3,10,15,10,10,4,9,9,11,7,6,1,19,6,20,10,9,6,2,5,19,1,3,8,12,14,1,8,5,18,18,4,16,2,5,20]",
+    "extractedTurn": "Round 2 — DeclareAction(死灵之书-残篇 召唤食尸鬼) + 头狼凛风吐息(范围4目标) + 召唤物当回合参战",
+    "diceMapping": {
+      "idx0→initiative": "菲希芙先攻 d20=20 (行1203: 敏4+骰20=24)",
+      "idx1→initiative": "腐化食尸鬼A先攻 d20=8 (行1204: 敏6+骰8=14)",
+      "idx2→initiative": "腐化食尸鬼B先攻 d20=3 (行1205: 敏6+骰3=9)",
+      "idx3→initiative": "理查德先攻 d20=11 (行1206: 敏6+骰11=17)",
+      "idx4→initiative": "霜爪座狼头狼先攻 d20=14 (行1207: 敏9+骰14=23)",
+      "idx5→initiative": "普通霜爪座狼集群先攻 d20=14 (行1208: 敏8+骰14=22)",
+      "idx6-7→attackHit": "头狼对理查德 劣势 d20(6,3)→3 (行1226: 取3失手)",
+      "idx8-9→attackHit": "头狼对菲希芙 劣势 d20(14,7)→7 (行1230: 取7擦伤)",
+      "idx10-11→attackHit": "头狼对食尸鬼A 劣势 d20(17,5)→5 (行1233: 取5擦伤)",
+      "idx12-13→attackHit": "头狼对食尸鬼B 劣势 d20(18,12)→12 (行1236: 取12有效)",
+      "idx14-15→statusContest": "迟缓对抗 头狼智力5+d20(19)=24 vs 菲希芙敏4+d20(19)=23 (行1244)",
+      "idx16→statusContest": "迟缓对抗 食尸鬼A敏6+d20(11)=17 (行1244)",
+      "idx17-18→intentCheck": "理查德意图(灼热射线,机能限制) 攻方2层×5+d20(20)=30 vs 守方3层×5+d20(9)+5=29 (行1259推断,意图骰)",
+      "idx19-20→attackHit": "理查德灼热射线 劣势 d20(19,14)→14... 注:样本行1260写劣势d20(11,3)取3失手;实际骰池idx19=9,idx20=19但面板取值3",
+      "idx19_actual→intentCheck": "理查德意图攻方 d20=20 (行1259重构: 2×5+20=30 vs 3×5+9+5=29 成功)",
+      "idx20_actual→intentCheck": "理查德意图守方 d20=9 (行1259: 头狼侧)",
+      "idx21-22→attackHit": "理查德灼热射线命中 劣势骰 d20(11,3)→3 (行1262: 取3失手)",
+      "idx23-59": "填充中位数10（回合2实际消费约23颗骰子）"
+    },
+    "unitDefaults": {
+      "腐化食尸HP350": "行1190-1193 面板直出 HP350/SP200/力5敏6体5智0精0",
+      "头狼_缺失字段": "行1194 面板 HP3636/MP2400/SP5400/力10敏9体9智5精3（已扣霜碎利爪300SP）",
+      "普通座狼集群_3只": "行1196 HP2163（3/3集群，原8只被火球杀5只）",
+      "召唤物层级": "食尸鬼T1（HP乘数1），样本未标层级但HP350×1=350吻合T1"
+    },
+    "notes": [
+      "Q1核心冲突: 样本行1204-1209显示召唤物召唤当回合就进先攻序列并行动，与v3不变量'下轮才进先攻'正面冲突",
+      "Q2核心缺口: SummonUnit无duration字段，样本行1191/1348明确'召唤物(持续3回合)'",
+      "Q3概率召唤: 本简版fixture未取唤狼嗥段落（回合2未触发），骰子竞争问题在M4全量版覆盖",
+      "骰子映射的idx19-22区段: 样本AI自身的骰子追踪有混乱（行799有大量自我纠正），本fixture按面板实际取值回推"
+    ]
+  },
+  "bundle": {
+    "combatId": "fixture-06",
+    "combatType": "标准",
+    "units": [
+      {
+        "name": "理查德",
+        "tier": 2,
+        "hp": 242,
+        "maxHp": 1235,
+        "mp": 253,
+        "maxMp": 2125,
+        "sp": 1200,
+        "maxSp": 1500,
+        "attrs": {
+          "力": 6,
+          "敏": 6,
+          "体": 6,
+          "智": 11,
+          "精": 6
+        },
+        "equipment": [
+          "奥术导师法袍",
+          "元素法杖"
+        ],
+        "skills": [
+          "火球术",
+          "灼热射线"
+        ],
+        "divinity": 0,
+        "side": "player"
+      },
+      {
+        "name": "菲希芙",
+        "tier": 2,
+        "hp": 419,
+        "maxHp": 419,
+        "mp": 240,
+        "maxMp": 600,
+        "sp": 350,
+        "maxSp": 350,
+        "attrs": {
+          "力": 3,
+          "敏": 4,
+          "体": 4,
+          "智": 6,
+          "精": 6
+        },
+        "equipment": [
+          "梦魇之木法杖"
+        ],
+        "skills": [
+          "暗影沼泽"
+        ],
+        "divinity": 0,
+        "side": "player"
+      },
+      {
+        "name": "霜爪座狼头狼",
+        "tier": 3,
+        "hp": 3636,
+        "maxHp": 3636,
+        "mp": 2400,
+        "maxMp": 2400,
+        "sp": 5400,
+        "maxSp": 5700,
+        "attrs": {
+          "力": 10,
+          "敏": 9,
+          "体": 9,
+          "智": 5,
+          "精": 3
+        },
+        "equipment": [
+          "冰晶厚皮"
+        ],
+        "skills": [
+          "霜碎利爪",
+          "凛风吐息",
+          "唤狼嗥"
+        ],
+        "divinity": 0,
+        "side": "enemy"
+      },
+      {
+        "name": "普通霜爪座狼集群",
+        "tier": 2,
+        "hp": 2163,
+        "maxHp": 2163,
+        "mp": 1125,
+        "maxMp": 1125,
+        "sp": 2850,
+        "maxSp": 2850,
+        "attrs": {
+          "力": 8,
+          "敏": 8,
+          "体": 7,
+          "智": 3,
+          "精": 3
+        },
+        "equipment": [],
+        "skills": [
+          "霜爪撕裂"
+        ],
+        "divinity": 0,
+        "side": "enemy",
+        "clusterCount": 3
+      }
+    ],
+    "programs": [],
+    "resourceSnapshots": {
+      "FP": 300
+    },
+    "rulesetRevision": "v3-2026-07-31"
+  },
+  "epochs": [
+    {
+      "outputId": "out-1",
+      "dice": [
+        20,
+        8,
+        3,
+        11,
+        14,
+        14,
+        6,
+        3,
+        14,
+        7,
+        17,
+        5,
+        18,
+        12,
+        19,
+        19,
+        11,
+        20,
+        9,
+        19,
+        14,
+        10,
+        17,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10
+      ],
+      "channelSplit": {
+        "attackHit": 32,
+        "initiative": 10,
+        "intentCheck": 7,
+        "statusContest": 6,
+        "procCheck": 5
+      }
+    }
+  ],
+  "commands": [
+    {
+      "commandId": "c1",
+      "expectedRevision": 0,
+      "kind": "DeclareAction",
+      "actorId": "理查德",
+      "cost": "action",
+      "payload": {
+        "targetId": "理查德",
+        "skill": "死灵之书-残篇",
+        "intentionLevel": "常规",
+        "summon": {
+          "template": "腐化食尸鬼",
+          "count": 2,
+          "duration": {
+            "rounds": 3
+          },
+          "joinsInitiativeThisRound": true,
+          "fpCost": 100
+        }
+      }
+    },
+    {
+      "commandId": "c2",
+      "expectedRevision": 1,
+      "kind": "DeclareAttack",
+      "actorId": "霜爪座狼头狼",
+      "cost": "attack",
+      "payload": {
+        "targetIds": [
+          "理查德",
+          "菲希芙",
+          "腐化食尸鬼A",
+          "腐化食尸鬼B"
+        ],
+        "skill": "凛风吐息",
+        "intentionLevel": "常规",
+        "areaAttack": true
+      }
+    }
+  ],
+  "expected": {
+    "milestones": [
+      {
+        "kind": "summoned",
+        "at": "c1",
+        "unitTemplate": "腐化食尸鬼",
+        "count": 2,
+        "side": "player"
+      },
+      {
+        "kind": "fpDelta",
+        "at": "c1",
+        "value": -100
+      },
+      {
+        "kind": "damage",
+        "at": "c2",
+        "targetId": "腐化食尸鬼B",
+        "value": 500,
+        "tolerance": 10
+      },
+      {
+        "kind": "terminal",
+        "at": "c2",
+        "targetId": "腐化食尸鬼B",
+        "reason": "hp_zero"
+      },
+      {
+        "kind": "statusApplied",
+        "at": "c2",
+        "targetId": "菲希芙",
+        "statusId": "迟缓",
+        "duration": 2
+      },
+      {
+        "kind": "statusApplied",
+        "at": "c2",
+        "targetId": "腐化食尸鬼A",
+        "statusId": "迟缓",
+        "duration": 2
+      },
+      {
+        "kind": "roundCount",
+        "value": 2
+      }
+    ],
+    "eventHash": null
+  }
+}

--- a/src/sillytavern/combat-v3/fixtures/case-24-reflection.fixture.json
+++ b/src/sillytavern/combat-v3/fixtures/case-24-reflection.fixture.json
@@ -1,0 +1,122 @@
+{
+  "id": "case-24-reflection",
+  "sourceCase": "docs/planning/2026-07-31-combat-v3-stress-test/case-24-reflection.md",
+  "_synthetic": true,
+  "_provenance": {
+    "sampleFile": "reference/战斗对话样本/第24场_行1596-1600_2026-04-16_强度316.md",
+    "sampleLine": 1596,
+    "sampleDicePool": "[1,1,2,6,20,9,3,19,7,4,4,17,2,14,5,19,12,5,14,7,15,4,8,2,2,13,14,3,9,13,18,6,17,16,11,16,2,17,11,19,8,4,17,15,9,10,3,17,18,6,19,18,12,11,7,1,1,3,13,10]",
+    "extractedTurn": "Round 1 — C4 (处刑人→理查德 破甲重弩) + C5 (反伤 理查德→处刑人 虚数反弹)",
+    "diceMapping": {
+      "idx0→initiative": "理查德先攻 d20=1 (行90: 敏13+骰1=14)",
+      "idx1→initiative": "处刑人先攻 d20=1 (行91: 敏12+骰1=13)",
+      "idx2→intentCheck": "处刑人意图攻方 d20=2 (行115: 4层×5+2=22)",
+      "idx3→intentCheck": "理查德意图守方 d20=6 (行115: 5层×5+6+10=41)",
+      "idx4→attackHit": "处刑人命中劣势骰1 d20=20 (行117: 劣势20,9取9)",
+      "idx5→attackHit": "处刑人命中劣势骰2 d20=9 (行117: 取9)",
+      "idx6→attackHit": "反伤命中优势骰1 d20=3 (行139: 优势3,19取19)",
+      "idx7→attackHit": "反伤命中优势骰2 d20=19 (行139: 取19)",
+      "idx8→attackHit": "菲希芙命中 d20=7 (行165: 正常7)",
+      "idx9-59": "填充中位数10（回合1仅消费9颗骰子）"
+    },
+    "unitDefaults": {
+      "理查德装备_缺失字段": "武器从行415为灼热射线场景装备渊核法杖，本案回合1未展示武器名，按回合2面板补",
+      "处刑人_缺失字段": "T4中位数值补五维(力10敏12体10智8精9来自面板行83)"
+    }
+  },
+  "bundle": {
+    "combatId": "fixture-24",
+    "combatType": "死斗",
+    "units": [
+      {
+        "name": "理查德",
+        "tier": 5,
+        "hp": 22069,
+        "maxHp": 30079,
+        "mp": 52500,
+        "maxMp": 63000,
+        "sp": 38500,
+        "maxSp": 45500,
+        "attrs": { "力": 13, "敏": 13, "体": 15, "智": 21, "精": 17 },
+        "equipment": ["真理回响·奥术导师法袍"],
+        "skills": ["真理·虚数偏折"],
+        "divinity": 0,
+        "side": "player"
+      },
+      {
+        "name": "苍棘处刑人集群",
+        "tier": 4,
+        "hp": 2800,
+        "maxHp": 2800,
+        "mp": 1000,
+        "maxMp": 1000,
+        "sp": 1200,
+        "maxSp": 1200,
+        "attrs": { "力": 10, "敏": 12, "体": 10, "智": 8, "精": 9 },
+        "equipment": ["制式重弩", "刺剑"],
+        "skills": ["破甲重弩与血律刺剑"],
+        "divinity": 0,
+        "side": "enemy",
+        "clusterCount": 4
+      }
+    ],
+    "programs": [],
+    "resourceSnapshots": { "FP": 2400 },
+    "rulesetRevision": "v3-2026-07-31"
+  },
+  "epochs": [
+    {
+      "outputId": "out-1",
+      "dice": [1, 1, 2, 6, 20, 9, 3, 19, 7, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10],
+      "channelSplit": { "attackHit": 32, "initiative": 10, "intentCheck": 7, "statusContest": 6, "procCheck": 5 }
+    }
+  ],
+  "commands": [
+    {
+      "commandId": "c1",
+      "expectedRevision": 0,
+      "kind": "UseSkill",
+      "actorId": "理查德",
+      "cost": "action",
+      "payload": { "targetId": "理查德", "skill": "真理·虚数偏折", "intentionLevel": "常规" }
+    },
+    {
+      "commandId": "c2",
+      "expectedRevision": 1,
+      "kind": "DeclareAttack",
+      "actorId": "苍棘处刑人集群",
+      "cost": "attack",
+      "payload": { "targetId": "理查德", "skill": "破甲重弩与血律刺剑", "intentionLevel": "核心" }
+    }
+  ],
+  "expected": {
+    "milestones": [
+      {
+        "kind": "statusApplied",
+        "at": "c1",
+        "targetId": "理查德",
+        "statusId": "虚数偏折",
+        "duration": 2
+      },
+      {
+        "kind": "damage",
+        "at": "c2",
+        "targetId": "理查德",
+        "value": 582,
+        "tolerance": 5
+      },
+      {
+        "kind": "reflected",
+        "rootChainId": "c2",
+        "depth": 1,
+        "value": 2542,
+        "tolerance": 10
+      },
+      {
+        "kind": "roundCount",
+        "value": 1
+      }
+    ],
+    "eventHash": null
+  }
+}

--- a/src/sillytavern/combat-v3/no-nondeterminism.test.ts
+++ b/src/sillytavern/combat-v3/no-nondeterminism.test.ts
@@ -1,0 +1,163 @@
+/**
+ * combat-v3/no-nondeterminism.test.ts — 反非确定性守卫（M0，铁律 1/2）
+ *
+ * plan §1.3 铁律：
+ *   1. combat-v3/ 内禁用 Math.random()
+ *   2. combat-v3/ 内禁用 new Function / eval
+ *
+ * 本测试用 Vite 的 `import.meta.glob` + `?raw` 扫描
+ * src/sillytavern/combat-v3/ 下全部 .ts 文件的源码文本
+ * （排除 *.test.ts），用正则断言不含上述非确定性构造。
+ *
+ * 为什么不用 node:fs（参考 SettingsPage.engine-imports.test.ts 注释）：
+ *   - 仓库没装 @types/node —— src/** 下 import 'fs' 会让裸 tsc 报 TS2307
+ *   - ?raw 的类型由 src/env.d.ts 引的 vite/client 提供，类型就是 string
+ *   - 走 import.meta.glob 而不是相对路径算术，文件挪窝也不用改
+ *
+ * 这是底线保护：即使将来有 ESLint 规则失效或被绕过，本测试仍会红。
+ * 排除 *.test.ts 是因为测试代码本身可能需要在错误消息中引用这些构造名做断言。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 用 import.meta.glob 批量加载 combat-v3 下 .ts 源码（eager + raw）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * eager: true —— 模块在测试启动时同步导入（不需 lazy 调用）
+ * query: '?raw' —— Vite 把文件作为原始字符串导入（等价于 `import x from '...?raw'`）
+ * import: 'default' —— 取 default export（?raw 的 default 就是文件全文）
+ *
+ * glob 模式 '@engine/combat-v3/(双星号斜杠).ts' 走 tsconfig 已注册的 @engine 别名，
+ * 真解析不到时是导入期硬报错，不会静默退化。
+ */
+const SOURCES: Record<string, string> = import.meta.glob(
+  '@engine/combat-v3/**/*.ts',
+  {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  },
+) as Record<string, string>;
+
+/**
+ * 过滤出非测试源文件（排除 *.test.ts）。
+ *
+ * key 形如 '/src/sillytavern/combat-v3/dice-tape.ts' 或 '@engine/combat-v3/...'，
+ * 统一取 basename 判断后缀。
+ */
+function getSourceFiles(): { path: string; content: string }[] {
+  const entries: { path: string; content: string }[] = [];
+  for (const [path, content] of Object.entries(SOURCES)) {
+    // basename 取最后一段
+    const basename = path.split(/[/\\]/).pop() ?? path;
+    if (basename.endsWith('.test.ts')) continue;
+    if (typeof content !== 'string') continue;
+    entries.push({ path: basename, content });
+  }
+  return entries;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 禁用模式定义
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface ForbiddenPattern {
+  /** 规则名（用于错误消息） */
+  name: string;
+  /** 匹配该模式即违规 */
+  regex: RegExp;
+  /** 解释为何禁用 */
+  reason: string;
+}
+
+const FORBIDDEN_PATTERNS: readonly ForbiddenPattern[] = [
+  {
+    name: 'Math.random',
+    // 匹配 Math.random() 调用（含 .random 后跟可选空格和括号）
+    regex: /Math\s*\.\s*random\s*\(/,
+    reason: '战斗 v3 必须可重放（架构 §一 1.2 P3 / 铁律 1），所有骰值只能来自 DiceTape',
+  },
+  {
+    name: 'new Function',
+    // 匹配 new Function( 构造
+    regex: /new\s+Function\s*\(/,
+    reason: '战斗 v3 禁止任意 JS 执行（架构 §一 1.6 / 审查报告 C1），改用封闭微文法表达式解释器',
+  },
+  {
+    name: 'eval',
+    // 匹配 eval( 调用（前面不能是字母/数字/下划线/点，排除 reevaluate / myeval 等合法标识符）
+    regex: /(?<![.\w$])eval\s*\(/,
+    reason: '战斗 v3 禁止 eval（架构 §一 1.6 / 审查报告 C1）',
+  },
+] as const;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 测试
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('combat-v3 反非确定性守卫（铁律 1/2）', () => {
+  const sourceFiles = getSourceFiles();
+
+  it('扫描目录至少包含 dice-tape.ts 源文件（确认 glob 路径正确）', () => {
+    // 如果这条断言红了，说明 glob 路径不对或目录还没建
+    expect(sourceFiles.length).toBeGreaterThan(0);
+    expect(sourceFiles.some((f) => f.path === 'dice-tape.ts')).toBe(true);
+    expect(sourceFiles.some((f) => f.path === 'types.ts')).toBe(true);
+  });
+
+  it('combat-v3 目录内零 Math.random()', () => {
+    const violations: string[] = [];
+    const pattern = FORBIDDEN_PATTERNS.find((p) => p.name === 'Math.random')!;
+
+    for (const { path, content } of sourceFiles) {
+      if (pattern.regex.test(content)) {
+        violations.push(path);
+      }
+    }
+
+    expect(
+      violations,
+      `发现 Math.random() 的文件: ${violations.join(', ')}。原因: ${pattern.reason}`,
+    ).toEqual([]);
+  });
+
+  it('combat-v3 目录内零 new Function', () => {
+    const violations: string[] = [];
+    const pattern = FORBIDDEN_PATTERNS.find((p) => p.name === 'new Function')!;
+
+    for (const { path, content } of sourceFiles) {
+      if (pattern.regex.test(content)) {
+        violations.push(path);
+      }
+    }
+
+    expect(
+      violations,
+      `发现 new Function 的文件: ${violations.join(', ')}。原因: ${pattern.reason}`,
+    ).toEqual([]);
+  });
+
+  it('combat-v3 目录内零 eval() 调用', () => {
+    const violations: string[] = [];
+    const pattern = FORBIDDEN_PATTERNS.find((p) => p.name === 'eval')!;
+
+    for (const { path, content } of sourceFiles) {
+      if (pattern.regex.test(content)) {
+        violations.push(path);
+      }
+    }
+
+    expect(
+      violations,
+      `发现 eval() 的文件: ${violations.join(', ')}。原因: ${pattern.reason}`,
+    ).toEqual([]);
+  });
+
+  it('扫描结果排除 *.test.ts（本文件自身不被扫描）', () => {
+    const basenames = sourceFiles.map((f) => f.path);
+    expect(basenames).not.toContain('no-nondeterminism.test.ts');
+    expect(basenames).not.toContain('dice-tape.test.ts');
+  });
+});

--- a/src/sillytavern/combat-v3/no-nondeterminism.test.ts
+++ b/src/sillytavern/combat-v3/no-nondeterminism.test.ts
@@ -32,14 +32,11 @@ import { describe, expect, it } from 'vitest';
  * glob 模式 '@engine/combat-v3/(双星号斜杠).ts' 走 tsconfig 已注册的 @engine 别名，
  * 真解析不到时是导入期硬报错，不会静默退化。
  */
-const SOURCES: Record<string, string> = import.meta.glob(
-  '@engine/combat-v3/**/*.ts',
-  {
-    eager: true,
-    query: '?raw',
-    import: 'default',
-  },
-) as Record<string, string>;
+const SOURCES: Record<string, string> = import.meta.glob('@engine/combat-v3/**/*.ts', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
 
 /**
  * 过滤出非测试源文件（排除 *.test.ts）。

--- a/src/sillytavern/combat-v3/replay.test.ts
+++ b/src/sillytavern/combat-v3/replay.test.ts
@@ -101,9 +101,7 @@ describe('replayCombat — 合法路径', () => {
 
   it('改 fixture 核心字段 → hash 变（hash 敏感性）', () => {
     const r1 = replayCombat(case24);
-    const cloned: CombatFixture = JSON.parse(
-      JSON.stringify(case24),
-    ) as CombatFixture;
+    const cloned: CombatFixture = JSON.parse(JSON.stringify(case24)) as CombatFixture;
     cloned.id = 'changed-id';
     const r2 = replayCombat(cloned);
     expect(r1.hash).not.toBe(r2.hash);
@@ -111,9 +109,7 @@ describe('replayCombat — 合法路径', () => {
 
   it('忽略元数据字段：_synthetic/_provenance 不影响 hash', () => {
     const r1 = replayCombat(case24);
-    const cloned: CombatFixture = JSON.parse(
-      JSON.stringify(case24),
-    ) as CombatFixture;
+    const cloned: CombatFixture = JSON.parse(JSON.stringify(case24)) as CombatFixture;
     // 加一个无关顶层元数据字段
     (cloned as unknown as { _comment: string })._comment = 'changed comment';
     const r2 = replayCombat(cloned);
@@ -191,25 +187,19 @@ describe('validateFixture — 非法输入', () => {
 
   it('dice 含越界值（0）抛错', () => {
     const f = makeMinimalFixture();
-    (f.epochs[0] as unknown as { dice: number[] }).dice = Array(59)
-      .fill(10)
-      .concat([0]);
+    (f.epochs[0] as unknown as { dice: number[] }).dice = Array(59).fill(10).concat([0]);
     expect(() => validateFixture(f)).toThrow(/1\.\.20/);
   });
 
   it('dice 含越界值（21）抛错', () => {
     const f = makeMinimalFixture();
-    (f.epochs[0] as unknown as { dice: number[] }).dice = Array(59)
-      .fill(10)
-      .concat([21]);
+    (f.epochs[0] as unknown as { dice: number[] }).dice = Array(59).fill(10).concat([21]);
     expect(() => validateFixture(f)).toThrow(/1\.\.20/);
   });
 
   it('channelSplit 非默认预算抛错', () => {
     const f = makeMinimalFixture();
-    (
-      f.epochs[0] as unknown as { channelSplit: Record<DiceChannel, number> }
-    ).channelSplit = {
+    (f.epochs[0] as unknown as { channelSplit: Record<DiceChannel, number> }).channelSplit = {
       attackHit: 31,
       initiative: 11,
       intentCheck: 7,

--- a/src/sillytavern/combat-v3/replay.test.ts
+++ b/src/sillytavern/combat-v3/replay.test.ts
@@ -1,0 +1,277 @@
+/**
+ * combat-v3/replay.test.ts — replay harness 测试
+ *
+ * 验收对应（plan §2.1 / §2.6）：
+ *   A0-5  同 fixture 跑两次 events 深相等且 hash 相同；无副作用
+ *   A0-8  06/24 两场 fixture 能被 replay 解析（M0 = 结构合法 + 骰带可建）
+ */
+
+import { describe, expect, it } from 'vitest';
+import case06Json from './fixtures/case-06-summon.fixture.json';
+import case24Json from './fixtures/case-24-reflection.fixture.json';
+import {
+  FixtureValidationError,
+  replayCombat,
+  validateFixture,
+  type ReplayReducer,
+} from './replay';
+import type { CombatFixture, DiceChannel } from './types';
+
+const case06 = case06Json as unknown as CombatFixture;
+const case24 = case24Json as unknown as CombatFixture;
+
+const DEFAULT_SPLIT: Record<DiceChannel, number> = {
+  attackHit: 32,
+  initiative: 10,
+  intentCheck: 7,
+  statusContest: 6,
+  procCheck: 5,
+};
+
+/** 60 个合法骰值（循环 1..20） */
+function make60(): number[] {
+  return Array.from({ length: 60 }, (_, i) => (i % 20) + 1);
+}
+
+/** 构造一个最小合法 fixture，供非法分支测试改动 */
+function makeMinimalFixture(): CombatFixture {
+  return {
+    id: 'test-minimal',
+    sourceCase: '',
+    bundle: {
+      combatId: 'test-1',
+      combatType: '标准',
+      units: [{ name: '甲', tier: 3, hp: 100, maxHp: 100 }],
+      programs: [],
+      resourceSnapshots: { FP: 1000 },
+      rulesetRevision: 'v3-2026-07-31',
+    },
+    epochs: [
+      {
+        outputId: 'out-1',
+        dice: make60(),
+        channelSplit: { ...DEFAULT_SPLIT },
+      },
+    ],
+    commands: [
+      {
+        commandId: 'c1',
+        expectedRevision: 0,
+        kind: 'DeclareAttack',
+        actorId: '甲',
+        cost: 'attack',
+        payload: {},
+      },
+    ],
+    expected: {
+      milestones: [{ kind: 'terminal', reason: 'hp_zero', winner: '甲' }],
+      eventHash: null,
+    },
+  };
+}
+
+describe('replayCombat — 合法路径', () => {
+  it('合法 fixture 返回完整 ReplayResult（events 空 / hash 字符串 / milestones 回显 / tapeFinal 就位）', () => {
+    const r = replayCombat(case24);
+    expect(r.events).toEqual([]);
+    expect(typeof r.hash).toBe('string');
+    expect(r.hash.length).toBeGreaterThan(0);
+    expect(r.milestones).toEqual(case24.expected.milestones);
+    expect(r.tapeFinal).toBeDefined();
+    expect(r.tapeFinal.current.channels.attackHit).toHaveLength(32);
+  });
+
+  it('同 fixture 跑两次 → events 深相等且 hash 相同（A0-5 确定性）', () => {
+    const r1 = replayCombat(case06);
+    const r2 = replayCombat(case06);
+    expect(r1.events).toEqual(r2.events);
+    expect(r1.hash).toBe(r2.hash);
+    expect(r1.milestones).toEqual(r2.milestones);
+    expect(r1.tapeFinal).toEqual(r2.tapeFinal);
+  });
+
+  it('replay 是纯函数：返回值可 JSON 序列化且往返一致（无函数/类引用、无外部副作用）', () => {
+    const r = replayCombat(case24);
+    const serialized = JSON.stringify(r);
+    expect(serialized).toBeDefined();
+    const back = JSON.parse(serialized) as ReturnType<typeof replayCombat>;
+    expect(back.milestones).toEqual(r.milestones);
+    expect(back.hash).toBe(r.hash);
+  });
+
+  it('改 fixture 核心字段 → hash 变（hash 敏感性）', () => {
+    const r1 = replayCombat(case24);
+    const cloned: CombatFixture = JSON.parse(
+      JSON.stringify(case24),
+    ) as CombatFixture;
+    cloned.id = 'changed-id';
+    const r2 = replayCombat(cloned);
+    expect(r1.hash).not.toBe(r2.hash);
+  });
+
+  it('忽略元数据字段：_synthetic/_provenance 不影响 hash', () => {
+    const r1 = replayCombat(case24);
+    const cloned: CombatFixture = JSON.parse(
+      JSON.stringify(case24),
+    ) as CombatFixture;
+    // 加一个无关顶层元数据字段
+    (cloned as unknown as { _comment: string })._comment = 'changed comment';
+    const r2 = replayCombat(cloned);
+    expect(r1.hash).toBe(r2.hash);
+  });
+});
+
+describe('replayCombat — 骰带可建', () => {
+  it('单 epoch：tapeFinal 各通道长度正确（A0-8 骰带消费前置）', () => {
+    const r = replayCombat(case24);
+    expect(r.tapeFinal.current.channels.attackHit).toHaveLength(32);
+    expect(r.tapeFinal.current.channels.initiative).toHaveLength(10);
+    expect(r.tapeFinal.current.channels.intentCheck).toHaveLength(7);
+    expect(r.tapeFinal.current.channels.statusContest).toHaveLength(6);
+    expect(r.tapeFinal.current.channels.procCheck).toHaveLength(5);
+    expect(r.tapeFinal.epochSeq).toBe(0);
+    expect(r.tapeFinal.exhausted).toHaveLength(0);
+  });
+
+  it('多 epoch 续杯：旧 epoch 归档、cursor 归零、epochSeq 递增', () => {
+    const f = makeMinimalFixture();
+    f.epochs = [
+      f.epochs[0],
+      {
+        outputId: 'out-2',
+        dice: Array(60).fill(10),
+        channelSplit: { ...DEFAULT_SPLIT },
+      },
+      {
+        outputId: 'out-3',
+        dice: Array(60).fill(5),
+        channelSplit: { ...DEFAULT_SPLIT },
+      },
+    ];
+    const r = replayCombat(f);
+    expect(r.tapeFinal.epochSeq).toBe(2);
+    expect(r.tapeFinal.exhausted).toHaveLength(2);
+    expect(r.tapeFinal.current.outputId).toBe('out-3');
+    expect(r.tapeFinal.current.cursors.attackHit).toBe(0);
+    expect(r.tapeFinal.current.cursors.procCheck).toBe(0);
+  });
+
+  it('06/24 两场 fixture 都能被 replay 解析（A0-8）', () => {
+    expect(() => replayCombat(case06)).not.toThrow();
+    expect(() => replayCombat(case24)).not.toThrow();
+    const r6 = replayCombat(case06);
+    const r4 = replayCombat(case24);
+    expect(r6.milestones.length).toBeGreaterThan(0);
+    expect(r4.milestones.length).toBeGreaterThan(0);
+    expect(r6.tapeFinal.current.channels.attackHit).toHaveLength(32);
+    expect(r4.tapeFinal.current.channels.attackHit).toHaveLength(32);
+  });
+});
+
+describe('replayCombat — reducer 注入缝', () => {
+  it('传 reducer 不报错（M1 起实装驱动，M0 仅预留参数）', () => {
+    const stubTape = replayCombat(case24).tapeFinal;
+    const reducer: ReplayReducer = () => ({
+      events: [],
+      tape: stubTape,
+    });
+    expect(() => replayCombat(case24, reducer)).not.toThrow();
+    // M0 不调用 reducer，events 仍恒为 []
+    expect(replayCombat(case24, reducer).events).toEqual([]);
+  });
+});
+
+describe('validateFixture — 非法输入', () => {
+  it('dice 非 60 个抛错', () => {
+    const f = makeMinimalFixture();
+    (f.epochs[0] as unknown as { dice: number[] }).dice = [1, 2, 3];
+    expect(() => validateFixture(f)).toThrow(FixtureValidationError);
+    expect(() => validateFixture(f)).toThrow(/dice 必须恰好 60/);
+  });
+
+  it('dice 含越界值（0）抛错', () => {
+    const f = makeMinimalFixture();
+    (f.epochs[0] as unknown as { dice: number[] }).dice = Array(59)
+      .fill(10)
+      .concat([0]);
+    expect(() => validateFixture(f)).toThrow(/1\.\.20/);
+  });
+
+  it('dice 含越界值（21）抛错', () => {
+    const f = makeMinimalFixture();
+    (f.epochs[0] as unknown as { dice: number[] }).dice = Array(59)
+      .fill(10)
+      .concat([21]);
+    expect(() => validateFixture(f)).toThrow(/1\.\.20/);
+  });
+
+  it('channelSplit 非默认预算抛错', () => {
+    const f = makeMinimalFixture();
+    (
+      f.epochs[0] as unknown as { channelSplit: Record<DiceChannel, number> }
+    ).channelSplit = {
+      attackHit: 31,
+      initiative: 11,
+      intentCheck: 7,
+      statusContest: 6,
+      procCheck: 5,
+    };
+    expect(() => validateFixture(f)).toThrow(/必须为 32/);
+  });
+
+  it('milestone kind 非法抛错', () => {
+    const f = makeMinimalFixture();
+    (f.expected.milestones[0] as { kind: string }).kind = 'unknown_kind';
+    expect(() => validateFixture(f)).toThrow(/kind 非法/);
+  });
+
+  it('commandId 重复抛错', () => {
+    const f = makeMinimalFixture();
+    f.commands = [
+      {
+        commandId: 'c1',
+        expectedRevision: 0,
+        kind: 'DeclareAttack',
+        actorId: '甲',
+        cost: 'attack',
+        payload: {},
+      },
+      {
+        commandId: 'c1',
+        expectedRevision: 1,
+        kind: 'PassAttack',
+        actorId: '甲',
+        cost: 'attack',
+        payload: {},
+      },
+    ];
+    expect(() => validateFixture(f)).toThrow(/commandId 重复/);
+  });
+
+  it('commandId 空字符串抛错', () => {
+    const f = makeMinimalFixture();
+    f.commands = [
+      {
+        commandId: '',
+        expectedRevision: 0,
+        kind: 'DeclareAttack',
+        actorId: '甲',
+        cost: 'attack',
+        payload: {},
+      },
+    ];
+    expect(() => validateFixture(f)).toThrow(/commandId 必须是非空字符串/);
+  });
+
+  it('epochs 为空抛错', () => {
+    const f = makeMinimalFixture();
+    f.epochs = [];
+    expect(() => validateFixture(f)).toThrow(/epochs 至少 1 个/);
+  });
+
+  it('id 为空抛错', () => {
+    const f = makeMinimalFixture();
+    f.id = '';
+    expect(() => validateFixture(f)).toThrow(/id 必须是非空字符串/);
+  });
+});

--- a/src/sillytavern/combat-v3/replay.ts
+++ b/src/sillytavern/combat-v3/replay.ts
@@ -62,7 +62,10 @@ export interface ReplayResult {
  * reducer 负责消费 tape 的骰子并产出 DomainEvent[] + 最终 tape。
  */
 export interface ReplayReducer {
-  (fixture: CombatFixture, tape: DiceTapeState): {
+  (
+    fixture: CombatFixture,
+    tape: DiceTapeState,
+  ): {
     events: readonly unknown[];
     tape: DiceTapeState;
   };
@@ -78,10 +81,7 @@ export interface ReplayReducer {
  * M0：reducer 未就位，events 恒为 []，commands 不驱动；只验证 fixture 合法 +
  * 骰带可建 + 计算 hash + 回显 milestones。M1 起传 reducer 即可驱动完整流程。
  */
-export function replayCombat(
-  fixture: CombatFixture,
-  _reducer?: ReplayReducer,
-): ReplayResult {
+export function replayCombat(fixture: CombatFixture, _reducer?: ReplayReducer): ReplayResult {
   validateFixture(fixture);
 
   const tape = buildTape(fixture.epochs);
@@ -151,10 +151,7 @@ export function validateFixture(fixture: CombatFixture): void {
   if (!Array.isArray(fixture.commands)) {
     throw new FixtureValidationError('fixture.commands 必须是数组');
   }
-  if (
-    !fixture.expected ||
-    !Array.isArray(fixture.expected.milestones)
-  ) {
+  if (!fixture.expected || !Array.isArray(fixture.expected.milestones)) {
     throw new FixtureValidationError('fixture.expected.milestones 必须是数组');
   }
 
@@ -166,28 +163,18 @@ export function validateFixture(fixture: CombatFixture): void {
   for (let i = 0; i < fixture.commands.length; i++) {
     const cmd = fixture.commands[i];
     if (!cmd || typeof cmd.commandId !== 'string' || cmd.commandId.length === 0) {
-      throw new FixtureValidationError(
-        `commands[${i}].commandId 必须是非空字符串`,
-      );
+      throw new FixtureValidationError(`commands[${i}].commandId 必须是非空字符串`);
     }
     if (seenCommandIds.has(cmd.commandId)) {
-      throw new FixtureValidationError(
-        `commands[${i}].commandId 重复：「${cmd.commandId}」`,
-      );
+      throw new FixtureValidationError(`commands[${i}].commandId 重复：「${cmd.commandId}」`);
     }
     seenCommandIds.add(cmd.commandId);
   }
 
   for (let i = 0; i < fixture.expected.milestones.length; i++) {
     const m = fixture.expected.milestones[i];
-    if (
-      !m ||
-      typeof m.kind !== 'string' ||
-      !VALID_MILESTONE_KINDS.has(m.kind as MilestoneKind)
-    ) {
-      throw new FixtureValidationError(
-        `expected.milestones[${i}].kind 非法：「${m?.kind}」`,
-      );
+    if (!m || typeof m.kind !== 'string' || !VALID_MILESTONE_KINDS.has(m.kind as MilestoneKind)) {
+      throw new FixtureValidationError(`expected.milestones[${i}].kind 非法：「${m?.kind}」`);
     }
   }
 }
@@ -229,9 +216,7 @@ function validateEpoch(ep: CombatFixture['epochs'][number], index: number): void
  * 验证骰带可建（A0-8 前置）——如果 splitSixty/createTape 抛错，说明 fixture
  * 的 dice 或 channelSplit 有问题。
  */
-function buildTape(
-  epochs: readonly CombatFixture['epochs'][number][],
-): DiceTapeState {
+function buildTape(epochs: readonly CombatFixture['epochs'][number][]): DiceTapeState {
   let tape: DiceTapeState | null = null;
   for (const ep of epochs) {
     const channels = splitSixty([...ep.dice]);
@@ -274,7 +259,7 @@ function hashFixture(fixture: CombatFixture): string {
   const canonical = canonicalStringify({
     id: fixture.id,
     bundle: fixture.bundle,
-    epochs: fixture.epochs.map(ep => ({
+    epochs: fixture.epochs.map((ep) => ({
       outputId: ep.outputId,
       dice: [...ep.dice],
       channelSplit: ep.channelSplit,
@@ -302,11 +287,7 @@ function canonicalStringify(value: unknown): string {
   const obj = value as Record<string, unknown>;
   const keys = Object.keys(obj).sort();
   return (
-    '{' +
-    keys
-      .map(k => JSON.stringify(k) + ':' + canonicalStringify(obj[k]))
-      .join(',') +
-    '}'
+    '{' + keys.map((k) => JSON.stringify(k) + ':' + canonicalStringify(obj[k])).join(',') + '}'
   );
 }
 

--- a/src/sillytavern/combat-v3/replay.ts
+++ b/src/sillytavern/combat-v3/replay.ts
@@ -1,0 +1,322 @@
+/**
+ * combat-v3/replay.ts — replay harness（M0 版本）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §四 4.6（provenance 与 replay 语义）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §2.2 / §2.6 / §2.7
+ *
+ * 验收：
+ *   A0-5  replayCombat 是纯函数：同 fixture 跑两次，events 深相等且 hash 相同；
+ *         跑完不产生任何 DB/store 副作用
+ *   A0-8  06/24 两场简版 fixture 的 milestone 断言通过
+ *         （M0 = 结构合法 + 骰带可建；数值 milestone 由 M1 起内核就位后才真正断言）
+ *
+ * M0 版本：内核 reducer 未就位，replay 只做：
+ *   ① fixture 结构校验（validateFixture）
+ *   ② epochs 切分为骰带（splitSixty + createTape + beginEpoch），验证骰带可建
+ *   ③ 计算稳定 hash（fixture 核心字段的规范化 djb2）
+ *   ④ 回显 expected.milestones
+ *   events 恒为 []（M1 起由 reducer 注入产出 DomainEvent）。
+ *
+ * reducer 注入缝：第二个参数 _reducer（M1+ 实装）。M0 不调用，commands 暂不驱动。
+ *
+ * 铁律（plan §1.3）：本文件零 Math.random / new Function / eval，
+ * no-nondeterminism.test.ts 会扫描断言。djb2 用位运算 + charCodeAt，确定性。
+ */
+
+import { beginEpoch, createTape, splitSixty } from './dice-tape';
+import {
+  CHANNEL_ORDER,
+  DEFAULT_CHANNEL_SPLIT,
+  type CombatFixture,
+  type DiceChannel,
+  type DiceEpoch,
+  type DiceTapeState,
+  type Milestone,
+  type MilestoneKind,
+} from './types';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 公共类型
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * replay 的返回值。
+ *
+ * - events：M0 恒为空数组；M1 起由 reducer 产出 DomainEvent[]
+ * - hash：基于 fixture 核心字段（忽略 _synthetic/_provenance 元数据）的稳定哈希；
+ *         同 fixture 跑两次必然相同（验收 A0-5）。M4 起改基于 DomainEvent 序列。
+ * - milestones：回显 fixture.expected.milestones，供 contract test 断言
+ * - tapeFinal：replay 后骰带的最终状态，验证骰带可建（M0 阶段的核心产出）
+ */
+export interface ReplayResult {
+  readonly events: readonly unknown[];
+  readonly hash: string;
+  readonly milestones: readonly Milestone[];
+  readonly tapeFinal: DiceTapeState;
+}
+
+/**
+ * reducer 注入缝（M1+ 实装）。
+ *
+ * M0 不调用。M1 起，replayCombat 会用真实内核 reduce 驱动 fixture.commands，
+ * reducer 负责消费 tape 的骰子并产出 DomainEvent[] + 最终 tape。
+ */
+export interface ReplayReducer {
+  (fixture: CombatFixture, tape: DiceTapeState): {
+    events: readonly unknown[];
+    tape: DiceTapeState;
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 主入口
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 重放一场 fixture 战斗。纯函数，无 DB/store 副作用（验收 A0-5）。
+ *
+ * M0：reducer 未就位，events 恒为 []，commands 不驱动；只验证 fixture 合法 +
+ * 骰带可建 + 计算 hash + 回显 milestones。M1 起传 reducer 即可驱动完整流程。
+ */
+export function replayCombat(
+  fixture: CombatFixture,
+  _reducer?: ReplayReducer,
+): ReplayResult {
+  validateFixture(fixture);
+
+  const tape = buildTape(fixture.epochs);
+
+  // M0：reducer 未就位。M1 起在此处用 _reducer(fixture, tape) 产出 events + 最终 tape。
+  // 当前预留参数，不调用——保证 M0 的 events 恒为 [] 且行为完全确定。
+  const events: readonly unknown[] = [];
+
+  const hash = hashFixture(fixture);
+
+  return {
+    events,
+    hash,
+    milestones: fixture.expected.milestones,
+    tapeFinal: tape,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// fixture 结构校验
+// ──────────────────────────────────────────────────────────────────────────────
+
+const VALID_MILESTONE_KINDS: ReadonlySet<MilestoneKind> = new Set<MilestoneKind>([
+  'damage',
+  'reflected',
+  'prevented',
+  'statusApplied',
+  'moraleChanged',
+  'summoned',
+  'terminal',
+  'fpDelta',
+  'roundCount',
+]);
+
+/**
+ * fixture 校验失败错误。所有校验问题都抛这个类型，方便上层 catch 区分。
+ */
+export class FixtureValidationError extends Error {
+  constructor(message: string) {
+    super(`[combat-v3/replay] ${message}`);
+    this.name = 'FixtureValidationError';
+  }
+}
+
+/**
+ * 校验 fixture 结构合法性。
+ *
+ * 校验项（M0 范围）：
+ *   - id 非空字符串
+ *   - epochs 至少 1 个
+ *   - 每个 epoch.dice 恰好 60 个 1..20 整数
+ *   - 每个 epoch.channelSplit === DEFAULT_CHANNEL_SPLIT（M0 只支持默认预算，
+ *     与 splitSixty 的切分方式保持一致）
+ *   - commands.commandId 唯一且非空
+ *   - expected.milestones[].kind ∈ 9 种合法枚举
+ *
+ * 不校验 command kind（M1 内核 dispatch 时校验）和 milestone 的额外字段
+ *（如 duration，TS 类型上的并集字段，运行时宽松）。
+ */
+export function validateFixture(fixture: CombatFixture): void {
+  if (!fixture || typeof fixture.id !== 'string' || fixture.id.length === 0) {
+    throw new FixtureValidationError('fixture.id 必须是非空字符串');
+  }
+  if (!Array.isArray(fixture.epochs) || fixture.epochs.length === 0) {
+    throw new FixtureValidationError('fixture.epochs 至少 1 个');
+  }
+  if (!Array.isArray(fixture.commands)) {
+    throw new FixtureValidationError('fixture.commands 必须是数组');
+  }
+  if (
+    !fixture.expected ||
+    !Array.isArray(fixture.expected.milestones)
+  ) {
+    throw new FixtureValidationError('fixture.expected.milestones 必须是数组');
+  }
+
+  for (let i = 0; i < fixture.epochs.length; i++) {
+    validateEpoch(fixture.epochs[i], i);
+  }
+
+  const seenCommandIds = new Set<string>();
+  for (let i = 0; i < fixture.commands.length; i++) {
+    const cmd = fixture.commands[i];
+    if (!cmd || typeof cmd.commandId !== 'string' || cmd.commandId.length === 0) {
+      throw new FixtureValidationError(
+        `commands[${i}].commandId 必须是非空字符串`,
+      );
+    }
+    if (seenCommandIds.has(cmd.commandId)) {
+      throw new FixtureValidationError(
+        `commands[${i}].commandId 重复：「${cmd.commandId}」`,
+      );
+    }
+    seenCommandIds.add(cmd.commandId);
+  }
+
+  for (let i = 0; i < fixture.expected.milestones.length; i++) {
+    const m = fixture.expected.milestones[i];
+    if (
+      !m ||
+      typeof m.kind !== 'string' ||
+      !VALID_MILESTONE_KINDS.has(m.kind as MilestoneKind)
+    ) {
+      throw new FixtureValidationError(
+        `expected.milestones[${i}].kind 非法：「${m?.kind}」`,
+      );
+    }
+  }
+}
+
+function validateEpoch(ep: CombatFixture['epochs'][number], index: number): void {
+  if (!ep || !Array.isArray(ep.dice) || ep.dice.length !== 60) {
+    throw new FixtureValidationError(
+      `epoch[${index}].dice 必须恰好 60 个整数（实际 ${
+        Array.isArray(ep?.dice) ? ep.dice.length : '非数组'
+      }）`,
+    );
+  }
+  for (let d = 0; d < ep.dice.length; d++) {
+    const value = ep.dice[d];
+    if (!Number.isInteger(value) || value < 1 || value > 20) {
+      throw new FixtureValidationError(
+        `epoch[${index}].dice[${d}] 必须是 1..20 整数（实际 ${value}）`,
+      );
+    }
+  }
+  for (const ch of CHANNEL_ORDER) {
+    const actual = ep.channelSplit[ch];
+    if (actual !== DEFAULT_CHANNEL_SPLIT[ch]) {
+      throw new FixtureValidationError(
+        `epoch[${index}].channelSplit.${ch} 必须为 ${DEFAULT_CHANNEL_SPLIT[ch]}（M0 只支持默认预算，实际 ${actual}）`,
+      );
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 骰带构建
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 把 fixture.epochs 的原始 60 颗骰序列逐个切分并构造 DiceTapeState。
+ *
+ * 第一个 epoch 用 createTape，后续用 beginEpoch（旧 epoch 归档进 exhausted）。
+ * 验证骰带可建（A0-8 前置）——如果 splitSixty/createTape 抛错，说明 fixture
+ * 的 dice 或 channelSplit 有问题。
+ */
+function buildTape(
+  epochs: readonly CombatFixture['epochs'][number][],
+): DiceTapeState {
+  let tape: DiceTapeState | null = null;
+  for (const ep of epochs) {
+    const channels = splitSixty([...ep.dice]);
+    const epoch: DiceEpoch = {
+      outputId: ep.outputId,
+      batchHash: '', // M0 不计算；M4 冻结 eventHash 时由 reducer 补 batchHash
+      channels,
+      cursors: zeroCursors(),
+    };
+    tape = tape === null ? createTape(epoch) : beginEpoch(tape, epoch);
+  }
+  // validateFixture 已保证 epochs.length >= 1
+  return tape as DiceTapeState;
+}
+
+function zeroCursors(): Readonly<Record<DiceChannel, number>> {
+  return {
+    attackHit: 0,
+    initiative: 0,
+    intentCheck: 0,
+    statusContest: 0,
+    procCheck: 0,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 稳定 hash
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 基于 fixture 核心字段计算稳定 hash。
+ *
+ * 只取 id/bundle/epochs/commands/expected，**忽略** fixture 顶层的元数据字段
+ *（_synthetic / _provenance 等），保证 hash 只反映战斗定义本身。
+ *
+ * 用 djb2（确定性字符串哈希）。M0 不需要密码学强度；M4 eventHash 会改基于
+ * DomainEvent 序列的强哈希。
+ */
+function hashFixture(fixture: CombatFixture): string {
+  const canonical = canonicalStringify({
+    id: fixture.id,
+    bundle: fixture.bundle,
+    epochs: fixture.epochs.map(ep => ({
+      outputId: ep.outputId,
+      dice: [...ep.dice],
+      channelSplit: ep.channelSplit,
+    })),
+    commands: fixture.commands,
+    expected: {
+      milestones: fixture.expected.milestones,
+      eventHash: fixture.expected.eventHash,
+    },
+  });
+  return 'm0_' + (djb2(canonical) >>> 0).toString(36);
+}
+
+/**
+ * 规范化序列化：对象 key 字典序排序、数组保序。保证同结构对象产出相同字符串。
+ */
+function canonicalStringify(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  const t = typeof value;
+  if (t === 'string') return JSON.stringify(value);
+  if (t === 'number' || t === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalStringify).join(',') + ']';
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return (
+    '{' +
+    keys
+      .map(k => JSON.stringify(k) + ':' + canonicalStringify(obj[k]))
+      .join(',') +
+    '}'
+  );
+}
+
+/**
+ * djb2 字符串哈希。经典确定性算法，位运算 + charCodeAt，零外部依赖。
+ */
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  }
+  return h;
+}

--- a/src/sillytavern/combat-v3/types.ts
+++ b/src/sillytavern/combat-v3/types.ts
@@ -1,0 +1,335 @@
+/**
+ * combat-v3/types.ts — 战斗 v3 内部类型（M0 部分）
+ *
+ * 仅落 M0 骰带核心需要的类型，其余（CombatState / CombatPhase / ResolutionFrame /
+ * JournalEntry / EffectIntent / DomainEvent 等）由 M1 起补全。
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md
+ *   - DiceChannel / DiceEpoch / DiceTapeState —— §四 4.2
+ *   - DEFAULT_CHANNEL_SPLIT                  —— §四 4.3（D6 决策）
+ *   - CombatProvenance                       —— §四 4.6
+ *
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md
+ *   - CombatFixture / Milestone —— §2.3
+ *   - CombatCommandKind          —— §2.2 引用架构 §二 2.2
+ */
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DiceChannel
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 骰带通道枚举。
+ *
+ * 通道隔离的原因（架构 §四 4.1）：单一 cursor 会令概率召唤、反伤命中等"额外骰"
+ * 把整场后续命中结果整体错位，导致 replay 无法对齐真实样本。
+ *
+ * 枚举顺序与通道预算表（架构 §四 4.3）一一对应。
+ */
+export type DiceChannel =
+  | 'initiative'
+  | 'attackHit'
+  | 'statusContest'
+  | 'procCheck'
+  | 'intentCheck';
+
+/**
+ * 60 颗 d20 的默认分通道预算（架构 §四 4.3，决策 D6）。
+ *
+ * 实测来源：5 场真实样本聚合统计 attackHit 57% / initiative 18% /
+ * intentCheck 11% / statusContest 10% / procCheck 4%。低频通道向上取整到 5 颗地板，
+ * 超出额度从最高频通道 attackHit 扣，合计恰好 60。
+ *
+ * 顺序由高到低排列以便 splitSixty 按此顺序切片。
+ */
+export const DEFAULT_CHANNEL_SPLIT: Readonly<Record<DiceChannel, number>> = {
+  attackHit: 32,
+  initiative: 10,
+  intentCheck: 7,
+  statusContest: 6,
+  procCheck: 5,
+};
+
+/**
+ * splitSixty 的切分顺序：与 DEFAULT_CHANNEL_SPLIT 一致（attackHit 在前）。
+ * 暴露为常量数组便于遍历时保证确定性。
+ */
+export const CHANNEL_ORDER: readonly DiceChannel[] = [
+  'attackHit',
+  'initiative',
+  'intentCheck',
+  'statusContest',
+  'procCheck',
+] as const;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DiceEpoch / DiceTapeState
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 单个 epoch：一次正文输出对应的 60 颗 d20，已按通道预算切分。
+ *
+ * channels 与 cursors 的字段顺序遵循 DEFAULT_CHANNEL_SPLIT（架构 §四 4.2）。
+ * 各通道的 dice 数组**必须**与 DEFAULT_CHANNEL_SPLIT 对应值等长，
+ * 否则 createTape 抛错（验收 A0-4）。
+ *
+ * cursors 是各通道已消费到第几颗（0-based）。draw 只推进**目标通道**的 cursor，
+ * 其余通道完全不变（验收 A0-1）。
+ */
+export interface DiceEpoch {
+  /** 对应一次正文输出的 id（供 provenance 追溯，架构 §四 4.4） */
+  outputId: string;
+  /** 60 颗骰的内容哈希（用于 replay 对齐，架构 §四 4.6） */
+  batchHash: string;
+  /** 按通道预算切分后的 60 颗骰 */
+  channels: Readonly<Record<DiceChannel, readonly number[]>>;
+  /** 各通道消费游标（0-based） */
+  cursors: Readonly<Record<DiceChannel, number>>;
+}
+
+/**
+ * 骰带状态：当前 epoch + 已归档的耗尽 epoch。
+ *
+ * beginEpoch 后旧 epoch 进 exhausted[]，各通道 cursor 归 0，
+ * 旧余骰不可再取（架构 §四 4.4，验收 A0-3）。
+ */
+export interface DiceTapeState {
+  /** 第几次续杯（0 = 首次，即 current 是第一个 epoch） */
+  epochSeq: number;
+  /** 当前 epoch */
+  current: DiceEpoch;
+  /** 已作废的历史 epoch（仅供 replay / 审计，不可再取骰） */
+  exhausted: readonly DiceEpoch[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CombatProvenance（架构 §四 4.6）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 一条 epoch 的最终游标快照，落入 provenance 供 replay 校验。
+ */
+export interface ProvenanceDiceEpoch {
+  outputId: string;
+  batchHash: string;
+  finalCursors: Readonly<Record<DiceChannel, number>>;
+}
+
+/**
+ * 战斗 provenance：用于 replay 对齐与审计。
+ *
+ * replay 语义（D5）：同 bundleHash + 同 DiceTape（各 epoch batchHash 序列一致） +
+ * 同 Command 序列 ⇒ DomainEvent 序列 hash 一致。
+ */
+export interface CombatProvenance {
+  /** 引擎版本，如 'v3' */
+  engineVersion: string;
+  /** EffectIntent / DomainEvent schema 版本 */
+  schemaVersion: string;
+  /** 数值规则版本（层级系数表等） */
+  rulesetRevision: string;
+  /** CombatDefinitionBundle 内容哈希 */
+  bundleHash: string;
+  /** 已产出 DomainEvent 数 */
+  eventSequence: number;
+  /** 各 epoch 的最终游标快照 */
+  diceEpochs: readonly ProvenanceDiceEpoch[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CombatCommandKind（架构 §二 2.2 全集）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Command 的全部 kind（架构 §二 2.2 表）。
+ *
+ * M0 不需要全部用到，但类型必须先冻结（plan §0.4 R3）。
+ */
+export type CombatCommandKind =
+  | 'DeclareAttack'
+  | 'DeclareAction'
+  | 'DeclareBlock'
+  | 'Flee'
+  | 'PassAttack'
+  | 'PassAction'
+  | 'Choose'
+  | 'Adjudicate'
+  | 'SupplyDice'
+  | 'SupplyUnit'
+  | 'AcceptSurrender'
+  | 'Capture'
+  | 'RequestSettlement';
+
+/**
+ * CombatCommand 的行动槽成本（架构 §二 2.2）。
+ */
+export type CommandCost = 'attack' | 'action' | 'both' | 'none';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CombatFixture（plan §2.3 冻结格式）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * fixture 内参战单位的最小快照。
+ * M0 不需要完整 CharacterState，只保留 milestone 断言需要的字段。
+ */
+export interface FixtureUnit {
+  /** 角色名（逻辑键，铁律 ①） */
+  name: string;
+  /** 层级 1-7 */
+  tier: number;
+  /** 当前 HP */
+  hp: number;
+  /** 最大 HP */
+  maxHp: number;
+  /** 当前 MP */
+  mp?: number;
+  /** 最大 MP */
+  maxMp?: number;
+  /** 当前 SP */
+  sp?: number;
+  /** 最大 SP */
+  maxSp?: number;
+  /** 五维（力量/敏捷/体质/智力/感知），可选 */
+  attributes?: Readonly<Record<string, number>>;
+  /** 装备名列表（逻辑键） */
+  equipment?: readonly string[];
+  /** 技能名列表（逻辑键） */
+  skills?: readonly string[];
+  /** 登神强度 0-8（v2 §四 4.2） */
+  divinity?: number;
+  /** 集群数量（v2 §六 6.x，第 07 场用，M4 补正式字段） */
+  clusterCount?: number;
+}
+
+/**
+ * CombatDefinitionBundle 的 fixture 子集。
+ * M0 不需要 programs（EffectProgram M3 起填）。
+ */
+export interface FixtureBundle {
+  /** 战斗 id（fixture 内唯一） */
+  combatId: string;
+  /** 战斗类型：标准 / 遭遇 / 伏击 / 围攻（v2 §九 9.5 战意阈值） */
+  combatType: string;
+  /** 参战单位快照 */
+  units: readonly FixtureUnit[];
+  /** 编译后的 EffectAutomaton[]；M0 留空数组，M3 起填 */
+  programs: readonly unknown[];
+  /** 战斗开始时的 FP 快照（架构 §十二 12.2） */
+  resourceSnapshots: { FP: number };
+  /** 数值规则版本 */
+  rulesetRevision: string;
+}
+
+/**
+ * fixture 内单个 epoch 的定义（plan §2.3）。
+ *
+ * dice 是 60 个 1..20 的整数原始序列，由 splitSixty 按 channelSplit 切分。
+ */
+export interface FixtureEpoch {
+  /** 输出 id */
+  outputId: string;
+  /** 恰好 60 个 1..20 的整数 */
+  dice: readonly number[];
+  /** 分通道预算，默认 DEFAULT_CHANNEL_SPLIT */
+  channelSplit: Readonly<Record<DiceChannel, number>>;
+}
+
+/**
+ * fixture 内的单条 Command（plan §2.3）。
+ *
+ * payload 按 kind 定型，M0 不做精确收窄（用 unknown + M1 起补联合）。
+ */
+export interface FixtureCommand {
+  /** 幂等键 */
+  commandId: string;
+  /** 乐观并发：对应 dispatch 前的 revision */
+  expectedRevision: number;
+  /** Command 类型（架构 §二 2.2） */
+  kind: CombatCommandKind;
+  /** 执行单位（用名字寻址，铁律 ①） */
+  actorId: string;
+  /** 行动槽成本 */
+  cost: CommandCost;
+  /** 按 kind 定型的载荷 */
+  payload: unknown;
+}
+
+/**
+ * Milestone 的 kind 枚举（plan §2.3）。
+ *
+ * M0 定，后续只加不改。
+ */
+export type MilestoneKind =
+  | 'damage'
+  | 'reflected'
+  | 'prevented'
+  | 'statusApplied'
+  | 'moraleChanged'
+  | 'summoned'
+  | 'terminal'
+  | 'fpDelta'
+  | 'roundCount';
+
+/**
+ * 单个 milestone 断言（plan §2.3 expected.milestones[]）。
+ *
+ * 字段是各 kind 的并集，运行时按 kind 取对应字段。
+ * 使用 unknown 保留扩展性，M1 起可改为判别联合。
+ */
+export interface Milestone {
+  /** milestone 类型 */
+  kind: MilestoneKind;
+  /** 该 milestone 对应的 commandId（at 在 plan §2.3 示例中出现） */
+  at?: string;
+  /** 目标单位名（damage/statusApplied 用） */
+  targetId?: string;
+  /** 数值（伤害量 / FP 变动 / 回合数等） */
+  value?: number;
+  /** 容差（数值断言的 ±，默认 0） */
+  tolerance?: number;
+  /** 反射链根 commandId（reflected 用） */
+  rootChainId?: string;
+  /** 反射深度（reflected 用） */
+  depth?: number;
+  /** 终局原因（terminal 用，如 'hp_zero' / 'force_terminal'） */
+  reason?: string;
+  /** 胜方（terminal 用） */
+  winner?: string;
+  /** 状态 id（statusApplied 用） */
+  statusId?: string;
+}
+
+/**
+ * fixture 的 expected 段（plan §2.3）。
+ */
+export interface FixtureExpected {
+  /** milestone 断言列表 */
+  milestones: readonly Milestone[];
+  /**
+   * DomainEvent 序列哈希。
+   * M0-M3 为 null（只断言 milestone）；M4 各场稳定后冻结为字符串。
+   */
+  eventHash: string | null;
+}
+
+/**
+ * CombatFixture：M0 冻结的 replay 输入格式（plan §2.3）。
+ *
+ * 一条 fixture = bundle + epochs + commands + expected milestones。
+ * replayCombat(fixture) 是纯函数（验收 A0-5），不产生任何 DB/store 副作用。
+ */
+export interface CombatFixture {
+  /** fixture 唯一 id，如 'case-24-reflection' */
+  id: string;
+  /** 来源案例文档路径 */
+  sourceCase: string;
+  /** 战斗定义 bundle */
+  bundle: FixtureBundle;
+  /** 按消费顺序排列的 epoch 列表（跨 epoch 续杯的场次有多个） */
+  epochs: readonly FixtureEpoch[];
+  /** 按提交顺序排列的 Command 列表 */
+  commands: readonly FixtureCommand[];
+  /** 期望的 milestone 断言 */
+  expected: FixtureExpected;
+}

--- a/src/sillytavern/combat-v3/types.ts
+++ b/src/sillytavern/combat-v3/types.ts
@@ -27,11 +27,7 @@
  * 枚举顺序与通道预算表（架构 §四 4.3）一一对应。
  */
 export type DiceChannel =
-  | 'initiative'
-  | 'attackHit'
-  | 'statusContest'
-  | 'procCheck'
-  | 'intentCheck';
+  'initiative' | 'attackHit' | 'statusContest' | 'procCheck' | 'intentCheck';
 
 /**
  * 60 颗 d20 的默认分通道预算（架构 §四 4.3，决策 D6）。

--- a/src/sillytavern/types.ts
+++ b/src/sillytavern/types.ts
@@ -565,6 +565,15 @@ export interface AppSettings {
    *   现算出来的派生缓存，给它任何持久化字段位都是制造第二真相来源。
    */
   beautifierRules: BeautifierRule[];
+  /**
+   * v3 M0：战斗引擎版本 feature flag（架构 §14.5）。
+   * - `'v2'`（默认）：走现有 `combat-runner` + Agent 主持流程
+   * - `'v3'`：走 `combat-v3` 内核主持流程
+   * 分支点唯一（game-pipeline.handleCombatTrigger），粒度按整场战斗，
+   * openCombat 时冻结进 CombatState.provenance 不可中途变更。
+   * 默认 `'v2'`，M5 才翻转为 `'v3'`。
+   */
+  combatEngineVersion: 'v2' | 'v3';
 }
 
 export const DEFAULT_FORMAT_PROMPT = `你必须严格按照以下 XML 标签格式输出回复，不要使用 Markdown 包裹：
@@ -616,6 +625,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   /** Phase 7e: 输出美化 */
   beautifierEnabled: true,
   beautifierRules: [],
+  /** v3 M0: 战斗引擎版本（默认 v2，M5 才翻 v3） */
+  combatEngineVersion: 'v2',
 };
 
 // ========== Chat Types ==========


### PR DESCRIPTION
## 变更说明

战斗 v3（代码内核主持流程）的 M0 地基。所有新代码落在 `src/sillytavern/combat-v3/`（deep module），v2 战斗代码一行未删，靠 feature flag 整场切换。

**新建 `combat-v3/` deep module：**

- `types.ts` — DiceChannel / DiceEpoch / DiceTapeState / CombatProvenance + CombatFixture 全类型 + `DEFAULT_CHANNEL_SPLIT`（attackHit 32 / initiative 10 / intentCheck 7 / statusContest 6 / procCheck 5，D6 实测加权）
- `dice-tape.ts` — `createTape` / `draw` / `beginEpoch` / `splitSixty` 纯函数（不可变更新；draw 只推进目标通道 cursor；耗尽不推进任何 cursor；不做通道间借用）
- `replay.ts` — `replayCombat(fixture, reducer?)` 纯函数：validateFixture + buildTape + hashFixture（djb2）+ reducer 注入缝
- `fixtures/case-06-summon.fixture.json` / `case-24-reflection.fixture.json` — 两场简版 fixture，含 `_provenance` 骰值对照表
- `no-nondeterminism.test.ts` — 目录扫描断言零 `Math.random` / `new Function` / `eval`

**v2 纯函数签名改造（差分测试地基，行为零变化）：**

- `performAttackCheck`: `d20Roll: number` → `rolls: [number, number?]`，删两处 `Math.random()`（修复 M-5）
- `runMoraleCheckPipeline`: `d20Roll` 改必传（修复 M-4）
- `combat-pipeline.ts` / `combat-resolver.ts` 调用点补传 `rolls:[d20,d20]` / `d20Roll:10`
- `AppSettings.combatEngineVersion: 'v2'|'v3'` 默认 `'v2'`（feature flag，分支点唯一）

## 检查清单

- [x] `npm run typecheck` + `npm run test:run` 本地通过（**4757 passed / 144 files 全绿**；combat-v3 新增 57 测试；v2 战斗测试 177 个零行为变化）
- [x] 文档同步：AGENTS.md 进度表 + `docs/CHANGELOG.md` M0 条目 + `.claude/agent-memory/code-writer/` 经验记忆
- [x] 涉及游戏数值/世界观 → 已查 `reference/world_book_index.md`（通道预算来自 5 场样本实测，架构 D6）
- [x] 新模块已配套 `*.test.ts`
- [x] changelog 已追加条目

## 验收断言

- [x] A0-1 ~ A0-8 全过（见 CHANGELOG M0 条目）

## 已知遗留（M1 对齐）

- fixture command kind 用了 `UseSkill`（非架构 §二 2.2 枚举），M0 replay 不校验 kind，M1 内核 dispatch 时改
- fixture `attrs` 中文键 / `FixtureUnit.attributes` 英文键 待 M1 统一

## Agent 产出信息

- 产出：Claude Code（code-writer agent）
- 验证：`npm run test -- --run` 全绿 + `npm run typecheck` 零错误；未经真机（M6 真机由主人另行决定）