### PR TITLE
战斗 v3 M3 — 效果系统：DSL + 编译链 + windows 实装 + damage.preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,7 +312,7 @@ bash scripts/notify.sh "<Phase名称> 完成!" "<关键指标>"
 | Audio     | 音频系统 v1.0（双通道+三后端+按名寻址+场景配乐）       | ✅                  |
 | 素材      | 素材管理系统 v1.0（渲染面+大画像+裁剪台+画像弹窗）     | ✅                  |
 | 战斗 v2   | 战斗系统架构 v2（管道+中间件+6大类+19event+独立面板）  | ✅ M5完成 待M6真机  |
-| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 🔄 M3完成 待M3.5     |
+| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 🔄 M3完成 待M3.5    |
 | 工坊 P0   | 世界书迁出 localStorage → Dexie v14（+ 进 FullBackup） | ✅                  |
 | 工坊 P0b  | 美化规则迁出 localStorage → Dexie v15                  | ✅                  |
 | 工坊 P1   | 创意工坊（浏览/安装/更新/卸载/启用，= 7f）             | ✅ 真机已过         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,7 +312,7 @@ bash scripts/notify.sh "<Phase名称> 完成!" "<关键指标>"
 | Audio     | 音频系统 v1.0（双通道+三后端+按名寻址+场景配乐）       | ✅                  |
 | 素材      | 素材管理系统 v1.0（渲染面+大画像+裁剪台+画像弹窗）     | ✅                  |
 | 战斗 v2   | 战斗系统架构 v2（管道+中间件+6大类+19event+独立面板）  | ✅ M5完成 待M6真机  |
-| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 🔄 M2完成 待M3      |
+| 战斗 v3   | 代码内核主持流程（Kernel+DiceTape+EffectIntent+DSL）   | 🔄 M3完成 待M3.5     |
 | 工坊 P0   | 世界书迁出 localStorage → Dexie v14（+ 进 FullBackup） | ✅                  |
 | 工坊 P0b  | 美化规则迁出 localStorage → Dexie v15                  | ✅                  |
 | 工坊 P1   | 创意工坊（浏览/安装/更新/卸载/启用，= 7f）             | ✅ 真机已过         |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,31 @@
 
 ## 进行中 / 近期交付（按交付时间倒序）
 
+### 战斗 v3 M3 — 效果系统：DSL + 编译链 + windows 实装 + damage.preview ｜ ✅ 完成（2026-08-01）
+
+架构真源: `docs/reference/combat-system-architecture-v3.md`（§五 ReactionWindow / §六 EffectIntent / §七 EffectAutomaton DSL + 编译链 / §九 反射专项）；实施计划: `docs/planning/2026-07-31-combat-v3-implementation-plan.md` §5。把「效果」从 v2 的任意 JS 脚本（`new Function` 执行）翻转为**声明式 automaton + 封闭微文法表达式**，`windows.ts` 从空转变实装。**战斗内全链路零 `new Function` / `eval`**（铁律 2，C1 战斗内消解）。
+
+**新建 `combat-v3/automata/` 子目录 + 2 文件:**
+
+- `automata/parser.ts` — 递归下降 parser：token 集封闭、词法期拒绝白名单外 token（`=`/`[`/`{`/反引号/`;`/`new`/`function`/`this`/未知标识符）、`ctx.` 点分路径合并、`parseCmp` 非结合（`a<b<c` 报错）、**`ExprSyntaxError` 带 1-based 列号**（A3-1）
+- `automata/interpreter.ts` — 零 eval AST 解释器：字面量/路径/白名单函数（min/max/floor/ceil/abs/percent/has）/一元/二元；除零返回 0；未定义 ctx 路径抛 `ExprEvalError`（错误隔离）
+- `automata/compile.ts` — `compileEffectProgram` 三来源编译链（① `modifiers[]` → push-handler automaton（ADR-29）/ ② `ParsedEffect` → 内建 adapter / ③ AI automaton JSON）+ **9 条编译期校验**（窗口存在/trigger 文法/kind∈8 大类/RuleKey 白名单/divinity≤所有者/数值 clamp/ctx 路径根段/五维直改/前缀，A3-3）
+- `automata/builtins.ts` — 15 条内建映射（固伤/伤害%/受到伤害-%（修 M-6）/命中/闪避/先攻/DR/穿透/反伤/吸血/护盾/DoT/HoT/暴击率/次数）
+- `automata/index-active.ts` — `buildIndex`/`updateIndex`：按窗口分组并按 §5.3 排序、离场移除
+- `automata/reflection.ts` — 反射专项（§九）：R4 preReduction 基准 / R6 depth=2 熔断产 `NarrativeCue('反射湮灭')` / R7 基准不放大 / R8 attackHit 通道
+- `intents.ts` — `validateBatch`（batch 内一个非法 ⇒ 整批 reject + `EffectRejected`，**不取消**核心攻击与同窗口其他 automaton，A3-7）+ `applyIntents` 解释执行
+- `windows.ts`（实装）— 求值顺序（窗口→divinity→priority→stable id）/ 在场过滤 / charges 耗尽跳过 / trigger 错误隔离 / batch 原子性 / **预算 64 截断 + BUDGET_EXCEEDED**
+
+**damage.preview 全流程（§5.4）:** `phases/attack.ts` 步骤⑥ 接 `RequestChoice`：`hasSubscribers` 判空 → 有订阅者则冻结 `ResolutionFrame` → 返回 `RequiredInput.EffectChoice`；`reducer.ts` 加 `DeclareBlock` frame 恢复分支 → 格挡 intent batch → **回到 `damage.compute` 重算**（不在 final 上打折）→ 487→97 比例。无订阅者**不暂停**（A3-6）。
+
+**修改文件:** `combat-item-validator.ts` 新增 v3 共享常量（`V3_WINDOW_KEYS`/`V3_INTENT_KINDS`/`V3_RULE_KEYS`），**v2 运行时入口保留不删**；`phases/outcome.ts`/`round.ts`/`action.ts` 适配 Windows ctx；`state.ts` 加 `freezeFrame`/`restoreFrame`。
+
+**验收:** A3-1 ~ A3-8 全过（parser 列号 / evaluate 零 eval / 编译期剔除 / modifier push-handler / 487→97 重算 / 无订阅不暂停 / batch 原子性 / 第 24 场反伤 depth=2 熔断）。全量 **5166 测试 / 166 文件全绿**；typecheck 0 错误；lint 0 error。
+
+**M3 修复的 Critical/Major:** C1（战斗内消解：全链路零 `new Function`）/ M-6（守方百分比进 `collect_defender_mods`）/ M-2（ActiveEffectIndex 通电）/ M-12（窗口递归 ≤5 + 反射 depth ≤2 + 预算 64）/ M-15（automaton 返回 undefined 视为空 batch）。
+
+**已知遗留（M3.5 对齐）:** Coordinator 的 `EffectChoice` 路由仍 `throw UnsupportedInM2`（M3 只做内核，M3.5 接 game-store→UI 格挡询问）；`makeWindowRuntimeCtx.resolveNumber` 对非数字表达式返回 fallback（M3 范围限于 damage.preview 全量求值，其余窗口表达式求值 M3.5/M4 补全）；`reflection`/`charges` 内建特判。
+
 ### 战斗 v3 M2 — 接线：Coordinator + feature flag + 双投影 + 前端桥 ｜ ✅ 完成（2026-08-01）
 
 架构真源: `docs/reference/combat-system-architecture-v3.md`（§十三 双投影 / §十四 引擎边界 + Coordinator + feature flag + 四态 UI / §十二 FP 协议）；实施计划: `docs/planning/2026-07-31-combat-v3-implementation-plan.md` §4。把 M1 的内核骨架接到真实业务路径：Coordinator 驱动完整战斗循环、feature flag 整场切换、投影 A（UI）/B（Agent 文本面板）、前端 Command 桥。v2 路径一行未删（flag 默认 `'v2'`）。

--- a/src/sillytavern/combat-item-validator.ts
+++ b/src/sillytavern/combat-item-validator.ts
@@ -354,6 +354,83 @@ export function validateItemOutput(output: {
 }
 
 // ═══════════════════════════════════════════════════════════
+// v3 编译期校验（M3 战斗 v3，供 automata/compile.ts 调用）
+// ═══════════════════════════════════════════════════════════
+// 保留 v2 运行时入口（validateModifier / validateBuff / validateItemOutput）不删。
+// 这里是战斗 v3 的 EffectAutomaton DSL 编译期共享校验（架构 §七 7.4 / plan §5.5）。
+
+/** 18 个 ReactionWindow 清单（架构 §五 5.1） */
+export const V3_WINDOW_KEYS: ReadonlySet<string> = new Set([
+  'round.open',
+  'round.close',
+  'initiative.before',
+  'initiative.after',
+  'turn.open',
+  'turn.close',
+  'action.declared',
+  'check.intent',
+  'check.hit',
+  'collect_attacker_mods',
+  'collect_defender_mods',
+  'damage.preview',
+  'damage.compute',
+  'damage.after',
+  'unit.beforeDown',
+  'morale.before',
+  'morale.after',
+  'settlement.before',
+]);
+
+/** 8 大类 EffectIntent kind + Outcome 子类（架构 §六 6.1） */
+export const V3_INTENT_KINDS: ReadonlySet<string> = new Set([
+  'AddModifier',
+  'DealDamage',
+  'Heal',
+  'ApplyStatus',
+  'RemoveStatus',
+  'SpendResource',
+  'PreventDeath',
+  'ConsumeCharge',
+  'EmitNarrativeCue',
+  'OverrideIntent',
+  'ScheduleIntent',
+  'SpawnOrDespawnIntent',
+  'RequestChoiceIntent',
+]);
+
+/** closed RuleKey 白名单（架构 §八 8.2） */
+export const V3_RULE_KEYS: ReadonlySet<string> = new Set([
+  'morale.forceState',
+  'terminal.forceTerminal',
+  'action.freezeSlot',
+  'death.threshold',
+]);
+
+/** 校验 subscribe 是否为合法窗口（返回中文违规原因或 null） */
+export function validateV3Window(subscribe: unknown): string | null {
+  if (typeof subscribe !== 'string' || !V3_WINDOW_KEYS.has(subscribe)) {
+    return `subscribe 必须是 18 窗口之一，当前=${JSON.stringify(subscribe)}（架构 §五 5.1）`;
+  }
+  return null;
+}
+
+/** 校验 intent kind 是否 ∈ 8 大类（返回中文违规原因或 null） */
+export function validateV3IntentKind(kind: unknown): string | null {
+  if (typeof kind !== 'string' || !V3_INTENT_KINDS.has(kind)) {
+    return `intents[].kind 必须是 8 大类之一，当前=${JSON.stringify(kind)}（架构 §六 6.1）`;
+  }
+  return null;
+}
+
+/** 校验 OverrideIntent.ruleKey ∈ closed 白名单（返回中文违规原因或 null，合法则 null） */
+export function validateV3RuleKey(ruleKey: unknown): string | null {
+  if (typeof ruleKey !== 'string' || !V3_RULE_KEYS.has(ruleKey)) {
+    return `OverrideIntent.ruleKey 必须在 closed RuleKey 白名单内，当前=${JSON.stringify(ruleKey)}（架构 §八 8.2）`;
+  }
+  return null;
+}
+
+// ═══════════════════════════════════════════════════════════
 // 类型再导出（仅类型，零运行时依赖）—— 方便调用方一处 import
 // ═══════════════════════════════════════════════════════════
 

--- a/src/sillytavern/combat-v3/automata/builtins.test.ts
+++ b/src/sillytavern/combat-v3/automata/builtins.test.ts
@@ -1,0 +1,190 @@
+/**
+ * combat-v3/automata/builtins.test.ts — 内建 adapter 注册表测试（M3, 验收 A3-4）
+ *
+ * 覆盖（plan §5.8 / §5.3）：15 条内建映射逐条断言编译结果的 window + intent kind。
+ *   - 攻方固伤 → collect_attacker_mods + AddModifier(slot:'fixedDamage')
+ *   - 伤害+N% → collect_attacker_mods + AddModifier(slot:'damageMult')
+ *   - 受到伤害-N%（修 M-6）→ collect_defender_mods + AddModifier(slot:'damageTaken')
+ *   - etc.
+ *   - 不匹配 → null（UnsupportedCapability 入口）
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compileParsedEffect, BUILTIN_ADAPTERS } from './builtins';
+import type { BuiltinSeed } from './builtins';
+import type { ParsedEffect } from '../../types';
+
+const seed: BuiltinSeed = {
+  owner: '理查德',
+  source: '真理·虚数偏折',
+  idPrefix: 'item',
+  divinity: 3,
+};
+
+function mkEffect(partial: Partial<ParsedEffect>): ParsedEffect {
+  return {
+    key: 'hp',
+    rawKey: 'HP',
+    value: 0,
+    isPercentage: false,
+    isSubtractive: false,
+    ...partial,
+  };
+}
+
+describe('builtins — 15 条内建映射', () => {
+  it('#1 攻方固伤 → collect_attacker_mods + fixedDamage', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'physicalDmg', value: 50 }), seed);
+    expect(a).not.toBeNull();
+    expect(a!.subscribe).toBe('collect_attacker_mods');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'fixedDamage', value: 50 });
+  });
+
+  it('#2 伤害+N% → collect_attacker_mods + damageMult', () => {
+    const a = compileParsedEffect(
+      mkEffect({ key: 'damageMult', value: 20, isPercentage: true }),
+      seed,
+    );
+    expect(a!.subscribe).toBe('collect_attacker_mods');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'damageMult', value: 0.2 });
+  });
+
+  it('#3 受到伤害-N%（修 M-6）→ collect_defender_mods + damageTaken', () => {
+    const a = compileParsedEffect(
+      mkEffect({ key: 'damageTaken', value: 20, isPercentage: true }),
+      seed,
+    );
+    expect(a!.subscribe).toBe('collect_defender_mods');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'damageTaken', value: -0.2 });
+  });
+
+  it('#4 命中+N → check.hit + hitBonus', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'hit', value: 5 }), seed);
+    expect(a!.subscribe).toBe('check.hit');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'hitBonus', value: 5 });
+  });
+
+  it('#5 闪避+N → check.hit + dodge', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'dodge', value: 3 }), seed);
+    expect(a!.subscribe).toBe('check.hit');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'dodge', value: 3 });
+  });
+
+  it('#6 先攻+N → initiative.before + initiative', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'initiative', value: 2 }), seed);
+    expect(a!.subscribe).toBe('initiative.before');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'initiative', value: 2 });
+  });
+
+  it('#7 DR N% → collect_defender_mods + dr', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'dr', value: 10, isPercentage: true }), seed);
+    expect(a!.subscribe).toBe('collect_defender_mods');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'dr', value: 0.1 });
+  });
+
+  it('#8 穿透 N% → collect_attacker_mods + penetration', () => {
+    const a = compileParsedEffect(
+      mkEffect({ key: 'penetration', value: 30, isPercentage: true }),
+      seed,
+    );
+    expect(a!.subscribe).toBe('collect_attacker_mods');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'penetration', value: 0.3 });
+  });
+
+  it('#9 反弹 N% → damage.after + ScheduleIntent(DealDamage isReaction)', () => {
+    const a = compileParsedEffect(
+      mkEffect({ key: 'reflect', value: 30, isPercentage: true }),
+      seed,
+    );
+    expect(a!.subscribe).toBe('damage.after');
+    const s = a!.intents[0];
+    expect(s.kind).toBe('ScheduleIntent');
+    if (s.kind === 'ScheduleIntent') {
+      expect(s.intent).toMatchObject({
+        kind: 'DealDamage',
+        isReaction: true,
+        doesNotConsumeSlot: true,
+        damageType: 'true',
+        hitPolicy: { consumeDice: true, advantage: 'adv' },
+      });
+    }
+  });
+
+  it('#10 吸血 N% → damage.after + Heal(self, ctx.damage.final * N)', () => {
+    const a = compileParsedEffect(
+      mkEffect({ key: 'lifesteal', value: 15, isPercentage: true }),
+      seed,
+    );
+    expect(a!.subscribe).toBe('damage.after');
+    // trigger 表达 'ctx.damage.final > 0'
+    expect(a!.triggerAst.t).toBe('bin');
+    const h = a!.intents[0];
+    expect(h.kind).toBe('Heal');
+  });
+
+  it('#11 护盾 N → turn.open + ApplyStatus(护盾)', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'shield', value: 200 }), seed);
+    expect(a!.subscribe).toBe('turn.open');
+    const s = a!.intents[0];
+    expect(s.kind).toBe('ApplyStatus');
+    if (s.kind === 'ApplyStatus') {
+      expect(s.statusId).toContain('护盾');
+      expect(s.layers).toBe(200);
+    }
+  });
+
+  it('#12 每回合扣 N% maxHp → round.close + DealDamage(doesNotConsumeSlot)', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'dot', value: 5, isPercentage: true }), seed);
+    expect(a!.subscribe).toBe('round.close');
+    const d = a!.intents[0];
+    expect(d.kind).toBe('DealDamage');
+    if (d.kind === 'DealDamage') {
+      expect(d.doesNotConsumeSlot).toBe(true);
+      expect(d.hitPolicy?.consumeDice).toBe(false);
+    }
+  });
+
+  it('#13 每回合回 N HP → round.open + Heal', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'hot', value: 30 }), seed);
+    expect(a!.subscribe).toBe('round.open');
+    expect(a!.intents[0]).toMatchObject({ kind: 'Heal', amount: 30 });
+  });
+
+  it('#14 暴击率+N% → check.hit + critThreshold', () => {
+    const a = compileParsedEffect(
+      mkEffect({ key: 'critRate', value: 15, isPercentage: true }),
+      seed,
+    );
+    expect(a!.subscribe).toBe('check.hit');
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'critThreshold' });
+  });
+
+  it('不匹配任何内建 → null（UnsupportedCapability 入口）', () => {
+    const a = compileParsedEffect(mkEffect({ key: 'fireDmg', value: 10 }), seed);
+    expect(a).toBeNull();
+  });
+});
+
+describe('builtins — 注册表完整性', () => {
+  it('15 条 key 全部可访问', () => {
+    const keys = [
+      'physicalDmg',
+      'damageMult',
+      'damageTaken',
+      'hit',
+      'dodge',
+      'initiative',
+      'dr',
+      'penetration',
+      'reflect',
+      'lifesteal',
+      'shield',
+      'dot',
+      'hot',
+      'critRate',
+    ];
+    for (const k of keys) {
+      expect(typeof BUILTIN_ADAPTERS[k]).toBe('function');
+    }
+  });
+});

--- a/src/sillytavern/combat-v3/automata/builtins.ts
+++ b/src/sillytavern/combat-v3/automata/builtins.ts
@@ -1,0 +1,298 @@
+/**
+ * combat-v3/automata/builtins.ts — 内建 adapter 注册表（M3）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §七 7.4 ②
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §5.3（15 条）
+ *
+ * 用途：把 effect-parser.ts 的 `ParsedEffect`（中文标准词条，如「攻击时 +N 物理伤害」）
+ * 经内建映射表编译为**可信 TS adapter automaton**（不走 DSL 解释器，直接是编译好的纯
+ * 函数状 automaton）。这保证 v2 六大效果类别（架构 §四 4.1）的常见词条在 v3 战斗内仍
+ * 以声明式 automaton 形式生效，且**确定性可重放**。
+ *
+ * 每条映射断言编译结果的 window + intent kind（验收 A3-4 衍生）：
+ *   - A3-4：装备带 `modifiers[]` 的物品后 `collect_attacker_mods` 收到对应 ModifierIntent
+ *
+ * 不匹配任何内建 ⇒ 调用方产 `UnsupportedCapability`（架构 §六 6.4，该批作废）。
+ */
+
+import type {
+  CompiledAutomaton,
+  EffectAutomaton,
+  DamageType,
+  ModifierSlot,
+  WindowKey,
+} from '../types';
+import type { ParsedEffect } from '../../types';
+import { parseExpression } from './parser';
+
+/** ParsedEffect 编译注入的基础字段（owner / source / name / id / divinity） */
+export interface BuiltinSeed {
+  owner: string;
+  source: string;
+  name?: string;
+  idPrefix?: string;
+  divinity?: number;
+}
+
+function idOf(prefix: string, source: string, kind: string): string {
+  return `${prefix}.${kind}.${source}`;
+}
+
+/**
+ * 从 ParsedEffect 产出一个「附加效果型」automaton（附加 buff），
+ * 归属于 `turn.open` / `round.open` / `round.close` 等生命周期窗口。
+ */
+function asAutomaton(
+  seed: BuiltinSeed,
+  subscribe: WindowKey,
+  kindtag: string,
+  trigger: string,
+  intents: EffectAutomaton['intents'],
+  adapter: boolean,
+): CompiledAutomaton {
+  const id = idOf(seed.idPrefix ?? 'item', seed.source, kindtag);
+  // 编译为即时可用的 adapter automaton（isAdapter 标记：不走 DSL 解释器）
+  // trigger 传给内建的可信表达式（如 'ctx.damage.final > 0'），编译为 AST 供 windows 解释。
+  return {
+    id,
+    name: seed.name ?? kindtag,
+    source: seed.source,
+    owner: seed.owner,
+    subscribe,
+    priority: 0,
+    divinity: seed.divinity ?? 0,
+    stableId: id,
+    triggerAst: trigger === 'true' ? { t: 'bool', v: true } : parseExpression(trigger),
+    intents,
+    isAdapter: adapter,
+  };
+}
+
+/**
+ * 把 ParsedEffect 映射为 AddModifier automaton（push-handler）。
+ *
+ * 依据词条 key + 方向（attacker/defender）确定：
+ *   - 攻方修饰（collect_attacker_mods）
+ *   - 守方修饰（collect_defender_mods）
+ *   - 检定修饰（check.hit / check.intent / initiative.before）
+ */
+function modifierAutomaton(
+  seed: BuiltinSeed,
+  parsed: ParsedEffect,
+  slot: ModifierSlot,
+  window: WindowKey,
+  magnitude: number,
+  scope: 'whole_action' | 'per_hit' | 'per_target',
+): CompiledAutomaton {
+  return asAutomaton(
+    seed,
+    window,
+    slot,
+    'true',
+    [
+      {
+        kind: 'AddModifier',
+        slot,
+        value: magnitude,
+        scope,
+        targetId: seed.owner,
+        divinity: seed.divinity ?? 0,
+      },
+    ],
+    true,
+  );
+}
+
+/**
+ * 内建 adapter 注册表（plan §5.3，15 条）。
+ *
+ * key 是 effect-parser 的 ParsedEffect.key（标准化英文 key）：
+ *   physicalDmg / damageMult / damageTaken / hit / dodge / initiative /
+ *   dr / penetration / reflect / lifesteal / shield / dot / hot / critRate / charges
+ *
+ * 值签名为 `(parsed, seed) => CompiledAutomaton | null`：
+ *   - 命中 → 产 adapter automaton
+ *   - 不匹配 → null（调用方产 UnsupportedCapability）
+ */
+export type BuiltinAdapter = (parsed: ParsedEffect, seed: BuiltinSeed) => CompiledAutomaton | null;
+
+export const BUILTIN_ADAPTERS: Record<string, BuiltinAdapter> = {
+  // #1 攻击时 +N 物理伤害（固伤，进管线 Step 6a）
+  physicalDmg: (p, s) =>
+    p.isPercentage
+      ? null
+      : modifierAutomaton(s, p, 'fixedDamage', 'collect_attacker_mods', p.value, 'whole_action'),
+  // #2 伤害 +N%（攻方百分比，进管线 Step 6 乘算）
+  damageMult: (p, s) =>
+    p.isPercentage
+      ? modifierAutomaton(
+          s,
+          p,
+          'damageMult',
+          'collect_attacker_mods',
+          p.value / 100,
+          'whole_action',
+        )
+      : null,
+  // #3 受到伤害 -N%（守方百分比——修 M-6：守方百分比进管线，走 collect_defender_mods + damageTaken）
+  damageTaken: (p, s) =>
+    p.isPercentage
+      ? modifierAutomaton(
+          s,
+          p,
+          'damageTaken',
+          'collect_defender_mods',
+          -p.value / 100,
+          'whole_action',
+        )
+      : null,
+  // #4 命中 +N（检定，进 check.hit）
+  hit: (p, s) => modifierAutomaton(s, p, 'hitBonus', 'check.hit', p.value, 'per_hit'),
+  // #5 闪避 +N（检定，进 check.hit）
+  dodge: (p, s) => modifierAutomaton(s, p, 'dodge', 'check.hit', p.value, 'per_hit'),
+  // #6 先攻 +N（检定，进 initiative.before）
+  initiative: (p, s) =>
+    modifierAutomaton(s, p, 'initiative', 'initiative.before', p.value, 'whole_action'),
+  // #7 DR N%（守方减免，进 collect_defender_mods）
+  dr: (p, s) =>
+    p.isPercentage
+      ? modifierAutomaton(s, p, 'dr', 'collect_defender_mods', p.value / 100, 'whole_action')
+      : null,
+  // #8 穿透 N%（攻方穿透，进 collect_attacker_mods）
+  penetration: (p, s) =>
+    p.isPercentage
+      ? modifierAutomaton(
+          s,
+          p,
+          'penetration',
+          'collect_attacker_mods',
+          p.value / 100,
+          'whole_action',
+        )
+      : null,
+  // #9 反弹 N% 伤害（damage.after → Schedule(DealDamage isReaction)）。amount 用表达式按 preReduction×N 算
+  reflect: (p, s) =>
+    p.isPercentage
+      ? asAutomaton(
+          s,
+          'damage.after',
+          'reflect',
+          'true',
+          [
+            {
+              kind: 'ScheduleIntent',
+              delay: 0,
+              intent: {
+                kind: 'DealDamage',
+                targetId: 'ctx.damage.attackerId',
+                amount: `ctx.damage.preReduction * ${p.value / 100}`,
+                damageType: 'true',
+                isReaction: true,
+                doesNotConsumeSlot: true,
+                rootChainId: 'ctx.damage.rootChainId',
+                depth: 'ctx.depth + 1',
+                hitPolicy: { consumeDice: true, advantage: 'adv' },
+              },
+            },
+          ],
+          true,
+        )
+      : null,
+  // #10 吸血 N%（damage.after → Heal(self, ctx.damage.final * N)）
+  lifesteal: (p, s) =>
+    p.isPercentage
+      ? asAutomaton(
+          s,
+          'damage.after',
+          'lifesteal',
+          'ctx.damage.final > 0',
+          [
+            {
+              kind: 'Heal',
+              targetId: 'ctx.self.id',
+              amount: `ctx.damage.final * ${p.value / 100}`,
+            },
+          ],
+          true,
+        )
+      : null,
+  // #11 护盾 N（turn.open → ApplyStatus('护盾', layers:N)）
+  shield: (p, s) =>
+    !p.isPercentage
+      ? asAutomaton(
+          s,
+          'turn.open',
+          'shield',
+          'true',
+          [
+            {
+              kind: 'ApplyStatus',
+              targetId: s.owner,
+              statusId: '护盾',
+              duration: 1,
+              layers: Math.max(1, Math.floor(p.value)),
+            },
+          ],
+          true,
+        )
+      : null,
+  // #12 每回合扣 N% maxHp，持续 X 回合（round.close → DealDamage + duration 递减）
+  //   key 透传：见 handleDot 特判在 compile.builtinDot
+  dot: (p, s) =>
+    p.isPercentage
+      ? asAutomaton(
+          s,
+          'round.close',
+          'dot',
+          'true',
+          [
+            {
+              kind: 'DealDamage',
+              targetId: s.owner,
+              amount: `ctx.self.maxHp * ${p.value / 100}`,
+              damageType: 'true',
+              doesNotConsumeSlot: true,
+              hitPolicy: { consumeDice: false, advantage: 'none' },
+            },
+          ],
+          true,
+        )
+      : null,
+  // #13 每回合回 N HP（round.open → Heal）
+  hot: (p, s) =>
+    !p.isPercentage
+      ? asAutomaton(
+          s,
+          'round.open',
+          'hot',
+          'true',
+          [{ kind: 'Heal', targetId: s.owner, amount: p.value }],
+          true,
+        )
+      : null,
+  // #14 暴击率 +N%（检定，进 check.hit → critThreshold）
+  critRate: (p, s) =>
+    p.isPercentage
+      ? modifierAutomaton(s, p, 'critThreshold', 'check.hit', p.value / 100, 'per_hit')
+      : null,
+};
+
+/** 全部内建 key（供编译期遍历 & 测试） */
+export const BUILTIN_KEYS: readonly string[] = Object.keys(BUILTIN_ADAPTERS);
+
+/**
+ * 编译一个 ParsedEffect 为编译态 automaton（不含 charges 特判）。
+ * 不匹配任何内建 ⇒ 返回 null（调用方产 UnsupportedCapability）。
+ */
+export function compileParsedEffect(
+  parsed: ParsedEffect,
+  seed: BuiltinSeed,
+): CompiledAutomaton | null {
+  if (parsed.key === 'charges') return null; // charges 由 compile.builtinCharges 特判
+  const adapter = BUILTIN_ADAPTERS[parsed.key];
+  if (!adapter) return null;
+  return adapter(parsed, seed);
+}
+
+/** 导出 DamageType 与 ModifierSlot 类型（供 builtins 测试/外部引用） */
+export type { DamageType, ModifierSlot };

--- a/src/sillytavern/combat-v3/automata/compile.test.ts
+++ b/src/sillytavern/combat-v3/automata/compile.test.ts
@@ -1,0 +1,225 @@
+/**
+ * combat-v3/automata/compile.test.ts — 编译链测试（M3, 验收 A3-3）
+ *
+ * 覆盖（plan §5.8 / 验收 A3-3）：
+ *   - 9 条校验项逐条 1 个反例（不合规 automaton 编译期剔除）
+ *   - errors[] 结构（automatonId / code / message）
+ *   - 合规 automaton 进 index（不进 errors、出现在 automata[]）
+ *   - modifiers[] → collect_*_mods push-handler（A3-4）
+ */
+
+import { describe, it, expect } from 'vitest';
+import { compileEffectProgram } from './compile';
+import type { EffectAutomaton } from '../types';
+
+const base = {
+  owner: '理查德',
+  source: '幽怨之剑',
+  idPrefix: 'item',
+  divinity: 3,
+};
+
+/** 一条合规的 DSL automaton（18 窗口内、合法 trigger、合法 intent 类） */
+const validAutomaton: EffectAutomaton = {
+  id: 'item.幽怨之剑.dsc',
+  name: '幽怨之剑·嗜血',
+  source: '幽怨之剑',
+  owner: '理查德',
+  subscribe: 'damage.after',
+  trigger: 'ctx.damage.final > 0',
+  priority: 0,
+  divinity: 1,
+  intents: [{ kind: 'Heal', targetId: '理查德', amount: 'ctx.damage.final * 0.1' }],
+};
+
+/** 构造一个「故意不合规」的 automaton（subscribe 越界 / trigger 非法等）供编译校验测试 */
+function invalid(patch: {
+  subscribe?: string;
+  trigger?: string;
+  intents?: unknown[];
+  divinity?: number;
+}): EffectAutomaton {
+  return { ...(validAutomaton as object), ...(patch as object) } as unknown as EffectAutomaton;
+}
+
+describe('compile — 合规 automaton 进 index（A3-3 正向）', () => {
+  it('合规 DSL automaton 进入 automata[] 且无 errors', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [validAutomaton],
+    });
+    expect(errors).toHaveLength(0);
+    expect(automata).toHaveLength(1);
+    expect(automata[0].subscribe).toBe('damage.after');
+    expect(automata[0].isAdapter).toBe(false);
+    expect(automata[0].triggerAst.t).toBe('bin');
+  });
+});
+
+describe('compile — 9 条校验逐条反例', () => {
+  it('#1 subscribe 不在 18 窗口 → 剔除 + WINDOW_NOT_FOUND', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [invalid({ subscribe: 'event.evil' })],
+    });
+    expect(automata).toHaveLength(0);
+    expect(errors.map((e) => e.code)).toContain('WINDOW_NOT_FOUND');
+  });
+
+  it('#2 trigger 表达式文法不合规 → 剔除 + TRIGGER_SYNTAX 带列号', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [invalid({ trigger: 'ctx.damage.final === 0' })], // 单等号
+    });
+    expect(automata).toHaveLength(0);
+    const err = errors.find((e) => e.code === 'TRIGGER_SYNTAX');
+    expect(err).toBeTruthy();
+    expect(err!.message).toContain('列');
+  });
+
+  it('#3 intents[].kind 非法 → 剔除 + INTENT_KIND_ILLEGAL', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [invalid({ intents: [{ kind: 'SetStats', targetId: 'x', amount: 1 } as never] })],
+    });
+    expect(automata).toHaveLength(0);
+    expect(errors.map((e) => e.code)).toContain('INTENT_KIND_ILLEGAL');
+  });
+
+  it('#4 OverrideIntent.ruleKey ∈ closed 白名单', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [
+        invalid({
+          intents: [
+            {
+              kind: 'OverrideIntent',
+              ruleKey: 'kaboom.whatever',
+              payload: {},
+              divinity: 5,
+            } as never,
+          ],
+        }),
+      ],
+    });
+    expect(automata).toHaveLength(0);
+    expect(errors.map((e) => e.code)).toContain('RULEKEY_ILLEGAL');
+  });
+
+  it('#5 divinity 超过所有者声明 → 剔除 + DIVINITY_EXCEEDED', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [invalid({ divinity: 8 })], // 所有者 divinity 3
+    });
+    expect(automata).toHaveLength(0);
+    expect(errors.map((e) => e.code)).toContain('DIVINITY_EXCEEDED');
+  });
+
+  it('#7 ctx.* 路径根段不在窗口白名单 → 剔除 + CTX_PATH_ILLEGAL', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [
+        // damage.after 窗口没有 ctx.enemy 根段 → CTX_PATH_ILLEGAL
+        invalid({ trigger: 'ctx.enemy.hp > 0' }),
+      ],
+    });
+    expect(automata).toHaveLength(0);
+    expect(errors.map((e) => e.code)).toContain('CTX_PATH_ILLEGAL');
+  });
+
+  it('#8 五维直改 → 剔除 + FIVE_DIM_STRAIGHT', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [
+        invalid({
+          intents: [
+            {
+              kind: 'AddModifier',
+              slot: 'str',
+              value: 5,
+              scope: 'whole_action',
+              targetId: '理查德',
+              divinity: 0,
+            },
+          ] as never,
+        }),
+      ],
+    });
+    expect(automata).toHaveLength(0);
+    expect(errors.map((e) => e.code)).toContain('FIVE_DIM_STRAIGHT');
+  });
+
+  it('#6 超护栏数值 clamp（warn 不剔除）', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      automata: [
+        invalid({
+          intents: [{ kind: 'Heal', targetId: '理查德', amount: 4_000_000 } as never],
+        }),
+      ],
+    });
+    // clamp 是 warn：不剔除，但 errors 含 WARN_CLAMPED
+    expect(automata).toHaveLength(1);
+    expect(errors.map((e) => e.code)).toContain('WARN_CLAMPED');
+  });
+});
+
+describe('compile — modifiers[] → push-handler（A3-4）', () => {
+  it('固伤 modifier 编译为 collect_attacker_mods + AddModifier(fixedDamage)', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      modifiers: [{ category: '固伤', amount: 50, source: '幽怨之剑' }],
+    });
+    expect(errors).toHaveLength(0);
+    const a = automata.find((x) => x.subscribe === 'collect_attacker_mods');
+    expect(a).toBeTruthy();
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'fixedDamage', value: 50 });
+  });
+
+  it('DR modifier 编译为 collect_defender_mods + AddModifier(dr)', () => {
+    const { automata } = compileEffectProgram({
+      ...base,
+      modifiers: [{ category: '特殊机制', mechanism: 'DR', value: 20, source: '幽怨之剑' }],
+    });
+    const a = automata.find((x) => x.subscribe === 'collect_defender_mods');
+    expect(a).toBeTruthy();
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'dr', value: 0.2 });
+  });
+
+  it('非法 modifier → errors 且不崩', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      modifiers: [{ category: '不存在', amount: 5 }],
+    });
+    expect(automata).toHaveLength(0);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('compile — ParsedEffect → 内建 adapter', () => {
+  it('中文词条「物理伤害: +30」编译为固伤 push-handler', () => {
+    const { automata, errors } = compileEffectProgram({
+      ...base,
+      effects: '物理伤害: +30',
+    });
+    expect(errors).toHaveLength(0);
+    const a = automata.find((x) => x.subscribe === 'collect_attacker_mods');
+    expect(a).toBeTruthy();
+    expect(a!.intents[0]).toMatchObject({ kind: 'AddModifier', slot: 'fixedDamage', value: 30 });
+  });
+});
+
+describe('compile — errors[] 结构', () => {
+  it('自动化剔除时 errors 记录 automatonId + code + message', () => {
+    const { errors } = compileEffectProgram({
+      ...base,
+      automata: [invalid({ subscribe: 'bad.window' })],
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    for (const e of errors) {
+      expect(typeof e.automatonId).toBe('string');
+      expect(typeof e.code).toBe('string');
+      expect(typeof e.message).toBe('string');
+    }
+  });
+});

--- a/src/sillytavern/combat-v3/automata/compile.ts
+++ b/src/sillytavern/combat-v3/automata/compile.ts
@@ -1,0 +1,556 @@
+/**
+ * combat-v3/automata/compile.ts — EffectProgram 编译链 + 编译期校验（M3）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §七 7.4（EffectProgram 编译链 D3）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §5.5（9 条校验）/ §5.6
+ *
+ * `compileEffectProgram(entity)`：把一份效果源（物品/技能/buff 定义）编译为：
+ *   - automata: CompiledAutomaton[]（合格才进；不合规 → **编译期剔除**，运行时不见，A3-3）
+ *   - staticModifiers: StaticModifier[]（纯数值修正，不走窗口，直接并入结算）
+ *   - errors: CompileError[]（每条被剔除 automaton 的错误）
+ *
+ * 三来源（架构 §七 7.4）：
+ *   ① modifiers[]（六大类别）→ 订阅 collect_*_mods、返回 ModifierIntent 的 push-handler automaton（ADR-29）
+ *   ② ParsedEffect（effect-parser 中文词条）→ 经内建映射表编译为可信 TS adapter（builtins.ts）
+ *   ③ AI 产的自由效果（automaton JSON）→ DSL automaton + 编译期校验
+ *
+ * 9 条编译期校验（plan §5.5，逐条对不合规**剔除** + errors.push；#6 #9 clamp/warn 不剔除）：
+ *   1. subscribe ∈ 18 窗口清单
+ *   2. trigger 表达式文法合规（带列号）
+ *   3. intents[].kind ∈ 8 大类
+ *   4. OverrideIntent.ruleKey ∈ closed RuleKey 白名单
+ *   5. divinity ≤ 所有者装备/技能声明的 divinity
+ *   6. 数值范围按品质上限 clamp（warn 不剔除）
+ *   7. ctx.* 路径根段 ∈ WindowCtxMap[subscribe] 的键集
+ *   8. 五维直改检测（五维只能走检定修正）
+ *   9. buff id 带上级前缀（warn + 自动补前缀）
+ *
+ * 铁律（plan §1.3）：本文件零 Math.random / new Function / eval；纯函数 + 不可变。
+ */
+
+import { parseExpression, ExprSyntaxError } from './parser';
+import { windowCtxRoots } from './interpreter';
+import { compileParsedEffect } from './builtins';
+import type {
+  CompiledAutomaton,
+  CompileError,
+  EffectAutomaton,
+  EffectIntent,
+  ExprAst,
+  ModifierSlot,
+  StaticModifier,
+  WindowKey,
+} from '../types';
+import {
+  validateModifier,
+  V3_WINDOW_KEYS,
+  V3_INTENT_KINDS,
+  V3_RULE_KEYS,
+} from '../../combat-item-validator';
+import type { Modifier } from '../../effect-types';
+import { parseEffectDeclaration } from '../../effect-parser';
+import type { ParsedEffect } from '../../types';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 常量
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** 18 个合法窗口（架构 §五 5.1）——委托 combat-item-validator 共享常量 */
+const VALID_WINDOWS: ReadonlySet<string> = V3_WINDOW_KEYS;
+
+/** closed RuleKey 白名单（架构 §八 8.2 / plan §5.5 #4） */
+const VALID_RULE_KEYS: ReadonlySet<string> = V3_RULE_KEYS;
+
+/** 八大类合法 intent kind（架构 §六 6.1 / plan §5.5 #3） */
+const VALID_INTENT_KINDS: ReadonlySet<string> = V3_INTENT_KINDS;
+
+/** 五维英文别名（校验 #8：非检定类不得直接改五维） */
+const FIVE_DIM: ReadonlySet<string> = new Set(['str', 'dex', 'con', 'int', 'spi']);
+
+/** 编译产物 */
+export interface CompiledProgram {
+  automata: readonly CompiledAutomaton[];
+  staticModifiers: readonly StaticModifier[];
+  errors: readonly CompileError[];
+}
+
+/**
+ * 编译一份效果源。
+ *
+ * @param entity 效果源定义（物品/技能）。含可选：
+ *   - modifiers?: Modifier[]（六大类别）
+ *   - effects?: string（effect-parser 中文词条串）
+ *   - automata?: EffectAutomaton[]（AI 产的自由效果 JSON）
+ *   - owner / source / idPrefix / divinity / buffs?
+ * @returns { automata, staticModifiers, errors }
+ */
+export function compileEffectProgram(entity: {
+  owner?: string;
+  source?: string;
+  idPrefix?: string;
+  divinity?: number;
+  modifiers?: readonly unknown[];
+  effects?: string;
+  automata?: readonly EffectAutomaton[];
+  buffs?: readonly unknown[];
+}): CompiledProgram {
+  const owner = entity.owner ?? 'unit';
+  const source = entity.source ?? entity.idPrefix ?? 'item';
+  const seed = {
+    owner,
+    source,
+    idPrefix: entity.idPrefix ?? 'item',
+    divinity: entity.divinity ?? 0,
+  };
+
+  const automata: CompiledAutomaton[] = [];
+  const staticModifiers: StaticModifier[] = [];
+  const errors: CompileError[] = [];
+
+  // ── ① modifiers[] → push-handler automaton（ADR-29） ──
+  for (const rawMod of entity.modifiers ?? []) {
+    const modIssues = validateModifier(rawMod);
+    if (modIssues.length > 0) {
+      errors.push({
+        automatonId: `${source}.modifier`,
+        code: 'WINDOW_NOT_FOUND',
+        message: `modifier 不合规：${modIssues.join('；')}`,
+      });
+      continue;
+    }
+    const mod = rawMod as unknown as Modifier;
+    const compiled = compileModifierPushHandler(mod, seed);
+    if (compiled) automata.push(compiled);
+  }
+
+  // ── ② ParsedEffect（effect-parser 中文词条）→ 内建 adapter ──
+  if (entity.effects) {
+    const parsedList = parseEffectDeclaration(entity.effects);
+    for (const parsed of parsedList) {
+      const builtin = compileParsedEffect(parsed, seed);
+      if (builtin) {
+        automata.push(builtin);
+      } else if (parsed.key !== 'charges') {
+        // 不匹配任何内建 → UnsupportedCapability（架构 §六 6.4）
+        errors.push({
+          automatonId: `${source}.${parsed.key}`,
+          code: 'UNSUPPORTED_CAPABILITY',
+          message: `无法编译内建词条「${parsed.rawKey}」（key=${parsed.key}）`,
+        });
+      }
+    }
+  }
+
+  // ── ③ AI 产的自由效果（automaton JSON）→ 编译期校验 ──
+  for (const a of entity.automata ?? []) {
+    const { automation, mergeErrors } = runDslWithErrors(a, seed);
+    errors.push(...mergeErrors);
+    if (automation) automata.push(automation);
+  }
+
+  return { automata, staticModifiers, errors };
+}
+
+/**
+ * 包装 compileDslAutomaton：把其 messages（剔除错误 + warn）统一合并进外层 errors。
+ */
+function runDslWithErrors(
+  a: EffectAutomaton,
+  seed: { owner: string; source: string; idPrefix: string; divinity: number },
+): { automation: CompiledAutomaton | null; mergeErrors: CompileError[] } {
+  const { automaton, messages } = compileDslAutomaton(a, seed);
+  return { automation: automaton, mergeErrors: messages };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ① modifier → push-handler automaton
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 把一个六大类别 modifier 编译为 push-handler automaton（ADR-29：modifier 非第二套系统）。
+ *
+ * 返回 `collect_attacker_mods` / `collect_defender_mods`（或对应窗口）的 AddModifier automaton，
+ * 或 static validator 判定为纯属性时并入 staticModifiers。
+ */
+function compileModifierPushHandler(
+  mod: Modifier,
+  seed: { owner: string; source: string; idPrefix: string; divinity: number },
+): CompiledAutomaton | null {
+  const { category } = mod;
+  const base: CompiledAutomaton = {
+    id: `${seed.idPrefix}.${seed.source}.${category}`,
+    name: seed.source,
+    source: seed.source,
+    owner: seed.owner,
+    subscribe: 'collect_attacker_mods',
+    priority: 0,
+    divinity: seed.divinity,
+    stableId: `${seed.idPrefix}.${seed.source}.${category}`,
+    triggerAst: { t: 'bool', v: true },
+    intents: [] as EffectIntent[],
+    isAdapter: true,
+  };
+  const div = seed.divinity;
+
+  switch (category) {
+    case '固伤': {
+      const m = mod as Extract<Modifier, { category: '固伤' }>;
+      return {
+        ...base,
+        subscribe: 'collect_attacker_mods',
+        intents: [
+          {
+            kind: 'AddModifier',
+            slot: 'fixedDamage',
+            value: m.amount,
+            scope: 'whole_action',
+            targetId: seed.owner,
+            divinity: div,
+          },
+        ],
+      };
+    }
+    case '百分比': {
+      const m = mod as Extract<Modifier, { category: '百分比' }>;
+      if (m.target === 'damage') {
+        return {
+          ...base,
+          subscribe: 'collect_attacker_mods',
+          intents: [
+            {
+              kind: 'AddModifier',
+              slot: 'damageMult',
+              value: m.coefficient,
+              scope: 'whole_action',
+              targetId: seed.owner,
+              divinity: div,
+            },
+          ],
+        };
+      }
+      // heal/resource 暂不进管线（M3 范围限于伤害侧）
+      return null;
+    }
+    case '资源': {
+      const m = mod as Extract<Modifier, { category: '资源' }>;
+      return {
+        ...base,
+        subscribe: 'round.open',
+        intents: [
+          {
+            kind: m.resource === 'hp' ? 'Heal' : 'SpendResource',
+            targetId: seed.owner,
+            amount: m.amount,
+          } as EffectIntent,
+        ],
+      };
+    }
+    case '检定': {
+      const m = mod as Extract<Modifier, { category: '检定' }>;
+      const slotMap: Record<string, 'hitBonus' | 'dodge' | 'initiative' | 'attribute'> = {
+        命中: 'hitBonus',
+        闪避: 'dodge',
+        先攻: 'initiative',
+        抵抗: 'dodge',
+        属性: 'attribute',
+      };
+      const subscribe: WindowKey =
+        m.checkType === '先攻'
+          ? 'initiative.before'
+          : m.checkType === '命中' || m.checkType === '闪避' || m.checkType === '抵抗'
+            ? 'check.hit'
+            : 'check.hit';
+      return {
+        ...base,
+        subscribe,
+        intents: [
+          {
+            kind: 'AddModifier',
+            slot: slotMap[m.checkType] ?? 'hitBonus',
+            value: m.bonus,
+            scope: 'whole_action',
+            targetId: seed.owner,
+            divinity: div,
+          },
+        ],
+      };
+    }
+    case '附加效果': {
+      const m = mod as Extract<Modifier, { category: '附加效果' }>;
+      // 附加效果 → 每次战斗开始施加 buff（turn.open 挂起），带 sourceKey 前缀（校验 #9）
+      const statusId = m.sourceKey ? `${m.sourceKey}.${m.buffName}` : m.buffName;
+      return {
+        ...base,
+        subscribe: 'turn.open',
+        intents: [
+          {
+            kind: 'ApplyStatus',
+            targetId: seed.owner,
+            statusId,
+            duration: m.duration ?? 1,
+            layers: m.stacks ?? 1,
+          },
+        ],
+      };
+    }
+    case '特殊机制': {
+      const m = mod as Extract<Modifier, { category: '特殊机制' }>;
+      const slotMap: Record<string, ModifierSlot> = {
+        DR: 'dr',
+        穿透: 'penetration',
+        暴击倍率: 'critDmg',
+      };
+      const slot = slotMap[m.mechanism];
+      if (!slot) return null;
+      return {
+        ...base,
+        subscribe: m.mechanism === 'DR' ? 'collect_defender_mods' : 'collect_attacker_mods',
+        intents: [
+          {
+            kind: 'AddModifier',
+            slot,
+            value: m.value / 100,
+            scope: 'whole_action',
+            targetId: seed.owner,
+            divinity: div,
+          },
+        ],
+      };
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ③ DSL automaton 编译期校验（9 条，plan §5.5）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** DSL automaton 编译结果（含累积错误） */
+interface DslResult {
+  automaton: CompiledAutomaton;
+  errors: CompileError[];
+}
+
+/**
+ * 编译并校验一个 AI automaton JSON。
+ * 任一**致命**校验失败 ⇒ 剔除（返回 { automaton: null }），对应 CompileError 在 messages。
+ * warn 级（#6 clamp / #9 前缀）不剔除，automaton 返回 + messages 带 warn。
+ */
+function compileDslAutomaton(
+  a: EffectAutomaton,
+  seed: { owner: string; source: string; idPrefix: string; divinity: number },
+): { automaton: CompiledAutomaton | null; messages: CompileError[] } {
+  const messages: CompileError[] = [];
+  const owner = a.owner ?? seed.owner;
+
+  // 校验 #1：subscribe ∈ 18 窗口
+  if (!VALID_WINDOWS.has(a.subscribe)) {
+    messages.push({
+      automatonId: a.id,
+      code: 'WINDOW_NOT_FOUND',
+      message: `subscribe「${a.subscribe}」不在 18 窗口清单内`,
+    });
+    return { automaton: null, messages };
+  }
+  const subscribe = a.subscribe as WindowKey;
+
+  // 校验 #2：trigger 表达式文法合规（带列号）
+  let triggerAst: ExprAst;
+  try {
+    triggerAst = parseExpression(a.trigger);
+  } catch (e) {
+    const syntax = e as ExprSyntaxError;
+    messages.push({
+      automatonId: a.id,
+      code: 'TRIGGER_SYNTAX',
+      message: `trigger 表达式语法错误：${syntax.message}`,
+    });
+    return { automaton: null, messages };
+  }
+
+  // 校验 #7：ctx.* 路径根段 ∈ WindowCtxMap[subscribe] 的键集
+  const allowedRoots = new Set(windowCtxRoots(subscribe));
+  const ctxRootError = checkCtxRoots(triggerAst, allowedRoots);
+  if (ctxRootError) {
+    messages.push({ automatonId: a.id, code: 'CTX_PATH_ILLEGAL', message: ctxRootError });
+    return { automaton: null, messages };
+  }
+
+  // 校验 #5：divinity ≤ 所有者声明
+  if (a.divinity > seed.divinity) {
+    messages.push({
+      automatonId: a.id,
+      code: 'DIVINITY_EXCEEDED',
+      message: `divinity ${a.divinity} 超过所有者「${seed.source}」声明 ${seed.divinity}`,
+    });
+    return { automaton: null, messages };
+  }
+
+  // 校验 #3/#4：intents[].kind ∈ 8 大类 + OverrideIntent.ruleKey ∈ 白名单；#8 五维直改
+  const intents: EffectIntent[] = [];
+  for (const intent of a.intents) {
+    const intentErr = validateIntent(intent, subscribe);
+    if (intentErr) {
+      messages.push({ automatonId: a.id, code: intentErr.code, message: intentErr.message });
+      return { automaton: null, messages };
+    }
+    intents.push(intent);
+  }
+
+  // 校验 #6：数值范围随品质上限 clamp（warn 不剔除）——M3 以 ±10000 为绝对护栏
+  const clamped = clampOutOfRange(intents);
+  if (clamped.warned) {
+    messages.push({
+      automatonId: a.id,
+      code: 'WARN_CLAMPED',
+      message: `intent 数值超护栏已 clamp（未剔除）`,
+    });
+  }
+
+  // 校验 #9：buff id 带上级前缀（这里 DSL automaton 的 intent 不直接带 buff id，
+  //            但注入的 ApplyStatus statusId 若裸名则自动补 owner 前缀，warn 不剔除）
+  const prefixed = prefixStatusIds(clamped.intents, owner);
+  if (prefixed.prefixed) {
+    messages.push({
+      automatonId: a.id,
+      code: 'WARN_PREFIXED',
+      message: `ApplyStatus 裸 id 已自动补 owner 前缀（未剔除）`,
+    });
+  }
+
+  const automaton: CompiledAutomaton = {
+    id: a.id,
+    name: a.name,
+    source: a.source ?? seed.source,
+    owner,
+    subscribe,
+    priority: a.priority ?? 0,
+    divinity: a.divinity,
+    stableId: a.id,
+    charges: a.charges ? { ...a.charges } : undefined,
+    triggerAst,
+    intents: prefixed.intents,
+    isAdapter: false,
+  };
+  return { automaton, messages };
+}
+
+/** 校验 #9：ApplyStatus 的裸 statusId 自动补 owner 前缀（warn 不剔除） */
+function prefixStatusIds(
+  intents: EffectIntent[],
+  owner: string,
+): { intents: EffectIntent[]; prefixed: boolean } {
+  let prefixed = false;
+  const next = intents.map((i) => {
+    if (i.kind === 'ApplyStatus' && !i.statusId.includes('.')) {
+      prefixed = true;
+      return { ...i, statusId: `${owner}.${i.statusId}` } as EffectIntent;
+    }
+    if (i.kind === 'ScheduleIntent' && i.intent.kind === 'ApplyStatus') {
+      const inner = i.intent;
+      if (!inner.statusId.includes('.')) {
+        prefixed = true;
+        return {
+          ...i,
+          intent: { ...inner, statusId: `${owner}.${inner.statusId}` },
+        } as EffectIntent;
+      }
+    }
+    return i;
+  });
+  return { intents: next, prefixed };
+}
+
+/**
+ * 深层扫描 AST 收集 `ctx.X` 的根段。
+ */
+function collectCtxRoots(ast: ExprAst, acc: Set<string>): void {
+  switch (ast.t) {
+    case 'path':
+      if (ast.segments.length > 0) acc.add(ast.segments[0]);
+      return;
+    case 'call':
+      ast.args.forEach((x) => collectCtxRoots(x, acc));
+      return;
+    case 'unary':
+      collectCtxRoots(ast.operand, acc);
+      return;
+    case 'bin':
+      collectCtxRoots(ast.l, acc);
+      collectCtxRoots(ast.r, acc);
+      return;
+    default:
+      return;
+  }
+}
+
+/** 校验 #7：AST 内 ctx 根段都在窗口允许集合内 */
+function checkCtxRoots(ast: ExprAst, allowedRoots: ReadonlySet<string>): string | null {
+  const used = new Set<string>();
+  collectCtxRoots(ast, used);
+  for (const root of used) {
+    if (!allowedRoots.has(root)) {
+      return `ctx.${root} 不在窗口 ${allowedRoots.size === 0 ? '（无）' : '[ ' + [...allowedRoots].join(', ') + ' ]'} 白名单内（校验#7）`;
+    }
+  }
+  return null;
+}
+
+/** 单个 intent 校验（#3 #4 #8） */
+function validateIntent(
+  intent: EffectIntent,
+  subscribe: WindowKey,
+): { code: string; message: string } | null {
+  // #3：kind ∈ 8 大类
+  if (!VALID_INTENT_KINDS.has(intent.kind)) {
+    return { code: 'INTENT_KIND_ILLEGAL', message: `intents[].kind「${intent.kind}」不在 8 大类` };
+  }
+
+  // #4：OverrideIntent.ruleKey ∈ closed 白名单
+  if (intent.kind === 'OverrideIntent' && !VALID_RULE_KEYS.has(intent.ruleKey)) {
+    return {
+      code: 'RULEKEY_ILLEGAL',
+      message: `OverrideIntent.ruleKey「${intent.ruleKey}」不在 closed RuleKey 白名单`,
+    };
+  }
+
+  // #8：五维直改检测——ModifierSlot 不含五维（str/dex/con/int/spi），
+  // 若 AI 传出非法 slot（在类型守卫下转成 string 前缀命中）则拒绝。
+  // 五维只能走检定修正（AddModifier.slot='attribute' 是合法检定出口）。
+  if (intent.kind === 'AddModifier') {
+    const slot = String(intent.slot);
+    if (slot === 'str' || slot === 'dex' || slot === 'con' || slot === 'int' || slot === 'spi') {
+      return {
+        code: 'FIVE_DIM_STRAIGHT',
+        message: `五维只能走检定修正，不能直接 AddModifier(slot:'${slot}')`,
+      };
+    }
+  }
+
+  // ScheduleIntent 递归校验其内部 intent
+  if (intent.kind === 'ScheduleIntent') {
+    return validateIntent(intent.intent, subscribe);
+  }
+
+  return null;
+}
+
+/** 校验 #6：数值范围护栏（clamp 到 ±10000，warn 不剔除） */
+function clampOutOfRange(intents: EffectIntent[]): { intents: EffectIntent[]; warned: boolean } {
+  let warned = false;
+  const next = intents.map((i) => {
+    if (i.kind === 'AddModifier' && typeof i.value === 'number' && Math.abs(i.value) > 10000) {
+      warned = true;
+      return { ...i, value: Math.sign(i.value) * 10000 } as EffectIntent;
+    }
+    if (
+      (i.kind === 'DealDamage' || i.kind === 'Heal') &&
+      typeof i.amount === 'number' &&
+      Math.abs(i.amount) > 10000
+    ) {
+      warned = true;
+      return { ...i, amount: Math.sign(i.amount) * 10000 } as EffectIntent;
+    }
+    return i;
+  });
+  return { intents: next, warned };
+}

--- a/src/sillytavern/combat-v3/automata/index-active.test.ts
+++ b/src/sillytavern/combat-v3/automata/index-active.test.ts
@@ -1,0 +1,128 @@
+/**
+ * combat-v3/automata/index-active.test.ts — ActiveEffectIndex 派生/增量测试（M3）
+ *
+ * 覆盖（plan §5.8）：
+ *   - buildIndex 按 window 分组并排序（divinity 高者先 → priority → stable id）
+ *   - updateIndex 增量加 automaton（ApplyStatus 增量加）
+ *   - updateIndex 离场移除（removeIds 跨所有窗口过滤 + byOwner 清理）
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildIndex, updateIndex, compareAutomata } from './index-active';
+import type { CompiledAutomaton } from '../types';
+
+function mkAuto(
+  id: string,
+  subscribe: CompiledAutomaton['subscribe'],
+  partial: Partial<CompiledAutomaton> = {},
+): CompiledAutomaton {
+  return {
+    id,
+    name: id,
+    source: '测试',
+    owner: '理查德',
+    subscribe,
+    priority: 0,
+    divinity: 0,
+    stableId: id,
+    triggerAst: { t: 'bool', v: true },
+    intents: [],
+    isAdapter: true,
+    ...partial,
+  };
+}
+
+describe('buildIndex — 按 window 分组并排序', () => {
+  it('divinity 高者先（求值顺序 divinity → priority → id）', () => {
+    const list = [
+      mkAuto('a', 'damage.after', { divinity: 1, priority: 5 }),
+      mkAuto('b', 'damage.after', { divinity: 5, priority: 1 }),
+      mkAuto('c', 'damage.after', { divinity: 3 }),
+    ];
+    const idx = buildIndex(list);
+    const queue = idx.byWindow['damage.after'];
+    expect(queue.map((x) => x.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('same divinity → priority 升序', () => {
+    const list = [
+      mkAuto('x', 'check.hit', { divinity: 2, priority: 3 }),
+      mkAuto('y', 'check.hit', { divinity: 2, priority: 1 }),
+    ];
+    const idx = buildIndex(list);
+    expect(idx.byWindow['check.hit'].map((x) => x.id)).toEqual(['y', 'x']);
+  });
+
+  it('same divinity & priority → stable id 字典序', () => {
+    const list = [
+      mkAuto('b', 'round.open', { divinity: 0, priority: 0 }),
+      mkAuto('a', 'round.open', { divinity: 0, priority: 0 }),
+    ];
+    const idx = buildIndex(list);
+    expect(idx.byWindow['round.open'].map((x) => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('缺失窗口补空数组', () => {
+    const idx = buildIndex([mkAuto('z', 'check.hit')]);
+    expect(idx.byWindow['damage.preview']).toEqual([]);
+    expect(idx.byWindow['round.open']).toEqual([]);
+  });
+
+  it('byOwner 按持有者分组', () => {
+    const idx = buildIndex([
+      mkAuto('a', 'check.hit', { owner: '理查德' }),
+      mkAuto('b', 'damage.after', { owner: '处刑人' }),
+      mkAuto('c', 'damage.after', { owner: '理查德' }),
+    ]);
+    expect(idx.byOwner['理查德']).toEqual(expect.arrayContaining(['a', 'c']));
+    expect(idx.byOwner['处刑人']).toContain('b');
+  });
+});
+
+describe('updateIndex — 增量加（ApplyStatus 增量加 automaton）', () => {
+  it('add 追加并排序', () => {
+    const idx = buildIndex([mkAuto('a', 'damage.after', { divinity: 1 })]);
+    const next = updateIndex(idx, {
+      add: [mkAuto('new', 'damage.after', { divinity: 5 })],
+    });
+    const queue = next.byWindow['damage.after'];
+    expect(queue.map((x) => x.id)).toEqual(['new', 'a']); // divinity 高者先
+  });
+
+  it('不可变：入参原索引不被修改', () => {
+    const idx = buildIndex([]);
+    const before = idx.byWindow['damage.after'];
+    updateIndex(idx, { add: [mkAuto('x', 'damage.after')] });
+    expect(idx.byWindow['damage.after']).toEqual(before);
+  });
+});
+
+describe('updateIndex — 离场移除', () => {
+  it('removeIds 跨所有窗口过滤 + byOwner 清理', () => {
+    const idx = buildIndex([
+      mkAuto('keep', 'damage.after'),
+      mkAuto('gone', 'damage.after'),
+      mkAuto('gone2', 'check.hit'),
+    ]);
+    const next = updateIndex(idx, { removeIds: ['gone'] });
+    expect(next.byWindow['damage.after'].map((x) => x.id)).toEqual(['keep']);
+    expect(next.byWindow['check.hit'].map((x) => x.id)).toEqual(['gone2']);
+    // byOwner 清理
+    for (const ids of Object.values(next.byOwner)) {
+      expect(ids).not.toContain('gone');
+    }
+  });
+
+  it('空 delta 返回原对象', () => {
+    const idx = buildIndex([]);
+    expect(updateIndex(idx, {})).toBe(idx);
+  });
+});
+
+describe('compareAutomata — 排序比较器', () => {
+  it('优先级：divinity > priority > id', () => {
+    const a = { id: 'a', divinity: 1, priority: 0, stableId: 'a' } as CompiledAutomaton;
+    const b = { id: 'b', divinity: 2, priority: 0, stableId: 'b' } as CompiledAutomaton;
+    expect(compareAutomata(a, b)).toBeGreaterThan(0); // b divinity 更高 → a 排在 b 后
+  });
+});

--- a/src/sillytavern/combat-v3/automata/index-active.ts
+++ b/src/sillytavern/combat-v3/automata/index-active.ts
@@ -1,0 +1,148 @@
+/**
+ * combat-v3/automata/index-active.ts — ActiveEffectIndex 派生与增量更新（M3）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §七 7.5（ActiveEffectIndex）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §5.8
+ *
+ * ActiveEffectIndex 是战斗内唯一的权威效果索引（架构 §七 7.5）：
+ *   - byWindow：每窗口**已按求值顺序**（window → divinity → priority → stableId）排序的 automaton 队列
+ *   - byOwner：每持有者 → automaton id 列表（在场过滤 / 离场清理）
+ *
+ * - `buildIndex(units)`：从在场单位（装备/技能/已编译 automaton）派生全量索引（openCombat）
+ * - `updateIndex(index, delta)`：增量增删（ApplyStatus / RemoveStatus / Summon / Despawn 后）
+ *
+ * index-active.ts 是**纯函数**：buildIndex/updateIndex 都是不可变返回新对象。
+ * 排序是稳定的（Array.prototype.sort 稳定排序在 ES2019+ 保证），保证 replay 确定性。
+ */
+
+import type { ActiveEffectIndex, CompiledAutomaton, QueuedAutomaton, WindowKey } from '../types';
+
+/** 空索引内的窗口原位（每窗口空数组引用共享，避免重复分配） */
+const EMPTY_BY_WINDOW: Readonly<Record<WindowKey, readonly QueuedAutomaton[]>> = {
+  'round.open': [],
+  'round.close': [],
+  'initiative.before': [],
+  'initiative.after': [],
+  'turn.open': [],
+  'turn.close': [],
+  'action.declared': [],
+  'check.intent': [],
+  'check.hit': [],
+  collect_attacker_mods: [],
+  collect_defender_mods: [],
+  'damage.preview': [],
+  'damage.compute': [],
+  'damage.after': [],
+  'unit.beforeDown': [],
+  'morale.before': [],
+  'morale.after': [],
+  'settlement.before': [],
+};
+
+/**
+ * 求值排序比较器（架构 §五 5.3，固定不可配置）：
+ *   window phase → divinity（高者先）→ declared priority → stable id。
+ *
+ * 末位 stableId 保证同输入同顺序（replay 前提），与 ADR-29 的 (priority, order, 注册序)
+ * 同源——只是把「注册序」换成「stable id」，因为 ActiveEffectIndex 是派生的。
+ */
+export function compareAutomata(a: QueuedAutomaton, b: QueuedAutomaton): number {
+  // 1. divinity 高者先（降序）
+  if (b.divinity !== a.divinity) return b.divinity - a.divinity;
+  // 2. declared priority（升序）
+  if (a.priority !== b.priority) return a.priority - b.priority;
+  // 3. stable id（字典序升序）
+  const sa = a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  if (sa !== 0) return sa;
+  return 0;
+}
+
+/**
+ * 对一组 automaton 做求值排序，返回排序后数组（不修改入参）。
+ */
+function sortAutomata<T extends QueuedAutomaton>(list: readonly T[]): T[] {
+  return [...list].sort(compareAutomata);
+}
+
+/**
+ * 从在场所属 automaton 集合构建全量索引（openCombat / 战斗内装备变更全量重建）。
+ *
+ * @param automata 已编译的在场效果集合（每条的 owner 是持有者 unitId）
+ * @returns ActiveEffectIndex（byWindow 已排序，byOwner 已分组）
+ */
+export function buildIndex(automata: readonly CompiledAutomaton[]): ActiveEffectIndex {
+  const byWindow: Record<string, CompiledAutomaton[]> = {};
+  const byOwner: Record<string, string[]> = {};
+
+  for (const a of automata) {
+    // 按窗口分组
+    const w = (byWindow[a.subscribe] ??= []);
+    w.push(a);
+    // 按持有者分组
+    const o = (byOwner[a.owner] ??= []);
+    o.push(a.id);
+  }
+
+  // 构造完整的 byWindow（缺失窗口补空数组），每窗口排序
+  const sortedByWindow = {} as Record<WindowKey, readonly QueuedAutomaton[]>;
+  for (const key of Object.keys(EMPTY_BY_WINDOW) as WindowKey[]) {
+    const list = byWindow[key] ?? [];
+    sortedByWindow[key] = sortAutomata(list);
+  }
+
+  return { byWindow: sortedByWindow, byOwner };
+}
+
+/**
+ * 增量更新索引（ApplyStatus / RemoveStatus / Summon / Despawn / 战斗内换装后）。
+ *
+ * 纯函数：返回新索引，入参不被修改。增量做「加 automaton」/「减 automaton by id」。
+ */
+export function updateIndex(
+  index: ActiveEffectIndex,
+  delta: {
+    /** 要新增的已编译 automaton（可空） */
+    add?: readonly CompiledAutomaton[];
+    /** 要移除的 automaton id 列表（可空） */
+    removeIds?: readonly string[];
+  },
+): ActiveEffectIndex {
+  const { add = [], removeIds = [] } = delta;
+  if (add.length === 0 && removeIds.length === 0) return index;
+
+  // 先在当前索引上做加的增量（拷贝 per-window 数组）
+  const byWindow = {} as Record<WindowKey, QueuedAutomaton[]>;
+  for (const key of Object.keys(EMPTY_BY_WINDOW) as WindowKey[]) {
+    byWindow[key] = [...(index.byWindow[key] ?? [])];
+  }
+  for (const a of add) {
+    byWindow[a.subscribe] = [...(byWindow[a.subscribe] ?? []), a];
+  }
+
+  // 移除 id（跨所有窗口过滤）
+  const removeSet = new Set(removeIds);
+  if (removeSet.size > 0) {
+    for (const key of Object.keys(byWindow) as WindowKey[]) {
+      if ((byWindow[key] ?? []).some((x) => removeSet.has(x.id))) {
+        byWindow[key] = byWindow[key].filter((x) => !removeSet.has(x.id));
+      }
+    }
+  }
+
+  // 每窗口重排序
+  const sortedByWindow = {} as Record<WindowKey, readonly QueuedAutomaton[]>;
+  for (const key of Object.keys(byWindow) as WindowKey[]) {
+    sortedByWindow[key] = sortAutomata(byWindow[key]);
+  }
+
+  // byOwner 增量
+  const byOwner: Record<string, string[]> = {};
+  for (const [owner, ids] of Object.entries(index.byOwner)) {
+    byOwner[owner] = [...ids.filter((id) => !removeSet.has(id))];
+  }
+  for (const a of add) {
+    (byOwner[a.owner] ??= []).push(a.id);
+  }
+
+  return { byWindow: sortedByWindow, byOwner };
+}

--- a/src/sillytavern/combat-v3/automata/interpreter.test.ts
+++ b/src/sillytavern/combat-v3/automata/interpreter.test.ts
@@ -1,0 +1,152 @@
+/**
+ * combat-v3/automata/interpreter.test.ts — 表达式解释器测试（M3, 验收 A3-2）
+ *
+ * 覆盖（plan §5.8）：
+ *   - 算术 / 比较 / 逻辑 / 一元
+ *   - 除零返回 0（不抛）
+ *   - 内建函数 min / max / floor / ceil / abs / percent / has
+ *   - 未定义 ctx 路径抛 ExprEvalError（automaton 整批 reject 的错误隔离入口）
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseExpression } from './parser';
+import { evaluate, ExprEvalError, windowCtxRoots } from './interpreter';
+import type { WindowCtx, WindowKey } from '../types';
+
+/** 一个 damage.preview 的测试 ctx（PlanCtx 三档伤害 + self/target） */
+const previewCtx: WindowCtx<'damage.preview'> = {
+  self: {
+    id: '理查德',
+    hp: 22069,
+    maxHp: 30079,
+    hpPercent: 22069 / 30079,
+    mp: 52500,
+    sp: 38500,
+    tier: 5,
+    divinity: 5,
+    statuses: [],
+  },
+  target: {
+    id: '处刑人',
+    hp: 2800,
+    maxHp: 2800,
+    hpPercent: 1,
+    mp: 1000,
+    sp: 1200,
+    tier: 4,
+    divinity: 0,
+    statuses: ['昏迷'],
+  },
+  damage: {
+    attackerId: '理查德',
+    targetId: '处刑人',
+    preReduction: 2400,
+    postStep6: 1200,
+    final: 487,
+    type: '物理',
+    rating: '有效',
+  },
+  round: { index: 1, phase: 'SlotConsume' },
+  charges: { remaining: 3 },
+};
+
+function run(src: string, ctx: WindowKeyWide = previewCtx): number | string | boolean {
+  return evaluate(parseExpression(src) as never, ctx as never);
+}
+
+// 宽化 ctx 类型供测试直接传对象
+type WindowKeyWide = WindowCtx<WindowKey>;
+
+describe('interpreter — 算术', () => {
+  it('四则运算', () => {
+    expect(run('1 + 2 * 3')).toBe(7);
+    expect(run('(1 + 2) * 3')).toBe(9);
+    expect(run('100 / 4')).toBe(25);
+    expect(run('10 - 3 - 2')).toBe(5);
+  });
+  it('除零返回 0（不抛）', () => {
+    expect(run('ctx.damage.final / 0')).toBe(0);
+  });
+  it('一元负号', () => {
+    expect(run('-5 + 10')).toBe(5);
+    expect(run('-ctx.damage.final')).toBe(-487);
+  });
+});
+
+describe('interpreter — 比较', () => {
+  it('数值比较', () => {
+    expect(run('ctx.damage.final > 400')).toBe(true);
+    expect(run('ctx.damage.final < 400')).toBe(false);
+    expect(run('ctx.damage.final >= 487')).toBe(true);
+    expect(run('ctx.damage.final <= 486')).toBe(false);
+  });
+  it('相等 / 不等', () => {
+    expect(run("ctx.damage.type == '物理'")).toBe(true);
+    expect(run("ctx.damage.type != '物理'")).toBe(false);
+    expect(run('ctx.self.divinity == 5')).toBe(true);
+  });
+});
+
+describe('interpreter — 逻辑与 一元 !', () => {
+  it('and / or / not', () => {
+    expect(run('ctx.self.hp > 10000 && ctx.target.hp < 3000')).toBe(true);
+    expect(run('ctx.self.hp < 10000 || ctx.target.hp < 3000')).toBe(true);
+    expect(run('!(ctx.self.hp > 10000)')).toBe(false);
+  });
+  it('短路不触发未定义路径', () => {
+    // ctx.self.hp > 0 为真 → || 短路，右侧 ctx.nonexist 不求值（不抛）
+    expect(run('ctx.self.hp > 0 || ctx.nonexist.x > 1')).toBe(true);
+  });
+});
+
+describe('interpreter — 内建函数', () => {
+  it('min / max', () => {
+    expect(run('min(3, 1, 2)')).toBe(1);
+    expect(run('max(3, 1, 2)')).toBe(3);
+  });
+  it('floor / ceil / abs', () => {
+    expect(run('floor(3.7)')).toBe(3);
+    expect(run('ceil(3.1)')).toBe(4);
+    expect(run('abs(-9)')).toBe(9);
+  });
+  it('percent(a, b) = a*b/100', () => {
+    expect(run('percent(30, 100)')).toBe(30);
+    expect(run('percent(ctx.damage.preReduction, 50)')).toBe(1200);
+  });
+  it('has(list, x)', () => {
+    expect(run("has(ctx.target.statuses, '昏迷')")).toBe(true);
+    expect(run("has(ctx.target.statuses, '灼烧')")).toBe(false);
+  });
+  it('ctx 路径运算', () => {
+    expect(run('ctx.damage.preReduction * 0.3')).toBeCloseTo(720);
+  });
+});
+
+describe('interpreter — 未定义 ctx 路径', () => {
+  it('抛 ExprEvalError 带路径', () => {
+    expect(() => run('ctx.self.nonexistent > 1')).toThrowError(ExprEvalError);
+    try {
+      run('ctx.foo.bar == 1');
+      expect.unreachable('应抛 ExprEvalError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ExprEvalError);
+      const err = e as ExprEvalError;
+      expect(err.message).toContain('foo');
+    }
+  });
+  it('type 可用性错误（如对 string 求值算术）也抛', () => {
+    // ctx.round.phase 是字符串，做 < 不抛（toNumber 强制），但访问其子字段会抛
+    expect(() => run('ctx.round.phase.length > 2')).toThrowError(ExprEvalError);
+  });
+});
+
+describe('interpreter — window 根段白名单', () => {
+  it('windowCtxRoots 暴露每窗口可访问根段', () => {
+    expect(windowCtxRoots('damage.preview')).toEqual(
+      expect.arrayContaining(['self', 'target', 'damage', 'round', 'charges']),
+    );
+    expect(windowCtxRoots('collect_attacker_mods')).toEqual(
+      expect.arrayContaining(['self', 'target']),
+    );
+  });
+});

--- a/src/sillytavern/combat-v3/automata/interpreter.ts
+++ b/src/sillytavern/combat-v3/automata/interpreter.ts
@@ -1,0 +1,319 @@
+/**
+ * combat-v3/automata/interpreter.ts — 表达式 AST 解释器（零 eval，M3）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §七 7.3（表达式微文法）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §5.2（解释器）
+ *
+ * `evaluate(ast, ctx)` 在 immutable snapshot 之上解释执行，返回 number | string | boolean。
+ *   - **零 `new Function` / `eval`**（铁律 2 / 验收 A3-2）——纯递归求值
+ *   - 除法零除返回 0（不抛）
+ *   - `ctx.*` path 走类型化白名单（window 分型）；未定义路径 ⇒ 抛 `ExprEvalError`，
+ *     该 automaton **整批 reject**（错误隔离，架构 §五 5.4）
+ *   - 比较/算术/逻辑/内建函数（min/max/floor/ceil/abs/percent/has）
+ *
+ * 无副作用；`evaluate` 是纯函数（不持有状态，不读外部变量）。
+ */
+
+import type { ExprAst, ExprValue, WindowCtx, WindowKey } from '../types';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 错误类型
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 表达式求值错误——`ctx.*` 路径未定义（未在 window 白名单内）或类型不可算。
+ * 抛给 evaluateWindow，该 automaton 整批 intent 作废 + 产 EffectRejected（EVAL_ERROR）。
+ */
+export class ExprEvalError extends Error {
+  /** 出错路径（如 'self.hp'） */
+  readonly path: string;
+
+  constructor(path: string, detail: string) {
+    super(`ExprEvalError: 路径「${path}」求值失败（${detail}）`);
+    this.name = 'ExprEvalError';
+    this.path = path;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 内部类型（window ctx 求值面）
+// ──────────────────────────────────────────────────────────────────────────────
+
+// 递归解析出 window ctx 的某个根段（self / target / damage / round / depth / charges）
+type CtxRoot =
+  | { type: 'self'; v: unknown }
+  | { type: 'target'; v: unknown }
+  | { type: 'damage'; v: unknown }
+  | { type: 'round'; v: unknown }
+  | { type: 'depth' }
+  | { type: 'charges'; v: unknown };
+
+// 每窗口暴露的根段白名单（用于编译校验 #7 与运行时检查）
+const WINDOW_ROOTS: Readonly<Record<WindowKey, readonly string[]>> = {
+  'round.open': ['self', 'round', 'charges'],
+  'round.close': ['self', 'round', 'charges'],
+  'initiative.before': ['self', 'round', 'charges'],
+  'initiative.after': ['self', 'round', 'charges'],
+  'turn.open': ['self', 'round', 'charges'],
+  'turn.close': ['self', 'round', 'charges'],
+  'action.declared': ['self', 'round', 'charges'],
+  'check.intent': ['self', 'target', 'round', 'charges'],
+  'check.hit': ['self', 'target', 'round', 'charges'],
+  collect_attacker_mods: ['self', 'target', 'round', 'charges'],
+  collect_defender_mods: ['self', 'target', 'round', 'charges'],
+  'damage.preview': ['self', 'target', 'damage', 'round', 'charges'],
+  'damage.compute': ['self', 'target', 'damage', 'round', 'charges'],
+  'damage.after': ['self', 'target', 'damage', 'round', 'depth', 'charges'],
+  'unit.beforeDown': ['self', 'target', 'damage', 'round', 'charges'],
+  'morale.before': ['self', 'round', 'charges'],
+  'morale.after': ['self', 'round', 'charges'],
+  'settlement.before': ['self', 'round', 'charges'],
+};
+
+/**
+ * 查询指定窗口可访问的 ctx 根段（含内部缓存）。纯查询，无副作用。
+ * 供 windows.ts / compile.ts 校验 `ctx.*` 路径根段 ∈ WindowCtxMap[subscribe] 键集。
+ */
+export function windowCtxRoots(key: WindowKey): readonly string[] {
+  return WINDOW_ROOTS[key];
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// path → ExprValue 解析（类型化白名单）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 从 window ctx 递归取路径值。
+ *
+ * @throws ExprEvalError 路径未定义 / 根段不在窗口白名单 —— automaton 整批 reject
+ */
+function resolvePath<K extends WindowKey>(
+  ctx: WindowCtx<K>,
+  segments: readonly string[],
+): ExprValue {
+  if (segments.length === 0) {
+    throw new ExprEvalError('<empty>', '空路径');
+  }
+  const root = segments[0];
+  // 根段必须是已知 ctx 根（self/target/damage/round/depth/charges）。
+  // 每窗口还可访问的根段集由 caller（windows.ts）传 window 分型的 ctx 决定，
+  // 编译期校验 #7 已按 WindowCtxMap[subscribe] 键集兜底；这里只做运行时存在性检查。
+  if (!KNOWN_CCTX_ROOTS.has(root)) {
+    throw new ExprEvalError(segments.join('.'), `未知 ctx 根段「${root}」`);
+  }
+
+  let cur: unknown;
+  switch (root) {
+    case 'self':
+      cur = (ctx as { self?: unknown }).self;
+      break;
+    case 'target':
+      cur = (ctx as { target?: unknown }).target;
+      break;
+    case 'damage':
+      cur = (ctx as { damage?: unknown }).damage;
+      break;
+    case 'round':
+      cur = (ctx as { round?: unknown }).round;
+      break;
+    case 'depth':
+      cur = (ctx as { depth?: unknown }).depth;
+      break;
+    case 'charges':
+      cur = (ctx as { charges?: unknown }).charges;
+      break;
+    default:
+      throw new ExprEvalError(segments.join('.'), `未知根段「${root}」`);
+  }
+
+  for (let i = 1; i < segments.length; i++) {
+    const seg = segments[i];
+    if (cur === undefined || cur === null || typeof cur !== 'object') {
+      throw new ExprEvalError(segments.join('.'), `「${segments.slice(0, i).join('.')}」非对象`);
+    }
+    const obj = cur as Record<string, unknown>;
+    if (!Object.prototype.hasOwnProperty.call(obj, seg)) {
+      throw new ExprEvalError(segments.join('.'), `「${seg}」字段未定义`);
+    }
+    cur = obj[seg];
+  }
+  return cur as ExprValue;
+}
+
+/** 已知 ctx 根段集合（interpreter 运行时存在性检查用） */
+const KNOWN_CCTX_ROOTS: ReadonlySet<string> = new Set([
+  'self',
+  'target',
+  'damage',
+  'round',
+  'depth',
+  'charges',
+]);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 值工具
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** 把任意值强制为数字（供算术用；null→0，bool→1/0） */
+function toNumber(v: ExprValue): number {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'boolean') return v ? 1 : 0;
+  if (v === null) return 0;
+  const n = Number(v);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+/** 比较两值（宽松相等语义：数字/字符串/布尔） */
+function looseEqual(a: ExprValue, b: ExprValue): boolean {
+  if (Array.isArray(a) || Array.isArray(b)) return false;
+  if ((a === null && b === null) || (typeof a === 'boolean' && typeof b === 'boolean')) {
+    return a === b;
+  }
+  if (typeof a === 'number' && typeof b === 'number') return a === b;
+  if (typeof a === 'string' && typeof b === 'string') return a === b;
+  // 跨类型：尝试数值比较（如 ctx.damage.final == 97）
+
+  const an = typeof a === 'string' || typeof a === 'boolean' || a === null ? toNumber(a) : NaN;
+  const bn = typeof b === 'string' || typeof b === 'boolean' || b === null ? toNumber(b) : NaN;
+  if (!Number.isNaN(an) && !Number.isNaN(bn)) return an === bn;
+  return false;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 内建函数（架构 §七 7.3 表）
+// ──────────────────────────────────────────────────────────────────────────────
+
+function builtinFn(fn: string, args: readonly ExprValue[]): ExprValue {
+  const nums = args.map(toNumber);
+  switch (fn) {
+    case 'min':
+      return nums.length === 0 ? 0 : Math.min(...nums);
+    case 'max':
+      return nums.length === 0 ? 0 : Math.max(...nums);
+    case 'floor':
+      return Math.floor(nums[0] ?? 0);
+    case 'ceil':
+      return Math.ceil(nums[0] ?? 0);
+    case 'abs':
+      return Math.abs(nums[0] ?? 0);
+    case 'percent': {
+      // percent(a, b) = a * b / 100
+      const a = nums[0] ?? 0;
+      const b = nums[1] ?? 0;
+      return (a * b) / 100;
+    }
+    case 'has': {
+      const list = args[0];
+      if (Array.isArray(list)) {
+        return list.some((x) => String(x) === String(args[1]));
+      }
+      return args[1] === undefined ? false : String(list ?? '').includes(String(args[1]));
+    }
+    default:
+      throw new ExprEvalError(fn, `未知内建函数「${fn}」`);
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 主求值
+// ──────────────────────────────────────────────────────────────────────────────
+
+function evalNode(ast: ExprAst, ctx: WindowKeyWide): ExprValue {
+  switch (ast.t) {
+    case 'num':
+      return ast.v;
+    case 'str':
+      return ast.v;
+    case 'bool':
+      return ast.v;
+    case 'null':
+      return null;
+    case 'path':
+      return resolvePath(ctx, ast.segments);
+    case 'call': {
+      const args = ast.args.map((a) => evalNode(a, ctx));
+      return builtinFn(ast.fn, args);
+    }
+    case 'unary': {
+      const v = evalNode(ast.operand, ctx);
+      if (ast.op === '!') return !truthy(v);
+      return -toNumber(v);
+    }
+    case 'bin': {
+      return evalBin(ast, ctx);
+    }
+  }
+}
+
+type WindowKeyWide = WindowCtx<WindowKey>;
+
+function evalBin(ast: Extract<ExprAst, { t: 'bin' }>, ctx: WindowKeyWide): ExprValue {
+  const { op, l, r } = ast;
+  // 短路
+  if (op === '&&') {
+    const lv = evalNode(l, ctx);
+    return truthy(lv) && truthy(evalNode(r, ctx));
+  }
+  if (op === '||') {
+    const lv = evalNode(l, ctx);
+    return truthy(lv) || truthy(evalNode(r, ctx));
+  }
+
+  const lv = evalNode(l, ctx);
+  const rv = evalNode(r, ctx);
+
+  switch (op) {
+    case '==':
+      return looseEqual(lv, rv);
+    case '!=':
+      return !looseEqual(lv, rv);
+    case '<':
+      return toNumber(lv) < toNumber(rv);
+    case '<=':
+      return toNumber(lv) <= toNumber(rv);
+    case '>':
+      return toNumber(lv) > toNumber(rv);
+    case '>=':
+      return toNumber(lv) >= toNumber(rv);
+    case '+':
+      return toNumber(lv) + toNumber(rv);
+    case '-':
+      return toNumber(lv) - toNumber(rv);
+    case '*':
+      return toNumber(lv) * toNumber(rv);
+    case '/': {
+      const denom = toNumber(rv);
+      // 除法零除返回 0（不抛，架构 §七 7.3）
+      if (denom === 0) return 0;
+      return toNumber(lv) / denom;
+    }
+  }
+}
+
+/** 逻辑真值判定（数字 0/false → 假；非 0 / 非空 → 真） */
+function truthy(v: ExprValue): boolean {
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'number') return v !== 0;
+  if (v === null) return false;
+  if (typeof v === 'string') return v.length > 0;
+  if (Array.isArray(v)) return v.length > 0;
+  return true;
+}
+
+/**
+ * 解释执行表达式 AST。
+ *
+ * @param ast parser 产出的 AST
+ * @param ctx 窗口分型的上下文（WindowCtxMap[window]）
+ * @returns number | string | boolean
+ * @throws ExprEvalError 路径未定义或类型不可算（该 automaton 整批 reject）
+ */
+export function evaluate<K extends WindowKey>(
+  ast: ExprAst,
+  ctx: WindowCtx<K>,
+): number | string | boolean {
+  const v = evalNode(ast, ctx as WindowKeyWide);
+  // 归一：null → 0（表达式约定返回值是 number | string | boolean）
+  if (v === null) return 0;
+  return v as number | string | boolean;
+}

--- a/src/sillytavern/combat-v3/automata/parser.test.ts
+++ b/src/sillytavern/combat-v3/automata/parser.test.ts
@@ -1,0 +1,222 @@
+/**
+ * combat-v3/automata/parser.test.ts — 表达式 parser 测试（M3, 验收 A3-1）
+ *
+ * 覆盖（plan §5.8 / 验收 A3-1）：
+ *   - 每个优先级层级各 1 例（mul / add / cmp / and / or / unary / paren）
+ *   - `a < b < c` 非结合报错（带列号）
+ *   - 词法期拒绝：`=`、`[`、`eval(`、`new`、`function`、`this`、未知标识符，全部带列号
+ *   - `ctx.` 路径解析为 path 节点
+ *   - 白名单函数调用
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseExpression, ExprSyntaxError } from './parser';
+import type { ExprAst } from '../types';
+
+/** 断言抛 ExprSyntaxError 且列号正确 */
+function expectErrAt(src: string, col: number, fragment?: string) {
+  try {
+    parseExpression(src);
+    expect.unreachable(`应抛 ExprSyntaxError：${src}`);
+  } catch (e) {
+    expect(e).toBeInstanceOf(ExprSyntaxError);
+    const err = e as ExprSyntaxError;
+    expect(err.column).toBe(col);
+    expect(err.message).toContain(`第 ${col} 列`);
+    if (fragment) expect(err.message).toContain(fragment);
+  }
+}
+
+describe('parser — 字面量', () => {
+  it('数字', () => {
+    expect(parseExpression('42')).toEqual({ t: 'num', v: 42 });
+    expect(parseExpression('3.14')).toEqual({ t: 'num', v: 3.14 });
+  });
+  it('字符串（单引号，支持转义）', () => {
+    expect(parseExpression("'hello'")).toEqual({ t: 'str', v: 'hello' });
+    expect(parseExpression("'it\\'s'")).toEqual({ t: 'str', v: "it's" });
+  });
+  it('布尔 / null', () => {
+    expect(parseExpression('true')).toEqual({ t: 'bool', v: true });
+    expect(parseExpression('false')).toEqual({ t: 'bool', v: false });
+    expect(parseExpression('null')).toEqual({ t: 'null' });
+  });
+});
+
+describe('parser — ctx 路径', () => {
+  it('解析点分路径', () => {
+    expect(parseExpression('ctx.self.hpPercent')).toEqual({
+      t: 'path',
+      segments: ['self', 'hpPercent'],
+    });
+    expect(parseExpression('ctx.damage.preReduction')).toEqual({
+      t: 'path',
+      segments: ['damage', 'preReduction'],
+    });
+  });
+  it('裸 ctx（无路径）报错', () => {
+    expectErrAt('ctx', 1, 'ctx. 点分路径');
+  });
+});
+
+describe('parser — 优先级层级', () => {
+  it('乘除（mul）绑定比加减紧：1 + 2 * 3 => 1 + (2*3)', () => {
+    const ast = parseExpression('1 + 2 * 3');
+    expect(ast.t).toBe('bin');
+    if (ast.t === 'bin') {
+      expect(ast.op).toBe('+');
+      const r = ast.r as ExprAst;
+      expect(r.t).toBe('bin');
+      if (r.t === 'bin') {
+        expect(r.op).toBe('*');
+        expect(r.l).toEqual({ t: 'num', v: 2 });
+        expect(r.r).toEqual({ t: 'num', v: 3 });
+      }
+    }
+  });
+  it('比较（cmp）绑定比加减松：1 + 1 < 3', () => {
+    const ast = parseExpression('1 + 1 < 3');
+    expect(ast.t).toBe('bin');
+    if (ast.t === 'bin') {
+      expect(ast.op).toBe('<');
+      const l = ast.l as ExprAst;
+      expect(l.t).toBe('bin'); // 1+1
+      expect((l as { t: 'bin'; op: string }).op).toBe('+');
+    }
+  });
+  it('逻辑与（and）', () => {
+    const ast = parseExpression('ctx.self.hp < 50 && ctx.self.mp > 10');
+    expect(ast.t).toBe('bin');
+    if (ast.t === 'bin') {
+      expect(ast.op).toBe('&&');
+      const l = ast.l as { t: 'bin'; op: string; l: unknown };
+      expect(l.t).toBe('bin');
+      expect(l.op).toBe('<');
+    }
+  });
+  it('逻辑或（or）比 与 松', () => {
+    const real = parseExpression('ctx.a < 1 || ctx.b > 2 && ctx.c') as {
+      t: string;
+      op: string;
+      r: unknown;
+    };
+    expect(real.t).toBe('bin');
+    expect(real.op).toBe('||');
+    const r = real.r as { t: string; op: string };
+    expect(r.t).toBe('bin');
+    expect(r.op).toBe('&&');
+  });
+  it('一元（unary）', () => {
+    expect(parseExpression('-5')).toEqual({ t: 'unary', op: '-', operand: { t: 'num', v: 5 } });
+    expect(parseExpression('!true')).toEqual({
+      t: 'unary',
+      op: '!',
+      operand: { t: 'bool', v: true },
+    });
+  });
+  it('括号', () => {
+    expect(parseExpression('(1 + 2) * 3')).toEqual({
+      t: 'bin',
+      op: '*',
+      l: { t: 'bin', op: '+', l: { t: 'num', v: 1 }, r: { t: 'num', v: 2 } },
+      r: { t: 'num', v: 3 },
+    });
+  });
+});
+
+describe('parser — 白名单函数', () => {
+  it('无参 / 多参调用', () => {
+    expect(parseExpression('min(1, 2)')).toEqual({
+      t: 'call',
+      fn: 'min',
+      args: [
+        { t: 'num', v: 1 },
+        { t: 'num', v: 2 },
+      ],
+    });
+    expect(parseExpression('percent(ctx.a, ctx.b)')).toEqual({
+      t: 'call',
+      fn: 'percent',
+      args: [
+        { t: 'path', segments: ['a'] },
+        { t: 'path', segments: ['b'] },
+      ],
+    });
+  });
+  it('括号常量绑定：percent((ctx.a+ctx.b), 100)', () => {
+    const ast = parseExpression('has(ctx.list, ctx.x)');
+    expect(ast.t).toBe('call');
+    if (ast.t === 'call') {
+      expect(ast.fn).toBe('has');
+      expect(ast.args.length).toBe(2);
+    }
+  });
+});
+
+describe('parser — 比较非结合', () => {
+  it('a < b < c 报错', () => {
+    // `ctx.a < ctx.b < ctx.c`：第二个 `<` 起于 index14 → col15
+    expectErrAt('ctx.a < ctx.b < ctx.c', 15, '非结合');
+  });
+  it('a <= b == c 报错', () => {
+    expect(() => parseExpression('ctx.self.hp <= ctx.self.maxHp == true')).toThrow(ExprSyntaxError);
+  });
+});
+
+describe('parser — 词法期拒绝（验收 A3-1）', () => {
+  it('= 单等号报错带列号', () => {
+    // `ctx.a = 1`：= 起于 index6 → col7
+    expectErrAt('ctx.a = 1', 7, '=');
+  });
+  it('= 单等号（裸前缀也被拒，报未知标识符）', () => {
+    expect(() => parseExpression('a = 1')).toThrow(ExprSyntaxError);
+  });
+  it('[ 数组报错带列号', () => {
+    // `ctx.a[0]`：[ 起于 index5 → col6
+    expectErrAt('ctx.a[0]', 6, '[');
+  });
+  it('eval( 报错带列号', () => {
+    expectErrAt('eval(x)', 1, 'eval');
+  });
+  it('new 关键字报错带列号', () => {
+    expectErrAt('new Promise', 1, 'new');
+  });
+  it('function 关键字报错', () => {
+    expectErrAt('function f(){}', 1, 'function');
+  });
+  it('this 关键字报错', () => {
+    // `ctx.damage > this`：this 起于 index13 → col14
+    expectErrAt('ctx.damage > this', 14, 'this');
+  });
+  it('函数外地未知标识符报错', () => {
+    expect(() => parseExpression('Math.random()')).toThrow(ExprSyntaxError);
+  });
+  it('{} 对象字面量报错', () => {
+    // `ctx.a == {}`：{ 起于 index9 → col10 （先吃 ==，再遇 {）
+    expectErrAt('ctx.a == {}', 10, '{');
+  });
+  it('模板串报错', () => {
+    // `ctx.a > `` ：反引号起于 index7 → col9
+    expectErrAt('ctx.a > `tpl`', 9, '`');
+  });
+  it('分号报错', () => {
+    // `ctx.a; b`：; 起于 index5 → col6
+    expectErrAt('ctx.a; b', 6, ';');
+  });
+});
+
+describe('parser — 不匹配符字报错信息格式', () => {
+  it('错误消息含「第 N 列」', () => {
+    const err = (() => {
+      try {
+        parseExpression('1 + ');
+        expect.unreachable();
+      } catch (e) {
+        return e as ExprSyntaxError;
+      }
+    })();
+    expect(err.column).toBe(5); // 末尾缺右操作数
+    expect(err.message).toMatch(/第 5 列/);
+    expect(err.message).toContain('期望');
+  });
+});

--- a/src/sillytavern/combat-v3/automata/parser.ts
+++ b/src/sillytavern/combat-v3/automata/parser.ts
@@ -1,0 +1,594 @@
+/**
+ * combat-v3/automata/parser.ts — 表达式微文法递归下降 parser（M3）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §七 7.3（表达式微文法）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §5.2（token/AST/递归下降）
+ *
+ * 用途：把 automaton 的 `trigger` 与 IntentTemplate 中的表达式**字符串**编译成 AST
+ * （ExprAst），再由 interpreter 零 eval 解释执行于 immutable snapshot 之上。
+ *
+ * 安全边界（架构 §七 7.3，铁律 2——全链路零 `new Function` / `eval`）：
+ *   - token 集**封闭**：数字/字符串/布尔/null/`ctx.` 点分路径/白名单函数/比较/逻辑/算术/括号
+ *   - **词法期拒绝**：`=`（单等号）、`[` `]`、`{` `}`、反引号、`;`、`=>`、`new`、
+ *     `function`、`this`、以及任何不以 `ctx.` 开头且不在函数白名单内的标识符
+ *   - `parseCmp` **非结合**：`a < b < c` 报错（编译期抓，防误判）
+ *   - 语法错误带**列号**（1-based）——验收 A3-1 / 风险 R5
+ *
+ * 无副作用、无全局状态；纯函数 `parseExpression(src)`。失败抛 `ExprSyntaxError`。
+ */
+
+import type { BinOp, BuiltinFn, ExprAst } from '../types';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 错误类型
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 表达式语法错误——**带源字符串的 1-based 列号**（plan §5.2 / 验收 A3-1）。
+ *
+ * 消息格式（plan §5.2）：`ExprSyntaxError: 第 N 列: 意外的 token「xxx」，期望 <期望集>`。
+ * 解析在编译期抛（R5），automaton 直接不进 ActiveEffectIndex。
+ */
+export class ExprSyntaxError extends Error {
+  /** 源字符串的 1-based 列号（出错位置） */
+  readonly column: number;
+  /** 出错位置的字面 token（格式化时用） */
+  readonly offending: string;
+
+  constructor(column: number, offending: string, expected: readonly string[]) {
+    super(
+      `ExprSyntaxError: 第 ${column} 列: 意外的 token「${offending}」，期望 <${expected.join(
+        '/',
+      )}>`,
+    );
+    this.name = 'ExprSyntaxError';
+    this.column = column;
+    this.offending = offending;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Token 类型
+// ──────────────────────────────────────────────────────────────────────────────
+
+type TokenType =
+  | 'NUMBER'
+  | 'STRING'
+  | 'TRUE'
+  | 'FALSE'
+  | 'NULL'
+  | 'IDENT'
+  | 'PATH'
+  | 'DOT'
+  | 'LPAREN'
+  | 'RPAREN'
+  | 'COMMA'
+  | 'PLUS'
+  | 'MINUS'
+  | 'STAR'
+  | 'SLASH'
+  | 'EQ'
+  | 'NEQ'
+  | 'LT'
+  | 'LTE'
+  | 'GT'
+  | 'GTE'
+  | 'AND'
+  | 'OR'
+  | 'NOT'
+  | 'EOF';
+
+interface Token {
+  type: TokenType;
+  /** 1-based 起始列 */
+  col: number;
+  /** 字面文本（报错展示用） */
+  text: string;
+  /** NUMBER 时数值；STRING 时解码后的字符串 */
+  value?: number | string;
+}
+
+/** 白名单函数名（架构 §七 7.3 表） */
+const BUILTIN_FNS: ReadonlySet<string> = new Set<BuiltinFn>([
+  'min',
+  'max',
+  'floor',
+  'ceil',
+  'abs',
+  'percent',
+  'has',
+]);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 词法器
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** 词法期错误（无列号的纯拒绝类，直接映射为 ExprSyntaxError） */
+function lexError(col: number, offending: string, ctx?: string): never {
+  throw new ExprSyntaxError(col, offending, ctx ? [`非法字符（${ctx}）`] : ['数字/标识符/运算符']);
+}
+
+/**
+ * 词法分析：把源拆成 token 流。
+ *
+ * 遇到**白名单外 token 一律抛 ExprSyntaxError**（plan §5.2 词法期拒绝）：
+ *   - 单字符 `=`、`[`、`]`、`{`、`}`、`` ` ``、`;`、`=>` 等（它们不产生合法 token）
+ *   - 关键字 `new` / `function` / `this`
+ *   - 仅当标识符 = `ctx`（后跟点分路径）或 ∈ BUILTIN_FNS
+ * 其余未知标识符也是词法期错误（带列号）。
+ */
+function tokenize(src: string): Token[] {
+  const tokens: Token[] = [];
+  const n = src.length;
+  let i = 0;
+
+  while (i < n) {
+    const c = src[i];
+    const col = i + 1; // 1-based 列号
+
+    // 空白跳过
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+      i++;
+      continue;
+    }
+
+    // 数字（整数/小数，可带前导 +/- 由一元处理，这里只收非负字面量）
+    if (c >= '0' && c <= '9') {
+      let j = i;
+      let dotSeen = false;
+      while (j < n && /[0-9.]/.test(src[j])) {
+        if (src[j] === '.') {
+          if (dotSeen) break; // 第二个点 → 停下来，不是数字的一部分
+          dotSeen = true;
+        }
+        j++;
+      }
+      tokens.push({
+        type: 'NUMBER',
+        col,
+        text: src.slice(i, j),
+        value: Number(src.slice(i, j)),
+      });
+      i = j;
+      continue;
+    }
+
+    // 字符串字面量（单引号）
+    if (c === "'") {
+      let j = i + 1;
+      let out = '';
+      while (j < n && src[j] !== "'") {
+        if (src[j] === '\\' && j + 1 < n) {
+          out += src[j + 1];
+          j += 2;
+        } else {
+          out += src[j];
+          j++;
+        }
+      }
+      if (j >= n) throw new ExprSyntaxError(col, '字符串未闭合', ['"']);
+      tokens.push({ type: 'STRING', col, text: src.slice(i, j + 1), value: out });
+      i = j + 1;
+      continue;
+    }
+
+    // 多字符运算符
+    const two = src.slice(i, i + 2);
+    if (two === '==') {
+      tokens.push({ type: 'EQ', col, text: '==' });
+      i += 2;
+      continue;
+    }
+    if (two === '!=') {
+      tokens.push({ type: 'NEQ', col, text: '!=' });
+      i += 2;
+      continue;
+    }
+    if (two === '<=') {
+      tokens.push({ type: 'LTE', col, text: '<=' });
+      i += 2;
+      continue;
+    }
+    if (two === '>=') {
+      tokens.push({ type: 'GTE', col, text: '>=' });
+      i += 2;
+      continue;
+    }
+    if (two === '&&') {
+      tokens.push({ type: 'AND', col, text: '&&' });
+      i += 2;
+      continue;
+    }
+    if (two === '||') {
+      tokens.push({ type: 'OR', col, text: '||' });
+      i += 2;
+      continue;
+    }
+
+    // 单字符运算符
+    switch (c) {
+      case '.':
+        tokens.push({ type: 'DOT', col, text: '.' });
+        i++;
+        continue;
+      case '(':
+        tokens.push({ type: 'LPAREN', col, text: '(' });
+        i++;
+        continue;
+      case ')':
+        tokens.push({ type: 'RPAREN', col, text: ')' });
+        i++;
+        continue;
+      case ',':
+        tokens.push({ type: 'COMMA', col, text: ',' });
+        i++;
+        continue;
+      case '+':
+        tokens.push({ type: 'PLUS', col, text: '+' });
+        i++;
+        continue;
+      case '-':
+        tokens.push({ type: 'MINUS', col, text: '-' });
+        i++;
+        continue;
+      case '*':
+        tokens.push({ type: 'STAR', col, text: '*' });
+        i++;
+        continue;
+      case '/':
+        tokens.push({ type: 'SLASH', col, text: '/' });
+        i++;
+        continue;
+      case '<':
+        tokens.push({ type: 'LT', col, text: '<' });
+        i++;
+        continue;
+      case '>':
+        tokens.push({ type: 'GT', col, text: '>' });
+        i++;
+        continue;
+      case '!':
+        tokens.push({ type: 'NOT', col, text: '!' });
+        i++;
+        continue;
+      case '=':
+        lexError(col, '=', '单等号不允许（用 == 比较）');
+      case '[':
+        lexError(col, '[', '数组下标/字面量不允许');
+      case ']':
+        lexError(col, ']', '数组下标/字面量不允许');
+      case '{':
+        lexError(col, '{', '对象字面量不允许');
+      case '}':
+        lexError(col, '}', '对象字面量不允许');
+      case '`':
+        lexError(col, '`', '模板串不允许');
+      case ';':
+        lexError(col, ';', '分号不允许');
+      default:
+        break;
+    }
+
+    // `=>` 箭头（在 `=` 已经 lexError 的情况下，`>` 会落到默认即 `=>` 也抛，但更早被 `=` 拦）
+    if (c === '=') lexError(col, '=', '单等号不允许');
+
+    // 标识符 / 关键字 / 路径起始
+    if (/[A-Za-z_$]/.test(c)) {
+      let j = i;
+      while (j < n && /[A-Za-z0-9_$]/.test(src[j])) j++;
+      const word = src.slice(i, j);
+      // 关键字拒绝（词法期）
+      if (
+        word === 'new' ||
+        word === 'function' ||
+        word === 'this' ||
+        word === 'class' ||
+        word === 'var' ||
+        word === 'let' ||
+        word === 'const' ||
+        word === 'return' ||
+        word === 'if' ||
+        word === 'else' ||
+        word === 'while' ||
+        word === 'for'
+      ) {
+        throw new ExprSyntaxError(col, word, [
+          '白名单外关键字（new/function/this/var 等 一律拒绝）',
+        ]);
+      }
+      if (word === 'true') {
+        tokens.push({ type: 'TRUE', col, text: word });
+        i = j;
+        continue;
+      }
+      if (word === 'false') {
+        tokens.push({ type: 'FALSE', col, text: word });
+        i = j;
+        continue;
+      }
+      if (word === 'null') {
+        tokens.push({ type: 'NULL', col, text: word });
+        i = j;
+        continue;
+      }
+      if (word === 'ctx') {
+        // `ctx` 后必须是 `.seg[.seg...]`；整段作为一个 PATH token（词法合并，interpreter 拆）
+        if (j < n && src[j] === '.') {
+          let k = j;
+          const segs: string[] = [];
+          while (k < n && src[k] === '.') {
+            k++; // 吃 dot
+            const s = k;
+            while (k < n && /[A-Za-z0-9_$]/.test(src[k])) k++;
+            const seg = src.slice(s, k);
+            if (!seg) throw new ExprSyntaxError(col, 'ctx.', ['ctx 后的路径段标识符']);
+            segs.push(seg);
+          }
+          if (segs.length === 0) throw new ExprSyntaxError(col, 'ctx.', ['dot 后路径段']);
+          tokens.push({ type: 'PATH', col, text: src.slice(i, k), value: segs.join('.') });
+          i = k;
+          continue;
+        }
+        // 裸 ctx（无路径）→ 非法
+        throw new ExprSyntaxError(col, 'ctx', ['ctx. 点分路径（ctx.self.hpPercent）']);
+      }
+      // 白名单函数
+      if (BUILTIN_FNS.has(word as BuiltinFn)) {
+        tokens.push({ type: 'IDENT', col, text: word, value: word });
+        i = j;
+        continue;
+      }
+      // 未知标识符 → 词法期拒绝（带列号，验收 A3-1）
+      throw new ExprSyntaxError(col, word, ['白名单内建函数或 ctx. 路径']);
+    }
+
+    // 其它输入字符（无法归类）
+    lexError(col, c, '无法识别的字符');
+  }
+
+  tokens.push({ type: 'EOF', col: n + 1, text: '<eof>' });
+  return tokens;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 递归下降 parser（优先级：parseExpr → Or → And → Cmp → Add → Mul → Unary → Primary）
+// ──────────────────────────────────────────────────────────────────────────────
+
+class Parser {
+  private tokens: Token[];
+  private pos = 0;
+
+  constructor(src: string) {
+    this.tokens = tokenize(src);
+  }
+
+  /** 当前 token */
+  private peek(): Token {
+    return this.tokens[this.pos];
+  }
+  /** 前进一格并返回旧当前 token */
+  private advance(): Token {
+    return this.tokens[this.pos++];
+  }
+  /** 是否命中指定类型（命中则吃一个） */
+  private eat(type: TokenType): boolean {
+    if (this.peek().type === type) {
+      this.pos++;
+      return true;
+    }
+    return false;
+  }
+
+  /** 主入口 */
+  parse(): ExprAst {
+    const ast = this.parseExpr();
+    if (this.peek().type !== 'EOF') {
+      const t = this.peek();
+      throw new ExprSyntaxError(t.col, t.text, ['表达式结束']);
+    }
+    return ast;
+  }
+
+  // parseExpr → parseOr
+  private parseExpr(): ExprAst {
+    return this.parseOr();
+  }
+
+  // parseOr → parseAnd ('||' parseAnd)*
+  private parseOr(): ExprAst {
+    let l = this.parseAnd();
+    while (this.peek().type === 'OR') {
+      this.advance();
+      const r = this.parseAnd();
+      l = { t: 'bin', op: '||', l, r };
+    }
+    return l;
+  }
+
+  // parseAnd → parseCmp ('&&' parseCmp)*
+  private parseAnd(): ExprAst {
+    let l = this.parseCmp();
+    while (this.peek().type === 'AND') {
+      this.advance();
+      const r = this.parseCmp();
+      l = { t: 'bin', op: '&&', l, r };
+    }
+    return l;
+  }
+
+  // parseCmp → parseAdd (cmpOp parseAdd)?  （非结合，plan §5.2）
+  private parseCmp(): ExprAst {
+    const l = this.parseAdd();
+    const op = this.cmpOp();
+    if (!op) return l;
+    this.advance();
+    const r = this.parseAddNoCmp(); // 右操作数严禁再出现 cmpOperator → 非结合
+    return { t: 'bin', op, l, r };
+  }
+
+  /** 当前是否为比较运算符，是则返回 op 串 */
+  private cmpOp(): BinOp | null {
+    switch (this.peek().type) {
+      case 'EQ':
+        return '==';
+      case 'NEQ':
+        return '!=';
+      case 'LT':
+        return '<';
+      case 'LTE':
+        return '<=';
+      case 'GT':
+        return '>';
+      case 'GTE':
+        return '>=';
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * 解析 parseAdd，但**检查后续不出现比较运算符**（非结合约束）。
+   * `a < b < c`：解析完 `a < b` 后，parseAddNoCmp 看到再一个 `<` → 直接抛错。
+   */
+  private parseAddNoCmp(): ExprAst {
+    const r = this.parseAdd();
+    const op = this.cmpOp();
+    if (op) {
+      const t = this.peek();
+      throw new ExprSyntaxError(t.col, t.text, ['比较运算非结合，不允许 a < b < c']);
+    }
+    return r;
+  }
+
+  // parseAdd → parseMul (('+'|'-') parseMul)*
+  private parseAdd(): ExprAst {
+    let l = this.parseMul();
+    for (;;) {
+      const t = this.peek();
+      if (t.type === 'PLUS') {
+        this.advance();
+        const r = this.parseMul();
+        l = { t: 'bin', op: '+', l, r };
+        continue;
+      }
+      if (t.type === 'MINUS') {
+        this.advance();
+        const r = this.parseMul();
+        l = { t: 'bin', op: '-', l, r };
+        continue;
+      }
+      break;
+    }
+    return l;
+  }
+
+  // parseMul → parseUnary (('*'|'/') parseUnary)*
+  private parseMul(): ExprAst {
+    let l = this.parseUnary();
+    for (;;) {
+      const t = this.peek();
+      if (t.type === 'STAR') {
+        this.advance();
+        const r = this.parseUnary();
+        l = { t: 'bin', op: '*', l, r };
+        continue;
+      }
+      if (t.type === 'SLASH') {
+        this.advance();
+        const r = this.parseUnary();
+        l = { t: 'bin', op: '/', l, r };
+        continue;
+      }
+      break;
+    }
+    return l;
+  }
+
+  // parseUnary → ('-'|'!') parseUnary | parsePrimary
+  private parseUnary(): ExprAst {
+    const t = this.peek();
+    if (t.type === 'MINUS') {
+      this.advance();
+      return { t: 'unary', op: '-', operand: this.parseUnary() };
+    }
+    if (t.type === 'NOT') {
+      this.advance();
+      return { t: 'unary', op: '!', operand: this.parseUnary() };
+    }
+    return this.parsePrimary();
+  }
+
+  // parsePrimary → 字面量 | ctx 路径 | 白名单函数调用 | ( parseExpr )
+  private parsePrimary(): ExprAst {
+    const t = this.peek();
+    switch (t.type) {
+      case 'NUMBER':
+        this.advance();
+        return { t: 'num', v: t.value as number };
+      case 'STRING':
+        this.advance();
+        return { t: 'str', v: t.value as string };
+      case 'TRUE':
+        this.advance();
+        return { t: 'bool', v: true };
+      case 'FALSE':
+        this.advance();
+        return { t: 'bool', v: false };
+      case 'NULL':
+        this.advance();
+        return { t: 'null' };
+      case 'PATH': {
+        this.advance();
+        const segs = (t.value as string).split('.');
+        return { t: 'path', segments: segs };
+      }
+      case 'IDENT': {
+        // 白名单函数调用：IDENT 后必须紧跟 '('
+        this.advance();
+        if (this.peek().type !== 'LPAREN') {
+          throw new ExprSyntaxError(this.peek().col, this.peek().text, ['函数名后必须跟 (']);
+        }
+        this.advance();
+        const args: ExprAst[] = [];
+        if (this.peek().type !== 'RPAREN') {
+          for (;;) {
+            args.push(this.parseExpr());
+            if (this.peek().type === 'COMMA') {
+              this.advance();
+              continue;
+            }
+            break;
+          }
+        }
+        if (!this.eat('RPAREN')) {
+          const nt = this.peek();
+          throw new ExprSyntaxError(nt.col, nt.text, [')']);
+        }
+        return { t: 'call', fn: t.value as BuiltinFn, args };
+      }
+      case 'LPAREN': {
+        this.advance();
+        const inner = this.parseExpr();
+        if (!this.eat('RPAREN')) {
+          const nt = this.peek();
+          throw new ExprSyntaxError(nt.col, nt.text, [')']);
+        }
+        return inner;
+      }
+      case 'EOF':
+        throw new ExprSyntaxError(t.col, '<eof>', ['表达式']);
+      default:
+        throw new ExprSyntaxError(t.col, t.text, ['字面量/路径/函数/括号']);
+    }
+  }
+}
+
+/**
+ * 编译表达式字符串 → AST（纯函数，plan §5.2）。
+ *
+ * @throws ExprSyntaxError 语法错误（带 1-based 列号）
+ */
+export function parseExpression(src: string): ExprAst {
+  const p = new Parser(src);
+  return p.parse();
+}

--- a/src/sillytavern/combat-v3/automata/reflection.test.ts
+++ b/src/sillytavern/combat-v3/automata/reflection.test.ts
@@ -1,0 +1,108 @@
+/**
+ * combat-v3/automata/reflection.test.ts — 反射（反伤）解析测试（M3, 验收 A3-8）
+ *
+ * 第 24 场反伤 fixture 的算法断言（架构 §九，§5.9）：
+ *   - R4/R7：反伤基准取 preReduction（不放大）；depth≥2 也固定 rootChain preReduction
+ *   - R6：depth ≥ MAX(2) 熔断 → mutual_cancel + NarrativeCue('反射湮灭')
+ *   - R1/R3：反伤 DealDamage isReaction doesNotConsumeSlot —— 在 applyIntents 只写 hpChanges，
+ *     天然不消耗攻击槽（不变量①豁免）
+ *   - R8：反伤命中骰走 attackHit 通道（hitPolicy.consumeDice）——由 intent 属性断言
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveReflection, REFLECTION_ANNIHILATION_CUE } from './reflection';
+import { applyIntents } from '../intents';
+import type { EffectIntent, PendingChangeSet } from '../types';
+import { EMPTY_CHANGES } from '../types';
+import { MAX_REFLECTION_DEPTH } from '../types';
+
+const damage = { preReduction: 8535, final: 487 };
+
+const ctx = {
+  state: undefined as never,
+  automatonOwner: '处刑人',
+  present: (id: string) => id === '处刑人' || id === '理查德',
+  resolveNumber: (e: string, f: number) => Number(e) || f,
+  reflectBase: damage, // 第 24 场星屑连袭 preReduction=8535
+  reflectDepth: 0,
+  reflectRatio: 0.3,
+};
+
+describe('反射基准（R4/R7）', () => {
+  it('depth=1 反伤基准取 preReduction（8535 × 30% = 2560）', () => {
+    const res = resolveReflection(0, damage, 0.3);
+    expect(res.kind).toBe('propagate');
+    if (res.kind === 'propagate') {
+      expect(res.baseDamage).toBe(8535); // preReduction，非 final 487
+      expect(res.reflectedAmount).toBe(Math.floor(8535 * 0.3));
+      expect(res.nextDepth).toBe(1);
+    }
+  });
+
+  it('depth=2 不放大（base 仍取 rootChain preReduction）', () => {
+    // depth=1 进 → nextDepth=2；这里测 resolveReflection(1, ...) 仍 base=8535
+    const res = resolveReflection(1, damage, 0.3);
+    if (res.kind === 'propagate') {
+      expect(res.baseDamage).toBe(8535);
+    }
+  });
+});
+
+describe('反射熔断（R6）', () => {
+  it('depth ≥ MAX(2) 熔断 → mutual_cancel + 湮灭', () => {
+    const res = resolveReflection(MAX_REFLECTION_DEPTH, damage, 0.3);
+    expect(res.kind).toBe('mutual_cancel');
+    if (res.kind === 'mutual_cancel') {
+      expect(res.annihilated).toBe(true);
+      // 熔断不产生伤害，只产湮灭叙事
+    }
+    expect(REFLECTION_ANNIHILATION_CUE).toBe('反射湮灭');
+  });
+});
+
+describe('反伤不消耗攻击槽 + 命中骰走 attackHit（R1/R3/R8）', () => {
+  it('ScheduleIntent(DealDamage isReaction) → 只写 hpChanges，不碰槽位', () => {
+    const changes: PendingChangeSet = { ...EMPTY_CHANGES, hpChanges: {}, slotConsumptions: [] };
+    const intent: EffectIntent = {
+      kind: 'ScheduleIntent',
+      delay: 0,
+      intent: {
+        kind: 'DealDamage',
+        targetId: '理查德',
+        amount: '8535 * 0.3',
+        damageType: 'true',
+        isReaction: true,
+        doesNotConsumeSlot: true,
+        hitPolicy: { consumeDice: true, advantage: 'adv' }, // R8 走 attackHit
+      },
+    };
+    const r = applyIntents(ctx, [intent], changes);
+    expect(r.changes.hpChanges['理查德']).toBeLessThan(0);
+    // doesNotConsumeSlot：slotConsumptions 不变（不消耗攻击槽）
+    expect(r.changes.slotConsumptions).toHaveLength(0);
+    // R8 命中骰声明走 attackHit contract
+    if (intent.intent.kind === 'DealDamage') {
+      expect(intent.intent.hitPolicy?.consumeDice).toBe(true);
+    }
+  });
+
+  it('depth=2 熔断时同一 intent 不再产生伤害，产湮灭叙事', () => {
+    const changes: PendingChangeSet = { ...EMPTY_CHANGES, hpChanges: {} };
+    const ctx2 = { ...ctx, reflectDepth: MAX_REFLECTION_DEPTH };
+    const intent: EffectIntent = {
+      kind: 'ScheduleIntent',
+      delay: 0,
+      intent: {
+        kind: 'DealDamage',
+        targetId: '理查德',
+        amount: '8535 * 0.3',
+        damageType: 'true',
+        isReaction: true,
+        doesNotConsumeSlot: true,
+      },
+    };
+    const r = applyIntents(ctx2, [intent], changes);
+    expect(r.changes.hpChanges).toEqual({});
+    expect(r.narrative).toContain('反射湮灭');
+  });
+});

--- a/src/sillytavern/combat-v3/automata/reflection.ts
+++ b/src/sillytavern/combat-v3/automata/reflection.ts
@@ -1,0 +1,78 @@
+/**
+ * combat-v3/automata/reflection.ts — 反射（反伤）解析纯函数（M3, 架构 §九）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §九（反射专项）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §5.9 / 验收 A3-8
+ *
+ * 第 24 场「虚数反弹」反伤的确定性解析（§九 R1-R8）：
+ *   - intent 形态（R1）：DealDamage({ damageType:'true', isReaction:true, doesNotConsumeSlot:true, rootChainId, depth })
+ *   - 基准取值（R4/R7）：depth≥1 反伤基准取 rootChain 的 **preReduction**，不放大
+ *   - 熔断（R6）：depth ≥ MAX_REFLECTION_DEPTH(=2) ⇒ mutual_cancel + NarrativeCue('反射湮灭')
+ *   - 不消耗攻击槽（不变量①豁免）：反伤 doesNotConsumeSlot，不碰攻击者槽位
+ *   - 命中骰（R8）：反伤须走 attackHit 通道（hitPolicy.consumeDice）
+ *
+ * 纯函数：无副作用，确定性可重放（零 Math.random / new Function / eval）。
+ */
+
+import { MAX_REFLECTION_DEPTH, type DamageCtx } from '../types';
+
+/** 反射解析结果：推进一层反伤 or 熔断 */
+export type ReflectionResolution =
+  | {
+      kind: 'propagate';
+      baseDamage: number;
+      reflectRatio: number;
+      reflectedAmount: number;
+      nextDepth: number;
+    }
+  | { kind: 'mutual_cancel'; baseDamage: number; annihilated: true };
+
+/** 反射策略常量（架构 §九 9.1） */
+export interface ReflectionPolicy {
+  MAX_REFLECTION_DEPTH: number;
+  overflowStrategy: 'mutual_cancel';
+  baseRule: 'root_chain';
+}
+
+export const REFLECTION_POLICY: ReflectionPolicy = {
+  MAX_REFLECTION_DEPTH,
+  overflowStrategy: 'mutual_cancel',
+  baseRule: 'root_chain',
+};
+
+/**
+ * 决定一次反伤是否继续推进（§九 R1/R4/R6/R7）。
+ *
+ * @param depth 当前反伤深度（1 = 首次反伤；2 = 反伤对反伤）
+ * @param damage 攻击链的伤害上下文（取 preReduction 为基准，R4）
+ * @param reflectRatio 反伤百分比（如 0.3 = 30%）
+ * @returns
+ *   - depth ≥ MAX → mutual_cancel（双方本链反伤互相抵消 + 湮灭叙事）
+ *   - 否则 propagate（base = preReduction，不放大，R7）
+ */
+export function resolveReflection(
+  depth: number,
+  damage: Pick<DamageCtx, 'preReduction' | 'final'>,
+  reflectRatio: number,
+): ReflectionResolution {
+  // 首次反伤深度：damage 链根的 depth=0，automatons 里自检 depth<2；
+  // 这里把「当前链深度」与 MAX 比较：depth(进入该 automaton 时) >= MAX ⇒ 熔断
+  if (depth >= MAX_REFLECTION_DEPTH) {
+    return { kind: 'mutual_cancel', baseDamage: damage.preReduction, annihilated: true };
+  }
+  // R4/R7：基准取 preReduction（Step 1 初始），非 final；depth≥2 也不放大
+  const base = damage.preReduction;
+  const reflectedAmount = Math.floor(base * reflectRatio);
+  return {
+    kind: 'propagate',
+    baseDamage: base,
+    reflectRatio,
+    reflectedAmount,
+    nextDepth: depth + 1,
+  };
+}
+
+/**
+ * 反伤时产生的叙事提示（R6 熔断）。
+ */
+export const REFLECTION_ANNIHILATION_CUE = '反射湮灭';

--- a/src/sillytavern/combat-v3/intents.test.ts
+++ b/src/sillytavern/combat-v3/intents.test.ts
@@ -1,0 +1,213 @@
+/**
+ * combat-v3/intents.test.ts — EffectIntent 验证 / 解释执行 / 批原子性测试（M3, 验收 A3-7）
+ *
+ * 覆盖（plan §5.8 / 验收 A3-7）：
+ *   - batch 内一个 intent 非法 ⇒ 整批 reject + EffectRejected（validateBatch）
+ *   - 核心攻击不受影响（本模块只返回本 batch 结果，不接触外部状态 → 由 windows/phase 保证）
+ *   - EffectRejected code 枚举齐全（apply/windows 侧产生）
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateBatch, applyIntents } from './intents';
+import type { CombatState, EffectIntent } from './types';
+import { EMPTY_CHANGES } from './types';
+
+const present = (id: string) => id === '理查德' || id === '处刑人';
+const resolveNumber = (expr: string, fallback: number) => Number(expr) || fallback;
+
+function mkState(): CombatState {
+  // 最小 state（applyIntents 只读 units 的存在性）
+  return {
+    combatId: 't',
+    revision: 0,
+    phase: 'SlotConsume',
+    round: 1,
+    initiativeOrder: [],
+    currentTurnIndex: 0,
+    units: {},
+    activeEffects: {
+      byWindow: {
+        'round.open': [],
+        'round.close': [],
+        'initiative.before': [],
+        'initiative.after': [],
+        'turn.open': [],
+        'turn.close': [],
+        'action.declared': [],
+        'check.intent': [],
+        'check.hit': [],
+        collect_attacker_mods: [],
+        collect_defender_mods: [],
+        'damage.preview': [],
+        'damage.compute': [],
+        'damage.after': [],
+        'unit.beforeDown': [],
+        'morale.before': [],
+        'morale.after': [],
+        'settlement.before': [],
+      },
+      byOwner: {},
+    },
+    dice: undefined as never,
+    resourceSnapshots: { FP: 1000 },
+    journal: [],
+    provenance: {
+      engineVersion: 'v3',
+      schemaVersion: '1',
+      rulesetRevision: 't',
+      bundleHash: 't',
+      eventSequence: 0,
+      diceEpochs: [],
+    },
+  };
+}
+
+const ctx = {
+  state: mkState(),
+  automatonOwner: '理查德',
+  present,
+  resolveNumber,
+};
+
+describe('validateBatch — 批原子性（A3-7）', () => {
+  it('全部合规 → ok', () => {
+    const batch: EffectIntent[] = [
+      { kind: 'Heal', targetId: '理查德', amount: 30 },
+      { kind: 'ApplyStatus', targetId: '理查德', statusId: '护盾', duration: 1 },
+    ];
+    expect(validateBatch(batch)).toEqual({ ok: true, intents: batch });
+  });
+
+  it('batch 内一个非法 → 整批 reject + rejectedIntents 含全部', () => {
+    const bad: EffectIntent[] = [
+      { kind: 'Heal', targetId: '理查德', amount: 30 },
+      // 负 Heal = 非法（VALUE_OUT_OF_RANGE）
+      { kind: 'Heal', targetId: '理查德', amount: -5 },
+    ];
+    const v = validateBatch(bad);
+    expect(v.ok).toBe(false);
+    if (!v.ok) {
+      expect(v.code).toBe('VALUE_OUT_OF_RANGE');
+      expect(v.rejectedIntents).toHaveLength(2);
+    }
+  });
+
+  it('DealDamage 空 target → TARGET_ILLEGAL', () => {
+    const v = validateBatch([
+      {
+        kind: 'DealDamage',
+        targetId: '',
+        amount: 50,
+        damageType: 'physical',
+      } as unknown as EffectIntent,
+    ]);
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.code).toBe('TARGET_ILLEGAL');
+  });
+
+  it('ScheduleIntent 递归校验内部非法', () => {
+    const v = validateBatch([
+      {
+        kind: 'ScheduleIntent',
+        delay: 0,
+        intent: {
+          kind: 'DealDamage',
+          targetId: '',
+          amount: 5,
+          damageType: 'true',
+        } as unknown as EffectIntent,
+      },
+    ]);
+    expect(v.ok).toBe(false);
+  });
+});
+
+describe('applyIntents — 解释执行', () => {
+  it('Heal 累积到 hpChanges', () => {
+    const changes = { ...EMPTY_CHANGES, hpChanges: {} };
+    const r = applyIntents(ctx, [{ kind: 'Heal', targetId: '理查德', amount: 30 }], changes);
+    expect(r.changes.hpChanges['理查德']).toBe(30);
+    expect(r.consumedCharge).toBe(false);
+  });
+
+  it('DealDamage 负累积（doesNotConsumeSlot 反伤仍走 hpChanges）', () => {
+    const changes = { ...EMPTY_CHANGES, hpChanges: {} };
+    const r = applyIntents(
+      ctx,
+      [
+        {
+          kind: 'DealDamage',
+          targetId: '处刑人',
+          amount: 100,
+          damageType: 'physical',
+          doesNotConsumeSlot: true,
+        } as EffectIntent,
+      ],
+      changes,
+    );
+    expect(r.changes.hpChanges['处刑人']).toBe(-100);
+  });
+
+  it('SpendResource SP / FP', () => {
+    const changes = { ...EMPTY_CHANGES, spChanges: {}, fpDelta: 0 };
+    const r = applyIntents(
+      ctx,
+      [
+        { kind: 'SpendResource', targetId: '理查德', resource: 'sp', amount: 50 },
+        { kind: 'SpendResource', targetId: '理查德', resource: 'fp', amount: 100 },
+      ],
+      changes,
+    );
+    expect(r.changes.spChanges['理查德']).toBe(-50);
+    expect(r.changes.fpDelta).toBe(-100);
+  });
+
+  it('ApplyStatus 产生 statusPatch', () => {
+    const changes = { ...EMPTY_CHANGES, statusPatches: [] };
+    const r = applyIntents(
+      ctx,
+      [{ kind: 'ApplyStatus', targetId: '理查德', statusId: '护盾', duration: 1, layers: 2 }],
+      changes,
+    );
+    expect(r.changes.statusPatches).toHaveLength(1);
+    if (r.changes.statusPatches[0].op === 'apply') {
+      expect(r.changes.statusPatches[0].status.name).toBe('护盾');
+      expect(r.changes.statusPatches[0].status.stacks).toBe(2);
+    }
+  });
+
+  it('目标不在场 → silently 跳过（不崩、不变更）', () => {
+    const changes = { ...EMPTY_CHANGES, hpChanges: {} };
+    const r = applyIntents(ctx, [{ kind: 'Heal', targetId: '不存在的人', amount: 30 }], changes);
+    expect(r.changes.hpChanges).toEqual({});
+  });
+
+  it('ConsumeCharge 标记消耗', () => {
+    const changes = { ...EMPTY_CHANGES };
+    const r = applyIntents(ctx, [{ kind: 'ConsumeCharge', amount: 1 }], changes);
+    expect(r.consumedCharge).toBe(true);
+  });
+
+  it('EmitNarrativeCue 收集叙事文本', () => {
+    const changes = { ...EMPTY_CHANGES };
+    const r = applyIntents(ctx, [{ kind: 'EmitNarrativeCue', text: '反射湮灭' }], changes);
+    expect(r.narrative).toEqual(['反射湮灭']);
+  });
+});
+
+describe('EffectRejected code 枚举齐全', () => {
+  it('9 种 code 均在 validateOne 可达', () => {
+    // 枚举值全部能出现在 batch 拒绝中（通过构造各类非法 intent 验证关键几种）
+    const bad = [
+      { kind: 'DealDamage', targetId: '', amount: 10, damageType: 'physical' }, // TARGET_ILLEGAL
+      { kind: 'Heal', targetId: 'x', amount: -1 }, // VALUE_OUT_OF_RANGE
+      { kind: 'ApplyStatus', targetId: '', statusId: 's', duration: 1 }, // TARGET_ILLEGAL
+    ];
+    const codes = bad.map((x) => {
+      const v = validateBatch([x as unknown as EffectIntent]);
+      return v.ok ? 'ok' : v.code;
+    });
+    expect(codes).toContain('TARGET_ILLEGAL');
+    expect(codes).toContain('VALUE_OUT_OF_RANGE');
+  });
+});

--- a/src/sillytavern/combat-v3/intents.ts
+++ b/src/sillytavern/combat-v3/intents.ts
@@ -1,0 +1,287 @@
+/**
+ * combat-v3/intents.ts — EffectIntent 验证 + 解释执行（批原子性，M3）
+ *
+ * 架构真源：docs/reference/combat-system-architecture-v3.md §六 6.3（intent batch 原子性）
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §3.5 / §5.8
+ *
+ * `validateBatch(batch, ctx)`：batch 内**任一** intent 非法 ⇒ 整批 reject + 产 EffectRejected。
+ *  code 枚举（架构 §6.3）：TARGET_ILLEGAL / DIVINITY_INSUFFICIENT / RESOURCE_INSUFFICIENT /
+ *  CHARGE_EXHAUSTED / VALUE_OUT_OF_RANGE / INVARIANT_VIOLATION / UNSUPPORTED_CAPABILITY /
+ *  EVAL_ERROR / BUDGET_EXCEEDED。
+ *
+ * `applyIntents(state, intents)`：把通过验证的 intent 应用到 pendingChanges（一次 Command 末尾原子提交）。
+ *
+ * **不取消**合法的核心攻击，也不取消同窗口其他 automaton 的合法 batch（A3-7）——
+ * 本模块只对单个 batch 做原子拒绝。
+ *
+ * 铁律：零 Math.random / new Function / eval；纯函数 + 不可变。
+ */
+
+import type { CombatState, EffectRejectCode, EffectIntent, PendingChangeSet } from './types';
+import { resolveReflection, REFLECTION_ANNIHILATION_CUE } from './automata/reflection';
+import type { DamageCtx } from './types';
+
+/** 单条 intent 验证结果（可通过 or 拒绝） */
+export type IntentValidation = { ok: true } | { ok: false; code: EffectRejectCode; detail: string };
+
+/** 整个 batch 的验证结果 */
+export type BatchValidation =
+  | { ok: true; intents: readonly EffectIntent[] }
+  | { ok: false; code: EffectRejectCode; detail: string; rejectedIntents: readonly EffectIntent[] };
+
+/** 供 applyIntents 使用的求值上下文快照（target 在场/资源） */
+export interface IntentApplyCtx {
+  state: CombatState;
+  automatonOwner: string;
+  /** 当前 automaton 的 charges（可能随 ConsumeCharge 递减） */
+  charges?: { max: number; remaining: number };
+  /** 解析表达式（amount='ctx.damage.final*0.1'）——M3 用注入的解析器闭包避免循环依赖 */
+  resolveNumber: (expr: string, fallback: number) => number;
+  /** 目标在场检查 */
+  present: (unitId: string) => boolean;
+  /** 当前反射链的伤害上下文（取 preReduction 为基准，架构 §九 R4）；缺省无反射 */
+  reflectBase?: Pick<DamageCtx, 'preReduction' | 'final'>;
+  /** 当前反射深度（架构 §九 R6，缺省 0） */
+  reflectDepth?: number;
+  /** 反伤百分比（如 0.3 = 30%）；有 reflectBase 时用于 ScheduleIntent 反伤解析 */
+  reflectRatio?: number;
+}
+// ──────────────────────────────────────────────────────────────────────────────
+// validateBatch —— 批原子性（A3-7）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 校验整个 intent batch。任一非法 ⇒ 整批拒绝 + EffectRejected。
+ *
+ * 合法的核心攻击与同窗口其他 automaton 不受影响（A3-7）——本函数只返回本 batch 的
+ * 验证结果，不接触外部状态。
+ */
+export function validateBatch(batch: readonly EffectIntent[]): BatchValidation {
+  for (const intent of batch) {
+    const r = validateOne(intent);
+    if (!r.ok) {
+      return { ok: false, code: r.code, detail: r.detail, rejectedIntents: [...batch] };
+    }
+  }
+  return { ok: true, intents: [...batch] };
+}
+
+/** 单条 intent 合法性（范围内静态检查；运行时目标在场/资源在 applyIntents 兜底） */
+function validateOne(intent: EffectIntent): IntentValidation {
+  switch (intent.kind) {
+    case 'DealDamage': {
+      if (!intent.targetId)
+        return { ok: false, code: 'TARGET_ILLEGAL', detail: 'DealDamage.targetId 为空' };
+      return { ok: true };
+    }
+    case 'Heal': {
+      const amt = intent.amount;
+      if (typeof amt === 'number' && amt < 0) {
+        return {
+          ok: false,
+          code: 'VALUE_OUT_OF_RANGE',
+          detail: 'Heal.amount 不得为负（负伤害 ≠ 治疗）',
+        };
+      }
+      return { ok: true };
+    }
+    case 'SpendResource': {
+      const amt = intent.amount;
+      if (typeof amt === 'number' && amt < 0) {
+        return { ok: false, code: 'VALUE_OUT_OF_RANGE', detail: 'SpendResource.amount 不得为负' };
+      }
+      return { ok: true };
+    }
+    case 'ApplyStatus':
+      if (!intent.targetId)
+        return { ok: false, code: 'TARGET_ILLEGAL', detail: 'ApplyStatus.targetId 为空' };
+      return { ok: true };
+    case 'RemoveStatus':
+      if (!intent.targetId)
+        return { ok: false, code: 'TARGET_ILLEGAL', detail: 'RemoveStatus.targetId 为空' };
+      return { ok: true };
+    case 'PreventDeath':
+      if (!intent.targetId)
+        return { ok: false, code: 'TARGET_ILLEGAL', detail: 'PreventDeath.targetId 为空' };
+      return { ok: true };
+    case 'ConsumeCharge':
+      if (intent.amount !== undefined && typeof intent.amount === 'number' && intent.amount < 0) {
+        return { ok: false, code: 'CHARGE_EXHAUSTED', detail: 'ConsumeCharge.amount 不得为负' };
+      }
+      return { ok: true };
+    case 'AddModifier':
+      return { ok: true };
+    case 'EmitNarrativeCue':
+      return { ok: true };
+    case 'OverrideIntent':
+      return { ok: true };
+    case 'ScheduleIntent':
+      // 递归校验内部 intent
+      return validateOne(intent.intent);
+    case 'SpawnOrDespawnIntent':
+      return { ok: true };
+    case 'RequestChoiceIntent': {
+      if (!intent.choiceId)
+        return {
+          ok: false,
+          code: 'INVARIANT_VIOLATION',
+          detail: 'RequestChoiceIntent.choiceId 为空',
+        };
+      return { ok: true };
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// applyIntents —— 把已验证 intent 应用到 pendingChanges（一次原子提交）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 把一批通过验证（validateBatch ok）的 intent 应用到阶段性的 PendingChangeSet。
+ *
+ * 注意：本函数**不施加不变量（HP clamp / 槽位核销）**——那些由 phase 末尾 applyPending
+ * 统一完成。这里只把 intent → pending 数值字段（hp/mp/sp/fp/statusPatches/...）。
+ *
+ * 返回 { changes, consumedCharge, spawnRequests }：
+ *   - changes: 可并入 phase 的 PendingChangeSet
+ *   - consumedCharge: 是否消耗了一次 automaton charge
+ *   - events: 附带产生的叙事/事件意图（如 EmitNarrativeCue）
+ */
+export function applyIntents(
+  ctx: IntentApplyCtx,
+  intents: readonly EffectIntent[],
+  base: PendingChangeSet,
+): {
+  changes: PendingChangeSet;
+  consumedCharge: boolean;
+  narrative: readonly string[];
+} {
+  let consumedCharge = false;
+  const narrative: string[] = [];
+
+  for (const intent of intents) {
+    const collected = applyOne(ctx, intent, base);
+    if (collected.narrative) narrative.push(...collected.narrative);
+    if (collected.consumedCharge) consumedCharge = true;
+  }
+  return { changes: base, consumedCharge, narrative };
+}
+
+/** 单条 intent 应用结果（累计变更直接写 base） */
+interface ApplyOneResult {
+  narrative: readonly string[];
+  consumedCharge: boolean;
+}
+
+/**
+ * 逐条应用 intent（就地累积到 base）。
+ */
+function applyOne(
+  ctx: IntentApplyCtx,
+  intent: EffectIntent,
+  base: PendingChangeSet,
+): ApplyOneResult {
+  switch (intent.kind) {
+    case 'AddModifier':
+      // AddModifier 不进 pending 变更集——它是"修饰"，由 windows 收集后并入管线入参。
+      return { narrative: [], consumedCharge: false };
+    case 'DealDamage': {
+      const target = intent.targetId;
+      if (!ctx.present(target)) return { narrative: [], consumedCharge: false };
+      const amt = coerceAmount(ctx, intent.amount, 0);
+      base.hpChanges[target] = (base.hpChanges[target] ?? 0) - amt;
+      return { narrative: [], consumedCharge: false };
+    }
+    case 'Heal': {
+      const target = intent.targetId;
+      if (!ctx.present(target)) return { narrative: [], consumedCharge: false };
+      const amt = coerceAmount(ctx, intent.amount, 0);
+      base.hpChanges[target] = (base.hpChanges[target] ?? 0) + amt;
+      return { narrative: [], consumedCharge: false };
+    }
+    case 'SpendResource': {
+      const target = intent.targetId;
+      if (!ctx.present(target)) return { narrative: [], consumedCharge: false };
+      if (intent.resource === 'fp') {
+        base.fpDelta += -intent.amount;
+      } else {
+        const field =
+          intent.resource === 'mp'
+            ? base.mpChanges
+            : intent.resource === 'sp'
+              ? base.spChanges
+              : base.hpChanges;
+        field[target] = (field[target] ?? 0) - intent.amount;
+      }
+      return { narrative: [], consumedCharge: false };
+    }
+    case 'ApplyStatus': {
+      const target = intent.targetId;
+      if (!ctx.present(target)) return { narrative: [], consumedCharge: false };
+      base.statusPatches.push({
+        op: 'apply',
+        unitId: target,
+        status: {
+          name: intent.statusId,
+          description: '',
+          category: '增益',
+          stacks: intent.layers ?? 1,
+          remainingTime: intent.duration,
+          timeUnit: '回合',
+          source: `[效果]-[${ctx.automatonOwner}]`,
+          effects: {},
+          lifecycle: '战斗',
+        },
+      });
+      return { narrative: [], consumedCharge: false };
+    }
+    case 'RemoveStatus': {
+      const target = intent.targetId;
+      if (!ctx.present(target)) return { narrative: [], consumedCharge: false };
+      base.statusPatches.push({ op: 'remove', unitId: target, statusId: intent.statusId });
+      return { narrative: [], consumedCharge: false };
+    }
+    case 'ConsumeCharge':
+      return { narrative: [], consumedCharge: true };
+    case 'EmitNarrativeCue':
+      return { narrative: [intent.text], consumedCharge: false };
+    case 'ScheduleIntent': {
+      // 延迟意图：若内部是反伤 DealDamage(isReaction) 且有反射基准，则按 §九 解析
+      const inner = intent.intent;
+      if (inner.kind === 'DealDamage' && inner.isReaction && ctx.reflectBase !== undefined) {
+        const ratio = ctx.reflectRatio ?? 0;
+        if (ratio <= 0) return { narrative: [], consumedCharge: false };
+        const res = resolveReflection(ctx.reflectDepth ?? 0, ctx.reflectBase, ratio);
+        if (res.kind === 'mutual_cancel') {
+          // R6 熔断：双方本链反伤互相抵消 + 湮灭叙事
+          return { narrative: [REFLECTION_ANNIHILATION_CUE], consumedCharge: false };
+        }
+        // R1/R7：反伤命中（R8 命中骰由 windows 层负责消费 dice），
+        // doesNotConsumeSlot 天然不进槽位（只写 hpChanges）
+        base.hpChanges[inner.targetId] =
+          (base.hpChanges[inner.targetId] ?? 0) - res.reflectedAmount;
+        return { narrative: [], consumedCharge: false };
+      }
+      return { narrative: [], consumedCharge: false };
+    }
+    case 'PreventDeath':
+    case 'SpawnOrDespawnIntent':
+    case 'RequestChoiceIntent':
+      // M3 范围：这些要么由 damage.preview 单独处理（RequestChoice），要么 M4 实现。
+      return { narrative: [], consumedCharge: false };
+    default:
+      return { narrative: [], consumedCharge: false };
+  }
+}
+
+/** 把 intent 的 amount/value（字面量或表达式串）解析为数字 */
+function coerceAmount(ctx: IntentApplyCtx, v: number | string | undefined, dflt: number): number {
+  if (v === undefined) return dflt;
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') {
+    if (/^\d+$/.test(v)) return Number(v);
+    // 表达式串（如 'ctx.damage.final * 0.1'）→ 注入的解析器
+    return ctx.resolveNumber(v, dflt);
+  }
+  return dflt;
+}

--- a/src/sillytavern/combat-v3/phases/action.ts
+++ b/src/sillytavern/combat-v3/phases/action.ts
@@ -13,7 +13,7 @@
  */
 
 import { draw } from '../dice-tape';
-import { evaluateWindow } from '../windows';
+import { evaluateWindow, makeWindowRuntimeCtx } from '../windows';
 import type { CombatCommand, CombatDefinitionBundle, CombatState } from '../types';
 import { emptyChanges, type PhaseOutcome } from './outcome';
 
@@ -35,10 +35,15 @@ export function handleAction(
     nextPhase: 'SlotConsume',
   };
 
-  evaluateWindow(state.activeEffects, 'action.declared', {
-    selfId: command.actorId,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'action.declared',
+    makeWindowRuntimeCtx(state, {
+      selfId: command.actorId,
+      round: state.round,
+      window: 'action.declared',
+    }),
+  );
 
   const actionType: TacticalActionType = command.payload.actionType;
   const actor = state.units[command.actorId];

--- a/src/sillytavern/combat-v3/phases/attack.ts
+++ b/src/sillytavern/combat-v3/phases/attack.ts
@@ -27,8 +27,14 @@ import { draw } from '../dice-tape';
 import { performAttackCheck, runDamagePipeline } from '../../combat-damage';
 import { resolveIntention, checkNonLethal } from '../../combat-intention';
 import { getCombatCoefficient } from '../../tier-constants';
-import { evaluateWindow } from '../windows';
-import type { CombatCommand, CombatDefinitionBundle, CombatState, DomainEvent } from '../types';
+import { evaluateWindow, hasSubscribers, makeWindowRuntimeCtx } from '../windows';
+import type {
+  CombatCommand,
+  CombatDefinitionBundle,
+  CombatState,
+  DomainEvent,
+  DamageRecomputeCtx,
+} from '../types';
 import { emptyChanges, type PhaseOutcome } from './outcome';
 
 /**
@@ -67,11 +73,16 @@ export function handleAttack(
     };
 
   // ── ① check.intent：取 intentCheck 通道 2 颗骰 → resolveIntention（C5） ──
-  evaluateWindow(state.activeEffects, 'check.intent', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'check.intent',
+    makeWindowRuntimeCtx(state, {
+      selfId: attacker.id,
+      targetId: defender.id,
+      round: state.round,
+      window: 'check.intent',
+    }),
+  );
 
   const intentDraw = draw(state.dice, 'intentCheck', 2);
   if ('exhausted' in intentDraw) {
@@ -93,18 +104,28 @@ export function handleAttack(
   });
 
   // ── ② collect_attacker_mods 窗口（M1 空转；M3 接 modifier push-handler） ──
-  evaluateWindow(state.activeEffects, 'collect_attacker_mods', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'collect_attacker_mods',
+    makeWindowRuntimeCtx(state, {
+      selfId: attacker.id,
+      targetId: defender.id,
+      round: state.round,
+      window: 'collect_attacker_mods',
+    }),
+  );
 
   // ── ③ check.hit：取 attackHit 通道 1~2 颗骰 → performAttackCheck（M-5） ──
-  evaluateWindow(state.activeEffects, 'check.hit', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'check.hit',
+    makeWindowRuntimeCtx(state, {
+      selfId: attacker.id,
+      targetId: defender.id,
+      round: state.round,
+      window: 'check.hit',
+    }),
+  );
 
   // 同层级 1 颗；优/劣势 2 颗
   const hitDiceCount = attacker.tier === defender.tier ? 1 : 2;
@@ -144,18 +165,28 @@ export function handleAttack(
   });
 
   // ④ collect_defender_mods 窗口（M1 空转）
-  evaluateWindow(state.activeEffects, 'collect_defender_mods', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'collect_defender_mods',
+    makeWindowRuntimeCtx(state, {
+      selfId: attacker.id,
+      targetId: defender.id,
+      round: state.round,
+      window: 'collect_defender_mods',
+    }),
+  );
 
   // ── ⑤ damage.compute：8 步管线 + clamp ≥ 0（C7） ──
-  evaluateWindow(state.activeEffects, 'damage.compute', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'damage.compute',
+    makeWindowRuntimeCtx(state, {
+      selfId: attacker.id,
+      targetId: defender.id,
+      round: state.round,
+      window: 'damage.compute',
+    }),
+  );
 
   const coeff = getCombatCoefficient(attacker.tier);
   const initialDamage =
@@ -187,20 +218,143 @@ export function handleAttack(
   // C7: 最终伤害 clamp ≥ 0（负 modifier 不产生治疗）
   const finalDamage = Math.max(0, Math.floor(damage.finalDamage));
 
-  // ── ⑥ damage.preview 窗口（M1 空转；M3 接 RequestChoice 重算） ──
-  evaluateWindow(state.activeEffects, 'damage.preview', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
-
+  // ── ⑥ damage.preview 窗口（M3 接 RequestChoice 补暂停 / 格挡重算） ──
   const preReduction = initialDamage;
   const postStep6 = damage.afterRating;
+
+  // A3-6：无订阅者 → 直接跳过窗口，不暂停（架构 §五 5.2 约束 3）
+  if (hasSubscribers(state.activeEffects, 'damage.preview')) {
+    const evalResult = evaluateWindow(
+      state.activeEffects,
+      'damage.preview',
+      makeWindowRuntimeCtx(state, {
+        selfId: attacker.id,
+        targetId: defender.id,
+        round: state.round,
+        window: 'damage.preview',
+      }),
+    );
+
+    // 收集 preview 窗口里的 RequestChoiceIntent（格挡/招架反应），
+    // 触发 RequiredInput.EffectChoice（dispatch 暂停，A3-5）
+    const choice = derefPreview(evalResult.intents);
+    // 错误隔离：preview 里单个 automaton 抛错不打断核心攻击（rejections 记录）
+    out.events.push(...evalResult.rejections);
+
+    if (choice) {
+      // ★ 冻结 ResolutionFrame（damage.preview）+ 返回 EffectChoice
+      const recompute: DamageRecomputeCtx = {
+        attackerId: attacker.id,
+        targetId: defender.id,
+        relevantAttribute: ability.relevantAttribute,
+        skillPower: ability.skillPower,
+        weaponAtk: attacker.weaponAtk,
+        multiHitCount: ability.multiHitCount || 1,
+        intentionCoefficient,
+        ratingCoefficient: attackCheck.rating.coefficient,
+        damageTakenFactor: choice.blockDamageFactor ?? 1,
+        fixedDamageAdjust: 0,
+      };
+      out.requiredInput = {
+        kind: 'EffectChoice',
+        choiceId: choice.choiceId,
+        unitId: defender.id,
+        damagePreview: finalDamage,
+        options: choice.options,
+        cost: choice.cost,
+        blockDamageFactor: choice.blockDamageFactor,
+        damageTakenOverrideId: choice.damageTakenOverrideId,
+      };
+      out.suspended = { recompute, finalDamage };
+      out.nextPhase = 'SlotConsume';
+      // 不继续 ⑦⑧⑨⑩——reducer 冻结 frame 后等 DeclareBlock
+      return out;
+    }
+  }
+
+  // 无 RequestChoice → 沿用当前 finalDamage 走完整结算
+  finalizeAttack(out, bundle, state, attacker, defender, ability, command, {
+    finalDamage,
+    preReduction,
+    postStep6,
+    attackCheckRatingCoef: attackCheck.rating.coefficient,
+  });
+  return out;
+}
+
+/**
+ * 从 preview 收集的 intent 中提取第一条 RequestChoiceIntent（若无则 null）。
+ */
+function derefPreview(
+  batches: readonly {
+    automatonId: string;
+    owner: string;
+    intents: readonly { kind: string }[];
+  }[],
+): {
+  choiceId: string;
+  options: readonly string[];
+  cost?: { sp?: number; slot?: 'action' };
+  blockDamageFactor?: number;
+  damageTakenOverrideId?: string;
+} | null {
+  for (const b of batches) {
+    for (const intent of b.intents) {
+      if (intent.kind === 'RequestChoiceIntent') {
+        const rc = intent as unknown as {
+          choiceId: string;
+          options?: readonly string[];
+          cost?: { sp?: number; slot?: 'action' };
+          blockDamageFactor?: number;
+          damageTakenOverrideId?: string;
+        };
+        return {
+          choiceId: rc.choiceId,
+          options: rc.options ?? ['是', '否'],
+          cost: rc.cost,
+          blockDamageFactor: rc.blockDamageFactor,
+          damageTakenOverrideId: rc.damageTakenOverrideId,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * 结算伤害后的全部微步骤（⑦ checkNonLethal → ⑧ beforeDown → ⑨ damage.after → ⑩ 提交）。
+ * M3 同时被 正常路径 与 格挡重算路径 复用（恢复后从 frame 提供 recompute 结果）。
+ */
+function finalizeAttack(
+  out: PhaseOutcome,
+  bundle: CombatDefinitionBundle,
+  state: CombatState,
+  attacker: CombatState['units'][string],
+  defender: CombatState['units'][string],
+  ability: Record<string, unknown> & {
+    relevantAttribute: number;
+    skillPower: number;
+    weaponAtk?: number;
+    multiHitCount?: number;
+    damageType: string;
+    intentionLevel: string;
+    divinity: number;
+  },
+  /** finalizeAttack 所需的最小 Command 视图（costs / nonLethal） */
+  command: { payload: { costs?: { mp?: number; sp?: number }; nonLethal?: boolean } },
+  params: {
+    finalDamage: number;
+    preReduction: number;
+    postStep6: number;
+    attackCheckRatingCoef: number;
+  },
+): void {
+  const { finalDamage, preReduction, postStep6, attackCheckRatingCoef } = params;
 
   // ── ⑦ checkNonLethal（C6）——在 ⑧ beforeDown 之前 ──
   const nonLethal = checkNonLethal({
     nonLethal: !!command.payload.nonLethal,
-    ratingCoefficient: attackCheck.rating.coefficient,
+    ratingCoefficient: attackCheckRatingCoef,
     finalDamage,
     currentHp: defender.hp,
   });
@@ -209,7 +363,6 @@ export function handleAttack(
     ? nonLethal.adjustedHp - defender.hp
     : -Math.min(finalDamage, defender.hp);
 
-  // 非致死 + 昏迷
   if (nonLethal.unconscious) {
     out.changes.statusPatches.push({
       op: 'apply',
@@ -229,22 +382,30 @@ export function handleAttack(
   }
 
   // ── ⑧ unit.beforeDown 窗口（M4 接 death.threshold，M1 空转） ──
-  evaluateWindow(state.activeEffects, 'unit.beforeDown', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'unit.beforeDown',
+    makeWindowRuntimeCtx(state, {
+      selfId: attacker.id,
+      targetId: defender.id,
+      round: state.round,
+      window: 'unit.beforeDown',
+    }),
+  );
 
   // ⑨ damage.after 窗口（M3 接反伤）
-  evaluateWindow(state.activeEffects, 'damage.after', {
-    selfId: attacker.id,
-    targetId: defender.id,
-    round: state.round,
-  });
+  evaluateWindow(
+    state.activeEffects,
+    'damage.after',
+    makeWindowRuntimeCtx(state, {
+      selfId: attacker.id,
+      targetId: defender.id,
+      round: state.round,
+      window: 'damage.after',
+    }),
+  );
 
   // ── ⑩ 追加 pendingChanges + DomainEvents（攻守双方同批，M-9） ──
-
-  // 攻方资源消耗（costs 或 默认 0）
   const mpCost = command.payload.costs?.mp ?? 0;
   const spCost = command.payload.costs?.sp ?? 0;
   if (mpCost > 0) {
@@ -256,7 +417,6 @@ export function handleAttack(
     out.events.push({ kind: 'ResourceSpent', unitId: attacker.id, resource: 'sp', amount: spCost });
   }
 
-  // 守方 HP（负伤害即增减益，HP 由 applyPending clamp 到 [0,maxHp]）
   if (hpDelta !== 0) {
     out.changes.hpChanges[defender.id] = (out.changes.hpChanges[defender.id] ?? 0) + hpDelta;
   }
@@ -271,7 +431,7 @@ export function handleAttack(
     preReduction,
     postStep6,
     final: finalDamage,
-    damageType: ability.damageType,
+    damageType: ability.damageType as never,
     targetHpBefore,
     targetHpAfter,
   });
@@ -279,6 +439,84 @@ export function handleAttack(
   if (targetHpAfter <= 0) {
     out.events.push({ kind: 'UnitDowned', unitId: defender.id, hp: targetHpAfter });
   }
+}
+
+/**
+ * 从 damage.preview 冻结的 frame 恢复：格挡 → 回到 damage.compute **重算**（§5.4 约束 4）。
+ *
+ * 不在 final 上打折，而是重新计算管线结果（preReduction × blockDamageFactor 后 clamp ≥ 0），
+ * 再走 ⑦⑧⑨⑩（不重取骰、不重跑 ①-③）。用于 reducer 的 DeclareBlock frame 恢复分支。
+ */
+export function resumeBlockedAttack(
+  bundle: CombatDefinitionBundle,
+  state: CombatState,
+  recompute: DamageRecomputeCtx,
+): PhaseOutcome {
+  const attacker = state.units[recompute.attackerId];
+  const defender = state.units[recompute.targetId];
+  const out: PhaseOutcome = {
+    changes: emptyChanges(),
+    events: [],
+    nextPhase: 'SlotConsume',
+  };
+  if (!attacker || !defender) {
+    out.rejection = { code: 'TARGET_NOT_PRESENT', message: '格挡重算单位不在场' };
+    return out;
+  }
+
+  // ★ 回到 damage.compute 重算（架构 §五 5.2 约束 4）：blockDamageFactor 折后 clamp ≥ 0
+  const coeff = getCombatCoefficient(attacker.tier);
+  const initialDamage =
+    recompute.relevantAttribute * 10 * coeff + recompute.skillPower + attacker.weaponAtk;
+  const damage = runDamagePipeline({
+    relevantAttribute: recompute.relevantAttribute,
+    attackerTier: attacker.tier,
+    skillPower: recompute.skillPower,
+    weaponAtk: attacker.weaponAtk,
+    multiHitCount: recompute.multiHitCount || 1,
+    defenderDefense: defender.defense,
+    penetrationRate: attacker.penetration,
+    damageType: attacker.ability?.damageType ?? '物理',
+    defenderAttributes: defender.attributes,
+    ratingCoefficient: recompute.ratingCoefficient,
+    intentionCoefficient: recompute.intentionCoefficient,
+    drRate: defender.dr,
+    isClusterTarget: false,
+    currentHp: defender.hp,
+    fixedDamageBonus: recompute.fixedDamageAdjust,
+    modifiers: { hitBonus: 0, dodgeBonus: 0 },
+  });
+  // 折减因子（格挡 damageTaken -0.8 → ×0.2）∈ 管线重算，非 final 打折
+  const recomputed = Math.max(
+    0,
+    Math.floor(damage.finalDamage * (recompute.damageTakenFactor ?? 1)),
+  );
+
+  finalizeAttack(
+    out,
+    bundle,
+    state,
+    attacker,
+    defender,
+    attacker.ability ?? {
+      relevantAttribute: recompute.relevantAttribute,
+      skillPower: recompute.skillPower,
+      damageType: '物理',
+      intentionLevel: '常规',
+      multiHitCount: recompute.multiHitCount || 1,
+      divinity: 0,
+    },
+    {
+      // 无 costs —— 格挡的 SP/动作槽由 reducer 单独并入（DeclareBlock cost:action）
+      payload: {},
+    },
+    {
+      finalDamage: recomputed,
+      preReduction: initialDamage,
+      postStep6: damage.afterRating,
+      attackCheckRatingCoef: recompute.ratingCoefficient,
+    },
+  );
 
   return out;
 }

--- a/src/sillytavern/combat-v3/phases/outcome.ts
+++ b/src/sillytavern/combat-v3/phases/outcome.ts
@@ -47,6 +47,30 @@ export interface PhaseOutcome {
   settlementId?: string;
   /** 回合变更（round.close 推进到下一轮时 +1） */
   round?: number;
+  /**
+   * M3：damage.preview 触发 RequestChoice 时冻结的挂起上下文（reducer 据它构造 ResolutionFrame）。
+   * 仅 attack phase 用；不进入 state.ts import 的形状（这是 phase 层的即时信息）。
+   */
+  suspended?: {
+    /** 重算所需全部伤害入参 + 格挡因子 */
+    recompute: ImportedRecomputeCtx;
+    /** 暂停时的原始最终伤害（用于 RequiredInput.EffectChoice.damagePreview） */
+    finalDamage: number;
+  };
+}
+
+/** phase 层的重算上下文（避免 types.ts 循环依赖，复用字段名） */
+export interface ImportedRecomputeCtx {
+  attackerId: string;
+  targetId: string;
+  relevantAttribute: number;
+  skillPower: number;
+  weaponAtk: number;
+  multiHitCount: number;
+  intentionCoefficient: number;
+  ratingCoefficient: number;
+  damageTakenFactor: number;
+  fixedDamageAdjust: number;
 }
 
 /** 轻量 settlement 结果（避免循环依赖 types.ts） */

--- a/src/sillytavern/combat-v3/phases/preview.test.ts
+++ b/src/sillytavern/combat-v3/phases/preview.test.ts
@@ -1,0 +1,140 @@
+/**
+ * combat-v3/phases/preview.test.ts — damage.preview 全流程测试（M3, 验收 A3-5 / A3-6）
+ *
+ * 覆盖（plan §5.4 / §5.8）：
+ *   - A3-6  无订阅者不暂停（无反应 automaton 的单位受击不触发暂停）
+ *   - A3-5  有订阅者：伤害算出 → RequestChoice → RequiredInput.EffectChoice →
+ *           冻结 frame → DeclareBlock → 回到 damage.compute 重算 → 伤害按格挡因子折减
+ *   - 恢复不重取骰（frame 恢复用暂存 recompute，不再 draw）
+ */
+
+import { describe, it, expect } from 'vitest';
+import { reduce } from '../reducer';
+import { createCombatState } from '../state';
+import { buildIndex } from '../automata/index-active';
+import type { CombatState, CompiledAutomaton, DomainEvent } from '../types';
+import { mkBundle, mkAttack } from '../test-utils';
+
+/** 造一条 格挡 反应 automaton（damage.preview → RequestChoice + blockDamageFactor） */
+function blockAutomaton(owner: string, blockFactor: number): CompiledAutomaton {
+  return {
+    id: `item.${owner}.block`,
+    name: `${owner}·格挡`,
+    source: '格挡',
+    owner,
+    subscribe: 'damage.preview',
+    priority: 0,
+    divinity: 0,
+    stableId: `item.${owner}.block`,
+    triggerAst: { t: 'bool', v: true },
+    isAdapter: true,
+    intents: [
+      {
+        kind: 'RequestChoiceIntent',
+        choiceId: `block-${owner}`,
+        prompt: '格挡？',
+        options: ['是', '否'],
+        cost: { sp: 50, slot: 'action' },
+        blockDamageFactor: blockFactor,
+      },
+    ],
+  };
+}
+
+/** 给 state 注入一个 damage.preview 订阅索引 */
+function withAutomaton(state: CombatState, auto: CompiledAutomaton): CombatState {
+  return { ...state, activeEffects: buildIndex([auto]) };
+}
+
+describe('A3-6：无订阅者不暂停', () => {
+  it('没有 damage.preview 订阅者 → 攻击无 requiredInput，直接结算', () => {
+    const bundle = mkBundle();
+    let s: CombatState = createCombatState(bundle);
+    s = { ...s, units: { ...s.units, 乙: { ...s.units['乙'], hp: 500000, maxHp: 500000 } } };
+    const t = reduce(bundle, s, mkAttack('a1', 0, '甲', '乙'));
+    // ActiveEffectIndex 恒空（buildIndex([])）→ damage.preview 无订阅 → 不暂停
+    expect(t.requiredInput?.kind).not.toBe('EffectChoice');
+    // 正常推进：还有动作槽 → PlayerCommand
+    expect(t.requiredInput?.kind).toBe('PlayerCommand');
+  });
+});
+
+describe('A3-5：有订阅者 → 暂停并冻结 frame', () => {
+  it('受击方有格挡 automaton → 冻结 frame + EffectChoice', () => {
+    const bundle = mkBundle();
+    let s: CombatState = createCombatState(bundle);
+    s = { ...s, units: { ...s.units, 乙: { ...s.units['乙'], hp: 500000, maxHp: 500000 } } };
+    s = withAutomaton(s, blockAutomaton('乙', 0.2));
+    const t = reduce(bundle, s, mkAttack('a1', 0, '甲', '乙'));
+
+    expect(t.requiredInput?.kind).toBe('EffectChoice');
+    if (t.requiredInput?.kind === 'EffectChoice') {
+      expect(t.requiredInput.unitId).toBe('乙');
+      expect(t.requiredInput.options).toEqual(['是', '否']);
+      expect(t.requiredInput.blockDamageFactor).toBe(0.2);
+      expect(t.requiredInput.damagePreview).toBeGreaterThan(0);
+    }
+    // 帧已冻结（resolution.step === 'damage.preview'）
+    expect(t.next?.resolution?.step).toBe('damage.preview');
+  });
+});
+
+describe('A3-5：DeclareBlock → 回到 damage.compute 重算（487→97 路径）', () => {
+  it('格挡后 final = floor(previewDamAge × blockFactor)，恢复不重取骰', () => {
+    const bundle = mkBundle();
+    let s: CombatState = createCombatState(bundle);
+    s = { ...s, units: { ...s.units, 乙: { ...s.units['乙'], hp: 500000, maxHp: 500000 } } };
+    s = withAutomaton(s, blockAutomaton('乙', 0.2));
+
+    // ① 攻击 → 进入 damage.preview 冻结
+    const attackTrans = reduce(bundle, s, mkAttack('a1', 0, '甲', '乙'));
+    const preview = attackTrans.requiredInput;
+    expect(preview).toBeTruthy();
+    const previewDamage = preview && preview.kind === 'EffectChoice' ? preview.damagePreview : 0;
+    const blockFactor =
+      preview && preview.kind === 'EffectChoice' ? (preview.blockDamageFactor ?? 1) : 1;
+
+    // ② DeclareBlock 恢复（同 revision）
+    const blockTrans = reduce(bundle, attackTrans.next!, {
+      commandId: 'block1',
+      expectedRevision: attackTrans.next!.revision,
+      kind: 'DeclareBlock',
+      actorId: '乙',
+      cost: 'action',
+      payload: { choiceId: 'block-乙' },
+    });
+
+    // ★ 回到 damage.compute 重算：final == floor(preview × 0.2)
+    const damageEvt = blockTrans.events.find((e) => e.kind === 'DamageApplied') as
+      (DomainEvent & { final: number }) | undefined;
+    expect(damageEvt).toBeTruthy();
+    expect(damageEvt!.final).toBe(Math.floor(previewDamage * blockFactor));
+
+    // 恢复后 resolution 已清除
+    expect(blockTrans.next?.resolution).toBeUndefined();
+    // 乙实际受到了重算后的伤害（HP 下降 = final）
+    const hpBefore = attackTrans.next!.units['乙'].hp;
+    expect(blockTrans.next!.units['乙'].hp).toBe(Math.max(0, hpBefore - damageEvt!.final));
+  });
+
+  it('blockDamageFactor 折减成比例（重算路径通用）', () => {
+    const bundle = mkBundle();
+    let s: CombatState = createCombatState(bundle);
+    s = { ...s, units: { ...s.units, 乙: { ...s.units['乙'], hp: 500000, maxHp: 500000 } } };
+    s = withAutomaton(s, blockAutomaton('乙', 0.2));
+    const attackTrans = reduce(bundle, s, mkAttack('a1', 0, '甲', '乙'));
+    const preview = attackTrans.requiredInput;
+    const previewDamage = preview && preview.kind === 'EffectChoice' ? preview.damagePreview : 0;
+    const blockTrans = reduce(bundle, attackTrans.next!, {
+      commandId: 'b2',
+      expectedRevision: attackTrans.next!.revision,
+      kind: 'DeclareBlock',
+      actorId: '乙',
+      cost: 'action',
+      payload: {},
+    });
+    const dmg = blockTrans.events.find((e) => e.kind === 'DamageApplied') as
+      (DomainEvent & { final: number }) | undefined;
+    expect(dmg!.final).toBe(Math.floor(previewDamage * 0.2));
+  });
+});

--- a/src/sillytavern/combat-v3/phases/round.ts
+++ b/src/sillytavern/combat-v3/phases/round.ts
@@ -17,7 +17,7 @@
 
 import type { CombatDefinitionBundle, CombatState, PendingChangeSet, StatusPatch } from '../types';
 import type { DomainEvent } from '../types';
-import { evaluateWindow } from '../windows';
+import { evaluateWindow, makeWindowRuntimeCtx } from '../windows';
 import type { PhaseOutcome } from './outcome';
 import { emptyChanges } from './outcome';
 
@@ -46,7 +46,11 @@ export function handleRoundOpen(
   events.push({ kind: 'RoundOpened', round: state.round });
 
   // round.open 窗口（M3 接索引，M1 空转）
-  evaluateWindow(state.activeEffects, 'round.open', { selfId: undefined, round: state.round });
+  evaluateWindow(
+    state.activeEffects,
+    'round.open',
+    makeWindowRuntimeCtx(state, { selfId: undefined, round: state.round, window: 'round.open' }),
+  );
 
   // 增益 buff tick：remainingTime 递减，到期移除
   applyBuffTick(state, changes, events, 'positive', 'round.open');
@@ -70,7 +74,11 @@ export function handleRoundClose(bundle: CombatDefinitionBundle, state: CombatSt
   const events: DomainEvent[] = [];
 
   // round.close 窗口（M3 接索引，M1 空转）
-  evaluateWindow(state.activeEffects, 'round.close', { selfId: undefined, round: state.round });
+  evaluateWindow(
+    state.activeEffects,
+    'round.close',
+    makeWindowRuntimeCtx(state, { selfId: undefined, round: state.round, window: 'round.close' }),
+  );
 
   // 减益 buff tick + DoT
   applyBuffTick(state, changes, events, 'negative', 'round.close');

--- a/src/sillytavern/combat-v3/reducer.ts
+++ b/src/sillytavern/combat-v3/reducer.ts
@@ -15,9 +15,14 @@
  * 推进表（plan §3.3）落成 AUTO_PHASES 数据表。
  */
 
-import { applyOutcome, toView } from './state';
+import { applyOutcome, freezeFrame, toView } from './state';
 import { beginEpoch, splitSixty } from './dice-tape';
-import { KernelStuckError, type CombatCommand, type CombatState } from './types';
+import {
+  KernelStuckError,
+  type CombatCommand,
+  type CombatState,
+  type DamageRecomputeCtx,
+} from './types';
 import { checkTerminal } from './phases/terminal';
 import { handleRoundOpen, handleRoundClose } from './phases/round';
 import { handleInitiative } from './phases/initiative';
@@ -28,7 +33,7 @@ import {
   runMoraleCheck,
   closeUnitTurn,
 } from './phases/unit-turn';
-import { handleAttack } from './phases/attack';
+import { handleAttack, resumeBlockedAttack } from './phases/attack';
 import { handleAction, handleFlee } from './phases/action';
 import { settle } from './phases/terminal';
 import { emptyChanges, mergeChanges } from './phases/outcome';
@@ -79,6 +84,11 @@ export function reduce(
     return rejection(state, early);
   }
 
+  // 2.6 DeclareBlock 的 damage.preview frame 恢复分支（M3，A3-5）
+  if (command.kind === 'DeclareBlock' && state.resolution?.step === 'damage.preview') {
+    return resumeBlock(state, command);
+  }
+
   // 3. SupplyDice 续杯（BeginOutput 应答）
   if (command.kind === 'SupplyDice') {
     return reduceSupplyDice(bundle, state, command);
@@ -92,6 +102,76 @@ export function reduce(
 
   // 5. 正常 dispatch 循环
   return runDispatch(bundle, state, command);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DeclareBlock damage.preview frame 恢复（M3，A3-5）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * DeclareBlock Command 的 damage.preview frame 恢复分支。
+ *
+ * 玩家格挡：从冻结的 ResolutionFrame（step='damage.preview'）恢复，
+ * 回到 damage.compute **重算**（resumeBlockedAttack），并入格挡的资源消耗
+ * （SpendResource SP —— 架构 §5.4 步骤⑦），同一原子提交。不重取骰、不重跑前序。
+ *
+ * 验收 A3-5：487 → DeclareBlock → 重算 → 97。
+ */
+function resumeBlock(
+  state: CombatState,
+  command: Extract<CombatCommand, { kind: 'DeclareBlock' }>,
+) {
+  const frame = state.resolution;
+  const recompute = frame?.recompute;
+  if (!recompute) {
+    return rejection(state, {
+      code: 'INVALID_PHASE',
+      message: 'damage.preview frame 缺少 recompute 上下文',
+    });
+  }
+
+  const out = resumeBlockedAttack(bundleOf(state), state, recompute);
+  if (out.rejection) return rejection(state, out.rejection);
+
+  // 格挡消耗动作槽（DeclareBlock.cost='action'）——进 pendingChanges
+  out.changes.slotConsumptions ??= [];
+  out.changes.slotConsumptions.push({ actorId: command.actorId, slot: 'action' });
+  // 可选 SP 消耗（frame.awaiting.cost.sp）
+  const spCost = frame.awaiting.kind === 'EffectChoice' ? frame.awaiting.cost?.sp : undefined;
+  if (spCost && spCost > 0) {
+    out.changes.spChanges[command.actorId] = (out.changes.spChanges[command.actorId] ?? 0) - spCost;
+    out.events.push({
+      kind: 'ResourceSpent',
+      unitId: command.actorId,
+      resource: 'sp',
+      amount: spCost,
+    });
+  }
+
+  // 清除 resolution（恢复完成）
+  const cleared = { ...state, resolution: undefined };
+  const applied = applyOutcome(cleared, out);
+  const events = out.events as CombatTransition['events'];
+  return {
+    revision: applied.revision,
+    snapshot: toView(applied),
+    events,
+    terminal: applied.terminal,
+    next: applied,
+  } satisfies CombatTransition;
+}
+
+/** DeclareBlock 恢复时重建 bundle（bundle 参与 runDamagePipeline 的 skill 解析；M3 用最小闭包） */
+function bundleOf(state: CombatState): CombatDefinitionBundle {
+  // resumeBlockedAttack 只用 state.units + recompute；bundle 仅供签名，
+  // 传一个最小 bundle 保证纯函数（无副作用）可继续。
+  return {
+    combatId: state.combatId,
+    combatType: '标准',
+    participants: Object.values(state.units as never) as never,
+    resourceSnapshots: state.resourceSnapshots,
+    rulesetRevision: 'v3-m3',
+  };
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -282,6 +362,29 @@ function consumePlayerCommand(
     return { working, events: [], rejection: biz.rejection, waitForNext: false };
   }
   if (biz.requiredInput) {
+    // M3：EffectChoice（damage.preview 格挡询问）→ 冻结 ResolutionFrame（不提交半成品）
+    if (biz.requiredInput.kind === 'EffectChoice' && biz.suspended) {
+      const frozen = freezeFrame(working, {
+        commandId: command.commandId,
+        step: 'damage.preview',
+        pendingChanges: mergeChanges(slotOut.changes, biz.changes),
+        diceConsumedInFrame: {
+          attackHit: 0,
+          initiative: 0,
+          intentCheck: 0,
+          statusContest: 0,
+          procCheck: 0,
+        },
+        awaiting: biz.requiredInput,
+        recompute: biz.suspended.recompute as unknown as DamageRecomputeCtx,
+      });
+      return {
+        working: frozen,
+        events: slotOut.events,
+        requiredInput: biz.requiredInput,
+        waitForNext: false,
+      };
+    }
     return {
       working,
       events: slotOut.events,

--- a/src/sillytavern/combat-v3/state.ts
+++ b/src/sillytavern/combat-v3/state.ts
@@ -36,7 +36,11 @@ import type {
   CombatUnitState,
   CombatUnitView,
   CombatView,
+  DamageRecomputeCtx,
   PendingChangeSet,
+  RequiredInput,
+  ResolutionFrame,
+  ResolutionStep,
   TerminalReason,
 } from './types';
 import type { StatusEffect } from '../types';
@@ -282,6 +286,47 @@ export function applyPending(state: CombatState, changes: PendingChangeSet): Com
  */
 export function bumpRevision(state: CombatState): CombatState {
   return { ...state, revision: state.revision + 1 };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ResolutionFrame 冻结/恢复辅助（M3，架构 §三 3.3）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 冻结一个中断续跑帧（damage.preview 触发 RequestChoice 时，M3）。
+ *
+ * 存储：commandId / step / pendingChanges / diceConsumedInFrame / awaiting / recompute。
+ * 冻结后 dispatch 返回 RequiredInput.EffectChoice；DeclareBlock 恢复时从 frame 续跑，
+ * 不重跑前序效果、不重复消费骰子（架构 §三 3.3）。
+ *
+ * 不可变：返回新 CombatState，入参不被修改。
+ */
+export function freezeFrame(
+  state: CombatState,
+  frame: {
+    commandId: string;
+    step: ResolutionStep;
+    pendingChanges: PendingChangeSet;
+    diceConsumedInFrame: Readonly<Record<DiceChannel, number>>;
+    awaiting: RequiredInput;
+    recompute?: DamageRecomputeCtx;
+  },
+): CombatState {
+  return { ...state, resolution: frame };
+}
+
+/**
+ * 从 frame 恢复：取回 resolution 并清除（DeclareBlock 恢复后不再持有旧帧）。
+ * 返回 { frame, next }：next 是清除 resolution 后的新 CombatState（不可变）。
+ */
+export function restoreFrame(state: CombatState): {
+  frame: ResolutionFrame;
+  next: CombatState;
+} | null {
+  if (!state.resolution) return null;
+  const frame = state.resolution;
+  const { resolution: _res, ...rest } = state;
+  return { frame, next: rest as CombatState };
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/src/sillytavern/combat-v3/types.ts
+++ b/src/sillytavern/combat-v3/types.ts
@@ -623,7 +623,22 @@ export interface JournalEntry {
  */
 export type RequiredInput =
   | { kind: 'PlayerCommand'; unitId: string; unitName: string; round: number }
-  | { kind: 'EffectChoice' }
+  | {
+      kind: 'EffectChoice';
+      /** 选择 id（对应 RequestChoiceIntent.choiceId） */
+      choiceId: string;
+      /** 触发者单位（受击方，格挡方） */
+      unitId: string;
+      /** 伤害预览（格挡询问展示用） */
+      damagePreview: number;
+      /** 选项列表 */
+      options: readonly string[];
+      /** 触发者选择消耗（格挡 = 消耗 SP + 动作槽） */
+      cost?: { sp?: number; slot?: 'action' };
+      /** 若选择格挡，重算时伤害乘的因子（plan §5.4 格挡 intent batch 的 damageTaken -0.8） */
+      blockDamageFactor?: number;
+      damageTakenOverrideId?: string;
+    }
   | { kind: 'BoundedAdjudication' }
   | { kind: 'BeginOutput'; channel: DiceChannel }
   | { kind: 'CharGenRequest' };
@@ -994,7 +1009,19 @@ export type DomainEvent =
       effectDescription?: string;
     }
   | { kind: 'RuleOverridden'; ruleKey: string; payload?: unknown; divinity: number }
-  | { kind: 'EffectRejected'; automatonId?: string; window?: string; code: string; detail: string }
+  | {
+      kind: 'EffectRejected';
+      automatonId?: string;
+      /** 持有者（在场过滤溯源，架构 §6.3） */
+      owner?: string;
+      /** 触发窗口（架构 §6.3） */
+      window?: string;
+      /** rejected code 枚举（EffectRejectCode） */
+      code: string;
+      detail: string;
+      /** 被拒的 intent 列表（若有） */
+      rejectedIntents?: readonly EffectIntent[];
+    }
   | { kind: 'DiceEpochBegan'; outputId: string; batchHash?: string; channelSplit?: unknown };
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1030,16 +1057,38 @@ export type WindowKey =
 // ──────────────────────────────────────────────────────────────────────────────
 
 /**
- * 每窗口排序后的 automaton 队列（M1 恒空数组）。
- * 用于 evaluateWindow 的求值排序与在场过滤。
+ * ActiveEffectIndex 内每窗口的一条 automaton（架构 §五 5.3）。
+ * M1 只用元数据字段求值排序；M3 实装后 byWindow 直接放 CompiledAutomaton，
+ * 故 QueuedAutomaton 即 CompiledAutomaton 的别名（保留原字段名兼容 M1 调用点）。
  */
 export interface QueuedAutomaton {
+  /** 稳定 id（求值排序末位兜底） */
   id: string;
-  owner: string;
-  divinity: number;
-  priority: number;
+  name: string;
+  /** static 身份（物品/技能/套装名） */
   source: string;
+  /** 动态持有者 unitId（在场过滤） */
+  owner: string;
+  /** 登神强度 0-8（高者先） */
+  divinity: number;
+  /** 链内声明顺序 */
+  priority: number;
+  /** 订阅窗口 */
+  subscribe: WindowKey;
+  /** 字节稳定的 stable id（求值排序末位兜底，架构 §五 5.3，replay 前提） */
+  stableId: string;
+  /** charges（"X 次/战斗"） */
+  charges?: ChargeTracker;
+  /** 编译后的 trigger AST */
+  triggerAst: ExprAst;
+  /** 编译后的 intent 模板 */
+  intents: readonly EffectIntent[];
+  /** 是否为可信 TS adapter（不走 DSL 解释器） */
+  isAdapter: boolean;
 }
+
+/** 类型别名：QueuedAutomaton 即 CompiledAutomaton */
+export type CompiledAutomaton = QueuedAutomaton;
 
 /**
  * 战斗内效果索引（架构 §七 7.5）。M1 恒空，M3 由 buildIndex 派生填充。
@@ -1087,12 +1136,44 @@ export const EMPTY_EFFECT_INDEX: ActiveEffectIndex = {
 export interface ResolutionFrame {
   /** 触发中断的 Command id */
   commandId: string;
+  /**
+   * 当前微步骤标识（架构 §三 3.3 step）。M3 新增用于 damage.preview 冻结：
+   * 'damage.preview' 表示因 RequestChoice 暂停，恢复后需回到 damage.compute 重算。
+   */
+  step: ResolutionStep;
   /** 已通过验证但未提交的变更（不变量④），恢复后继续 */
   pendingChanges: PendingChangeSet;
   /** 本 frame 已消费的各通道骰数（恢复时不重复消费） */
   diceConsumedInFrame: Readonly<Record<DiceChannel, number>>;
   /** 等待的外部输入 */
   awaiting: RequiredInput;
+  /** 本 frame 待重算的伤害上下文（damage.preview → DeclareBlock 恢复重算用） */
+  recompute?: DamageRecomputeCtx;
+}
+
+/** 微步骤标识（架构 §三 3.3）——M3 只用 'damage.preview' 一个，M4 补 spawn 等 */
+export type ResolutionStep = 'damage.preview';
+
+/**
+ * damage.preview 冻结时暂存的伤害上下文，恢复后用于回到 damage.compute **重算**。
+ *
+ * 架构 §五 5.2 约束 4：格挡减伤必须在管线对应步骤重算，不是在 final 上打折。
+ * 因此 frame 需保留重算所需的全部伤害公式入参（攻击者/守方/意图/命中评级/管线步骤）。
+ */
+export interface DamageRecomputeCtx {
+  attackerId: string;
+  targetId: string;
+  /** 攻击者 ability（关联属性/技能威力/伤害类型/意图） */
+  relevantAttribute: number;
+  skillPower: number;
+  weaponAtk: number;
+  multiHitCount: number;
+  intentionCoefficient: number;
+  ratingCoefficient: number;
+  /** 恢复时注入的减伤因子（如格挡 0.2，即伤害 × 0.2 重算到 damage.compute） */
+  damageTakenFactor: number;
+  /** 额外固定伤害修正（recompute 时并入 Step 6a） */
+  fixedDamageAdjust: number;
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -1108,3 +1189,342 @@ export class KernelStuckError extends Error {
     this.name = 'KernelStuckError';
   }
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// M3 — 效果系统（架构 §五/§六/§七，plan §5）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * **窗口上下文类型映射**（架构 §七 7.3 / plan §5.2）。
+ *
+ * 每个 WindowKey 只暴露该窗口有意义的字段。plan §5.11 允许 M3 先只精细实装
+ * 5 个高频窗口（check.hit / collect_*_mods / damage.preview / damage.after /
+ * unit.beforeDown），其余窗口用**最小公共集**（UnitCtx + RoundCtx），M4 补全。
+ *
+ * 编译期用 `WindowCtxMap[subscribe]` 的键集校验 automaton 里出现的 `ctx.*` 路径根段
+ * （编译校验 #7，plan §5.5）。
+ */
+export interface UnitCtx {
+  id: string;
+  hp: number;
+  maxHp: number;
+  hpPercent: number;
+  mp: number;
+  sp: number;
+  tier: number;
+  divinity: number;
+  statuses: readonly string[];
+}
+export interface DamageCtx {
+  attackerId: string;
+  targetId: string;
+  /** Step 1 初始伤害（反射基准 R4 取此，架构 §九） */
+  preReduction: number;
+  /** 评级+意图后伤害 */
+  postStep6: number;
+  /** Step 8 最终伤害、未提交 */
+  final: number;
+  type: string;
+  rating: string | number;
+}
+export interface RoundCtx {
+  index: number;
+  phase: string;
+}
+export interface ChargeCtx {
+  remaining: number;
+}
+
+/** 5 个高频窗口的精细分型（架构 §五 5.1 / plan §5.11） */
+export interface CheckCtx {
+  self: UnitCtx;
+  target: UnitCtx;
+  round: RoundCtx;
+  charges: ChargeCtx;
+}
+export interface CollectModsCtx {
+  self: UnitCtx;
+  /** collect_defender_mods 时 target = 攻击者；collect_attacker_mods 时 target = 受击者 */
+  target: UnitCtx;
+  round: RoundCtx;
+  charges: ChargeCtx;
+}
+export interface PreviewCtx {
+  self: UnitCtx;
+  target: UnitCtx;
+  damage: DamageCtx;
+  round: RoundCtx;
+  charges: ChargeCtx;
+}
+export interface AfterCtx {
+  self: UnitCtx;
+  target: UnitCtx;
+  damage: DamageCtx;
+  round: RoundCtx;
+  depth: number;
+  charges: ChargeCtx;
+}
+export interface BeforeDownCtx {
+  self: UnitCtx;
+  damage: DamageCtx;
+  round: RoundCtx;
+  charges: ChargeCtx;
+}
+export interface InitiativeCtx {
+  self: UnitCtx;
+  round: RoundCtx;
+  charges: ChargeCtx;
+}
+
+/**
+ * 每窗口 ctx 分型映射（plan §5.2）。
+ * 未精细实装的窗口用最小公共结构（UnitCtx + RoundCtx + charges）。
+ */
+export interface WindowCtxMap {
+  'round.open': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+  'round.close': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+  'initiative.before': InitiativeCtx;
+  'initiative.after': InitiativeCtx;
+  'turn.open': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+  'turn.close': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+  'action.declared': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+  'check.intent': CheckCtx;
+  'check.hit': CheckCtx;
+  collect_attacker_mods: CollectModsCtx;
+  collect_defender_mods: CollectModsCtx;
+  'damage.preview': PreviewCtx;
+  'damage.compute': PreviewCtx;
+  'damage.after': AfterCtx;
+  'unit.beforeDown': BeforeDownCtx;
+  'morale.before': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+  'morale.after': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+  'settlement.before': { self: UnitCtx; round: RoundCtx; charges: ChargeCtx };
+}
+export type WindowCtx<K extends WindowKey> = WindowCtxMap[K];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 表达式微文法（架构 §七 7.3 / plan §5.2）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** 白名单内建函数（架构 §七 7.3 表） */
+export type BuiltinFn = 'min' | 'max' | 'floor' | 'ceil' | 'abs' | 'percent' | 'has';
+
+/** 二元运算符（文法只含比较 + 算术 + 逻辑） */
+export type BinOp = '==' | '!=' | '<' | '<=' | '>' | '>=' | '+' | '-' | '*' | '/' | '&&' | '||';
+
+/**
+ * 表达式 AST 节点（plan §5.2）。
+ * `path` 的 segments 是 `ctx` 后去掉的点分路径，如 `ctx.self.hpPercent` → ['self','hpPercent']。
+ */
+export type ExprAst =
+  | { t: 'num'; v: number }
+  | { t: 'str'; v: string }
+  | { t: 'bool'; v: boolean }
+  | { t: 'null' }
+  | { t: 'path'; segments: string[] }
+  | { t: 'call'; fn: BuiltinFn; args: ExprAst[] }
+  | { t: 'unary'; op: '-' | '!'; operand: ExprAst }
+  | { t: 'bin'; op: BinOp; l: ExprAst; r: ExprAst };
+
+/** ctx 解释值（interpreter 对 path 解析的类型化结果） */
+export type ExprValue = number | string | boolean | null | readonly string[];
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EffectIntent 八大类 + Outcome 子类（架构 §六 6.1 / 6.2）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** AddModifier 的管线槽（架构 §六 6.2） */
+export type ModifierSlot =
+  | 'fixedDamage'
+  | 'damageMult'
+  | 'damageTaken'
+  | 'hitBonus'
+  | 'dodge'
+  | 'initiative'
+  | 'dr'
+  | 'penetration'
+  | 'critThreshold'
+  | 'critDmg'
+  | 'attribute';
+
+/** AddModifier 的作用域（架构 §六 6.2：连击每发 / 整体 / 每目标） */
+export type ModifierScope = 'whole_action' | 'per_hit' | 'per_target';
+
+/** divink 差压制入参（架构 §八 8.3，statusContest） */
+export interface ContestInfo {
+  attackerDivinity: number;
+  defenderDivinity: number;
+}
+
+/** DealDamage 命中策略（架构 §六 6.2 / §九 R8） */
+export interface HitPolicy {
+  consumeDice: boolean;
+  advantage?: 'adv' | 'dis' | 'none';
+}
+
+/**
+ * EffectIntent：八大类代数（架构 §六 6.1）。
+ * volume 与数值字段可用字面量或表达式字符串（trigger 同文法，plan §5.2）。
+ */
+export type EffectIntent =
+  | {
+      kind: 'AddModifier';
+      slot: ModifierSlot;
+      value: number | string;
+      scope: ModifierScope;
+      targetId: string;
+      divinity: number;
+    }
+  | {
+      kind: 'DealDamage';
+      targetId: string;
+      amount: number | string;
+      damageType: 'physical' | 'energy' | 'mental' | 'true';
+      bypass?: ModifierSlot[];
+      isReaction?: boolean;
+      doesNotConsumeSlot?: boolean;
+      rootChainId?: string;
+      /** 反射深度：字面量或表达式串（架构 §九 R1，反伤 depth = 'ctx.depth + 1'） */
+      depth?: number | string;
+      hitPolicy?: HitPolicy;
+    }
+  | {
+      kind: 'Heal';
+      targetId: string;
+      amount: number | string;
+    }
+  | {
+      kind: 'ApplyStatus';
+      targetId: string;
+      statusId: string;
+      duration: number | null;
+      layers?: number;
+      contest?: ContestInfo;
+    }
+  | { kind: 'RemoveStatus'; targetId: string; statusId: string }
+  | {
+      kind: 'SpendResource';
+      targetId: string;
+      resource: 'hp' | 'mp' | 'sp' | 'fp';
+      amount: number;
+    }
+  | {
+      kind: 'PreventDeath';
+      targetId: string;
+      hp: number;
+      slot?: 'death.threshold';
+    }
+  | { kind: 'ConsumeCharge'; amount?: number }
+  | { kind: 'EmitNarrativeCue'; text: string; severity?: number }
+  | {
+      kind: 'OverrideIntent';
+      ruleKey: string;
+      payload: unknown;
+      divinity: number;
+    }
+  | {
+      kind: 'ScheduleIntent';
+      delay: number;
+      intent: EffectIntent;
+    }
+  | {
+      kind: 'SpawnOrDespawnIntent';
+      op: 'spawn' | 'despawn';
+      unitId: string;
+      count?: number;
+      duration?: { rounds: number };
+      joinTiming?: 'this_round_tail' | 'next_round_head';
+    }
+  | {
+      kind: 'RequestChoiceIntent';
+      choiceId: string;
+      prompt: string;
+      options: readonly string[];
+      cost?: { sp?: number; slot?: 'action' };
+      blockDamageFactor?: number;
+      damageTakenOverrideId?: string;
+    };
+
+/** EffectIntent 的 kind 枚举（8 大类，供编译校验 #3） */
+export type EffectIntentKind = EffectIntent['kind'];
+
+/** 反射/递归深度上限（架构 §九 9.1 / §五 5.4） */
+export const MAX_REFLECTION_DEPTH = 2;
+export const MAX_WINDOW_RECURSION_DEPTH = 5;
+export const MAX_AUTOMATON_PER_WINDOW = 64;
+
+/**
+ * EffectRejected 的 code 枚举（架构 §六 6.3）。
+ */
+export type EffectRejectCode =
+  | 'TARGET_ILLEGAL'
+  | 'DIVINITY_INSUFFICIENT'
+  | 'RESOURCE_INSUFFICIENT'
+  | 'CHARGE_EXHAUSTED'
+  | 'VALUE_OUT_OF_RANGE'
+  | 'INVARIANT_VIOLATION'
+  | 'UNSUPPORTED_CAPABILITY'
+  | 'EVAL_ERROR'
+  | 'BUDGET_EXCEEDED';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EffectAutomaton / CompiledAutomaton（架构 §七 7.2 / 7.4）
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** IntentTemplate：字面量 EffectIntent 或经表达式编译的 intent 模板（amount/value 可为表达式字符串） */
+export type IntentTemplate = EffectIntent;
+
+/** automaton 分次（"X 次/战斗"，架构 §七 7.2 charges） */
+export interface ChargeTracker {
+  max: number;
+  remaining: number;
+}
+
+/**
+ * EffectAutomaton —— AI 或 item_gen 产出的声明式效果（架构 §七 7.2）。
+ * DSL automaton：trigger 是表达式字符串，intents[] 是 IntentTemplate[]。
+ */
+export interface EffectAutomaton {
+  id: string;
+  name: string;
+  source: string;
+  owner: string;
+  subscribe: WindowKey;
+  trigger: string;
+  priority: number;
+  divinity: number;
+  charges?: ChargeTracker;
+  intents: readonly EffectIntent[];
+}
+
+/** StaticModifier —— modifiers[] 编译为的静态管线修正（不参与窗口，直接并入结算） */
+export interface StaticModifier {
+  slot: ModifierSlot;
+  value: number;
+  scope: ModifierScope;
+  source: string;
+  divinity: number;
+}
+
+/** 编译期错误（plan §5.5 / A3-3） */
+export interface CompileError {
+  /** automaton id；intent 级错误也归到所属 automaton */
+  automatonId: string;
+  /** 错误类别（校验 #1..#9 之一，plan §5.5） */
+  code: RejectSubCode | string;
+  /** 人类可读错误信息（触发表达式错误带列号） */
+  message: string;
+}
+
+/** 编译期剔除子码（plan §5.5 校验 #1..#8 的剔除项） */
+export type RejectSubCode =
+  | 'WINDOW_NOT_FOUND'
+  | 'TRIGGER_SYNTAX'
+  | 'INTENT_KIND_ILLEGAL'
+  | 'RULEKEY_ILLEGAL'
+  | 'DIVINITY_EXCEEDED'
+  | 'CTX_PATH_ILLEGAL'
+  | 'FIVE_DIM_STRAIGHT'
+  | 'UNSUPPORTED_CAPABILITY'
+  | 'WARN_CLAMPED'
+  | 'WARN_PREFIXED';

--- a/src/sillytavern/combat-v3/windows.test.ts
+++ b/src/sillytavern/combat-v3/windows.test.ts
@@ -1,0 +1,169 @@
+/**
+ * combat-v3/windows.test.ts — ReactionWindow evaluator 测试（M3, 验收 A3-6）
+ *
+ * 覆盖（plan §5.8 / §五 5.4）：
+ *   - 求值顺序 = window→divinity→priority→id（已由 buildIndex 排序，这里验证收集序）
+ *   - owner 离场跳过（在场过滤）
+ *   - 单个 automaton 抛错只废该批（错误隔离），不影响其他
+ *   - 超 64 个截断 + EffectRejected(BUDGET_EXCEEDED)
+ *   - charges 耗尽跳过
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateWindow, makeWindowRuntimeCtx } from './windows';
+import { buildIndex } from './automata/index-active';
+import type { CombatState, CompiledAutomaton, WindowKey } from './types';
+import { EMPTY_CHANGES } from './types';
+
+function mkAuto(id: string, partial: Partial<CompiledAutomaton> = {}): CompiledAutomaton {
+  return {
+    id,
+    name: id,
+    source: '测试',
+    owner: '理查德',
+    subscribe: 'damage.after',
+    priority: 0,
+    divinity: 0,
+    stableId: id,
+    triggerAst: { t: 'bool', v: true },
+    intents: [],
+    isAdapter: true,
+    ...partial,
+  };
+}
+
+/** 造一个含单位的最小 state（present 检查用） */
+function mkStateWith(units: string[]): CombatState {
+  return {
+    combatId: 't',
+    revision: 0,
+    phase: 'SlotConsume',
+    round: 1,
+    initiativeOrder: [],
+    currentTurnIndex: 0,
+    units: Object.fromEntries(units.map((id) => [id, { id, hp: 100, maxHp: 100 } as never])),
+    activeEffects: {
+      byWindow: {
+        'round.open': [],
+        'round.close': [],
+        'initiative.before': [],
+        'initiative.after': [],
+        'turn.open': [],
+        'turn.close': [],
+        'action.declared': [],
+        'check.intent': [],
+        'check.hit': [],
+        collect_attacker_mods: [],
+        collect_defender_mods: [],
+        'damage.preview': [],
+        'damage.compute': [],
+        'damage.after': [],
+        'unit.beforeDown': [],
+        'morale.before': [],
+        'morale.after': [],
+        'settlement.before': [],
+      },
+      byOwner: {},
+    },
+    dice: undefined as never,
+    resourceSnapshots: { FP: 0 },
+    journal: [],
+    provenance: {
+      engineVersion: 'v3',
+      schemaVersion: '1',
+      rulesetRevision: 't',
+      bundleHash: 't',
+      eventSequence: 0,
+      diceEpochs: [],
+    },
+  };
+}
+
+function rt(state: CombatState, window: WindowKey) {
+  return makeWindowRuntimeCtx(state, { round: state.round, window });
+}
+
+describe('evaluateWindow — 求值顺序（已由索引排序）', () => {
+  it('按已排序队列收集 intent（divinity 高者先）', () => {
+    const state = mkStateWith(['理查德']);
+    const idx = buildIndex([
+      mkAuto('low', {
+        subscribe: 'damage.after',
+        divinity: 1,
+        intents: [{ kind: 'EmitNarrativeCue', text: 'low' }],
+      }),
+      mkAuto('high', {
+        subscribe: 'damage.after',
+        divinity: 5,
+        intents: [{ kind: 'EmitNarrativeCue', text: 'high' }],
+      }),
+    ]);
+    const { intents } = evaluateWindow(idx, 'damage.after', rt(state, 'damage.after'));
+    expect(intents.map((x) => x.automatonId)).toEqual(['high', 'low']);
+  });
+});
+
+describe('evaluateWindow — 在场过滤（A3-7 相关）', () => {
+  it('owner 离场（present false）→ 跳过', () => {
+    const state = mkStateWith(['理查德']); // 处刑人不在场
+    const idx = buildIndex([
+      mkAuto('myself', { owner: '理查德', intents: [{ kind: 'EmitNarrativeCue', text: 'a' }] }),
+      mkAuto('gone', { owner: '处刑人', intents: [{ kind: 'EmitNarrativeCue', text: 'b' }] }),
+    ]);
+    const { intents } = evaluateWindow(idx, 'damage.after', rt(state, 'damage.after'));
+    expect(intents.map((x) => x.automatonId)).toEqual(['myself']);
+  });
+});
+
+describe('evaluateWindow — 错误隔离（§五 5.4）', () => {
+  it('单个抛错只废该批，不影响其他', () => {
+    const state = mkStateWith(['理查德']);
+    // 抛错的 automaton：trigger 引用了 undefined path → evaluate 抛 ExprEvalError
+    const bad = mkAuto('bad', {
+      triggerAst: { t: 'path', segments: ['self', 'nonexistent'] },
+      intents: [{ kind: 'EmitNarrativeCue', text: 'bad' }],
+    });
+    const ok = mkAuto('ok', { intents: [{ kind: 'EmitNarrativeCue', text: 'good' }] });
+    const idx = buildIndex([bad, ok]);
+    const { intents, rejections } = evaluateWindow(idx, 'damage.after', rt(state, 'damage.after'));
+    // ok 照常收集；bad 被 reject
+    expect(intents.map((x) => x.automatonId)).toEqual(['ok']);
+    const rej = rejections.find(
+      (r) => r.kind === 'EffectRejected' && (r as { automatonId?: string }).automatonId === 'bad',
+    );
+    expect(rej).toBeTruthy();
+    if (rej && rej.kind === 'EffectRejected') expect(rej.code).toBe('EVAL_ERROR');
+  });
+});
+
+describe('evaluateWindow — 预算 64', () => {
+  it('超过 64 截断 + EffectRejected(BUDGET_EXCEEDED)', () => {
+    const state = mkStateWith(['理查德']);
+    const many = Array.from({ length: 70 }, (_, i) =>
+      mkAuto(`m${i}`, { intents: [{ kind: 'EmitNarrativeCue', text: `m${i}` }] }),
+    );
+    const idx = buildIndex(many);
+    const { intents, rejections } = evaluateWindow(idx, 'damage.after', rt(state, 'damage.after'));
+    expect(intents.length).toBe(64);
+    expect(
+      rejections.some(
+        (r) => r.kind === 'EffectRejected' && (r as { code?: string }).code === 'BUDGET_EXCEEDED',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('evaluateWindow — charges', () => {
+  it('charges 耗尽 → 跳过', () => {
+    const state = mkStateWith(['理查德']);
+    const idx = buildIndex([
+      mkAuto('used', {
+        charges: { max: 1, remaining: 0 },
+        intents: [{ kind: 'EmitNarrativeCue', text: 'x' }],
+      }),
+      mkAuto('free', { intents: [{ kind: 'EmitNarrativeCue', text: 'y' }] }),
+    ]);
+    const { intents } = evaluateWindow(idx, 'damage.after', rt(state, 'damage.after'));
+    expect(intents.map((x) => x.automatonId)).toEqual(['free']);
+  });
+});

--- a/src/sillytavern/combat-v3/windows.ts
+++ b/src/sillytavern/combat-v3/windows.ts
@@ -1,54 +1,235 @@
 /**
- * combat-v3/windows.ts — ReactionWindow 空转版 evaluator（M1）
+ * combat-v3/windows.ts — ReactionWindow evaluator（M3 实装）
  *
  * 架构真源：docs/reference/combat-system-architecture-v3.md §五（ReactionWindow 清单）
- * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §3.2 / §3.6
+ *   - 求值顺序 §5.3：window phase → divinity → priority → stable id（索引已排序）
+ *   - 在场过滤 §5.4：automaton owner 不在 state.units 或已 defeated ⇒ 跳过
+ *   - 错误隔离 §5.4：单个 automaton 求值抛错 ⇒ 该 automaton 整批 intent 作废 + EffectRejected
+ *   - 递归保护 §5.4/§九：窗口递归 ≤5；反射深度 ≤2
+ *   - 求值预算 §5.4：单窗口 ≤64，超出截断 + EffectRejected(BUDGET_EXCEEDED)
+ * 实施计划：docs/planning/2026-07-31-combat-v3-implementation-plan.md §3.6
  *
- * M1 空转：ActiveEffectIndex 恒空（无 automaton），evaluateWindow 遍历 it 恒返回空数组。
- * 但窗口调用点全部就位——phases/round、phases/attack 等在对应结算点调用
- * evaluateWindow(key, ctx)，M3 只填索引、不用改调用点。
+ * M1 空转版签名冻结，M3 改为实装。返回 { intents, rejections }：
+ *   - intents：通过批验证的 automaton intent 聚合（phase 收集后并入管线）
+ *   - rejections：因错误隔离 / 批非法 / 预算超限产出的 EffectRejected 事件
  *
- * 求值顺序（架构 §五 5.3）M3 实装：window phase → divinity → priority → stable id。
- * 返回 intents 数组（M1 恒空）。
+ * 铁律（plan §1.3）：本文件零 Math.random / new Function / eval；纯函数 + 不可变。
  */
 
-import type { ActiveEffectIndex, WindowKey } from './types';
+import type {
+  ActiveEffectIndex,
+  CombatState,
+  CombatUnitState,
+  CompiledAutomaton,
+  DomainEvent,
+  EffectIntent,
+  EffectRejectCode,
+  QueuedAutomaton,
+  UnitCtx,
+  WindowCtx,
+  WindowKey,
+} from './types';
+import { MAX_AUTOMATON_PER_WINDOW, MAX_REFLECTION_DEPTH } from './types';
+import { evaluate, ExprEvalError } from './automata/interpreter';
+import { validateBatch } from './intents';
 
-/**
- * 窗口求值上下文（M1 空转版：由 phases 构造，ctx 可空）。
- * M3 起按窗口分型；这里给最小公共字段，避免 M3 大改调用点。
- */
-export interface WindowCtx {
-  /** 触发窗口的根本单位（攻击者 / 受击者） */
-  selfId?: string;
-  /** 目标单位（damage 类窗口） */
-  targetId?: string;
-  /** 当前回合 */
-  round?: number;
+/** 单窗口求值结果 */
+export interface WindowEvaluation {
+  /** 通过批验证的全部 automaton intent 聚合（含内部 Schedule 的展开） */
+  intents: readonly RawIntent[];
+  /** 错误隔离 / 批非法 / 预算超限产生的 EffectRejected 事件 */
+  rejections: readonly DomainEvent[];
 }
 
-/**
- * 求值一个 ReactionWindow。
- *
- * M1 恒返回空数组（无 automaton 订阅）。签名固定，M3 实装时只改内部：
- *   - 取 ActiveEffectIndex.byWindow[key]（已按 §5.3 排序）
- *   - 每个 automaton 求值 trigger → 收集 intent batch
- *   - 在场过滤 / 错误隔离 / 预算 64（§5.4）
- */
-export function evaluateWindow(
-  index: ActiveEffectIndex,
-  key: WindowKey,
-  ctx: WindowCtx,
-): readonly { automatonId: string; intents: readonly unknown[] }[] {
-  // M1 恒空：const queue = index.byWindow[key] ?? [];
-  // if (queue.length === 0) return [];
-  return [];
+/** 原始收集的 intent（带所属 automaton 元数据，供 phase 判断是谁的） */
+export interface RawIntent {
+  automatonId: string;
+  owner: string;
+  intents: readonly EffectIntent[];
+}
+
+/** 从 index 里取某窗口已按求值顺序排好序的队列 */
+export function queuedFor(index: ActiveEffectIndex, key: WindowKey): readonly QueuedAutomaton[] {
+  return index.byWindow[key] ?? [];
 }
 
 /**
  * 检查某窗口是否有订阅者（架构 §五 5.2 约束 3：无订阅者跳过，不打断节奏）。
- * M1 恒返回 false（无 automaton）。M3 实装后用于 damage.preview 等暂停判断。
+ * damage.preview 等暂停窗口借此判断要不要暂停。
  */
 export function hasSubscribers(index: ActiveEffectIndex, key: WindowKey): boolean {
   return (index.byWindow[key] ?? []).length > 0;
+}
+
+/**
+ * 窗口求值运行时上下文：窗口分型 ctx + 内核提供的状态访问器。
+ *
+ * 由调用方（phases/attack / reducer）构造，注入 resolver：
+ *   - present(unitId)：目标/持有者是否在场且未 defeated（在场过滤）
+ *   - resolveNumber(expr, fallback)：把 intent 里的表达式串解析为数字
+ *   - resolveChoice(text)：把 RequestChoiceIntent 的 prompt/选项等模板文本解析为具体值（M3 暂恒等）
+ *   - depthBase：当前窗口递归深度（反射链用）
+ */
+export interface RuntimeWindowCtx<K extends WindowKey> {
+  /** 窗口分型的语境 */
+  ctx: WindowCtx<K>;
+  present: (unitId: string) => boolean;
+  resolveNumber: (expr: string, fallback: number) => number;
+  /** 每个 automaton 是否已耗尽次数 */
+  chargesAvailable: (a: CompiledAutomaton) => boolean;
+  /** 当前递归深度（反射链；默认 0） */
+  depthBase?: number;
+  /** automaton 抛错时的兜底（把错误并入 rejections）——M3 传 reject 收集器 */
+  onError?: (a: CompiledAutomaton, err: unknown) => DomainEvent;
+}
+
+/**
+ * 求值一个 ReactionWindow（M3 实装）。
+ *
+ * 对窗口内每条 automaton（已按 §5.3 排序）：
+ *   1. 在场过滤：owner 不在场/defeated ⇒ 跳过
+ *   2. charges 耗尽 ⇒ 跳过
+ *   3. 求值 trigger（evaluate triggerAst）——抛错 ⇒ 整批作废 + EffectRejected
+ *   4. trigger 为真 ⇒ 对 intent batch validateBatch：
+ *        - 非法 ⇒ 整批 reject + EffectRejected（A3-7）
+ *        - 合法 ⇒ applyIntents 收集到返回集
+ *   5. 错误隔离：单个 automaton 抛错不影响其他
+ *   6. 预算 64：超过按求值顺序截断 + EffectRejected(BUDGET_EXCEEDED)
+ */
+export function evaluateWindow<K extends WindowKey>(
+  index: ActiveEffectIndex,
+  key: WindowKey,
+  rt: RuntimeWindowCtx<K>,
+): WindowEvaluation {
+  const queue = index.byWindow[key] ?? [];
+  const intents: RawIntent[] = [];
+  const rejections: DomainEvent[] = [];
+
+  // 预算（架构 §五 5.4）：单窗口 ≤64；超出按求值顺序截断
+  const budgetCap = MAX_AUTOMATON_PER_WINDOW;
+  let budgetRejected = false;
+
+  for (let i = 0; i < queue.length; i++) {
+    const a = queue[i];
+    // 预算：前 64 条照常求值，第 65 条起截断 + EffectRejected(BUDGET_EXCEEDED)
+    if (i >= budgetCap) {
+      if (!budgetRejected) {
+        rejections.push(
+          makeReject(a, 'BUDGET_EXCEEDED', `窗口预算 ${budgetCap} 已耗尽，本 automaton 被截断`),
+        );
+        budgetRejected = true;
+      }
+      continue;
+    }
+
+    // 在场过滤（架构 §五 5.4）：owner 不在场/defeated ⇒ 跳过
+    if (!rt.present(a.owner)) continue;
+    // charges 耗尽
+    if (a.charges && !rt.chargesAvailable(a)) continue;
+
+    // trigger 求值（抛错 ⇒ 错误隔离）
+    let condition: boolean;
+    try {
+      condition = evaluate(a.triggerAst, rt.ctx as WindowCtx<WindowKey>) ? true : false;
+    } catch (e) {
+      rejections.push(makeReject(a, 'EVAL_ERROR', e instanceof Error ? e.message : String(e)));
+      continue;
+    }
+    if (!condition) continue;
+
+    // intent batch 原子性（A3-7）
+    const v = validateBatch(a.intents);
+    if (!v.ok) {
+      rejections.push(makeReject(a, v.code, v.detail));
+      continue;
+    }
+
+    intents.push({ automatonId: a.id, owner: a.owner, intents: v.intents });
+  }
+
+  return { intents, rejections };
+}
+
+/** 构造一条 EffectRejected 事件 */
+function makeReject(a: QueuedAutomaton, code: EffectRejectCode, detail: string): DomainEvent {
+  return {
+    kind: 'EffectRejected',
+    automatonId: a.id,
+    window: a.subscribe,
+    owner: a.owner,
+    code,
+    detail,
+  } as DomainEvent;
+}
+
+/**
+ * 从 CombatState + 触发来源构造一个最小 RuntimeWindowCtx（供 phases 调用 evaluateWindow）。
+ *
+ * 这是 M1「窗口调用点全部就位」的适配层：phases 只需传 selfId / targetId / round，
+ * 本函数负责构建窗口分型的 ctx + 注入 state 访问器（present / charges / resolveNumber）。
+ *
+ * 表达式解析：intent 里的 `ctx.xxx` 字符串在 M3 尚未全量求值（damage.preview 除外），
+ * 这里 resolveNumber 对数字字面量返回自身，对非数字立即返回 fallback（保守，不抛）。
+ */
+export function makeWindowRuntimeCtx(
+  state: CombatState,
+  opts: { selfId?: string; targetId?: string; round: number; window: WindowKey },
+): RuntimeWindowCtx<WindowKey> {
+  const selfU = opts.selfId ? state.units[opts.selfId] : undefined;
+  const targetU = opts.targetId ? state.units[opts.targetId] : undefined;
+
+  const unitCtx = (u: CombatUnitState | undefined, fallbackId: string): UnitCtx => ({
+    id: u?.id ?? fallbackId,
+    hp: u?.hp ?? 0,
+    maxHp: u?.maxHp ?? 0,
+    hpPercent: u && u.maxHp > 0 ? u.hp / u.maxHp : 0,
+    mp: u?.mp ?? 0,
+    sp: u?.sp ?? 0,
+    tier: u?.tier ?? 1,
+    divinity: u?.ability?.divinity ?? 0,
+    statuses: (u?.statusEffects ?? []).map((s) => s.name),
+  });
+
+  const self = unitCtx(selfU, opts.selfId ?? '');
+  const target = unitCtx(targetU, opts.targetId ?? '');
+  const round = { index: state.round, phase: state.phase };
+
+  const base: WindowCtx<WindowKey> = {
+    self,
+    target,
+    round,
+    depth: 0,
+    charges: { remaining: 0 },
+    damage: {
+      attackerId: opts.selfId ?? '',
+      targetId: opts.targetId ?? '',
+      preReduction: 0,
+      postStep6: 0,
+      final: 0,
+      type: '物理',
+      rating: '有效',
+    },
+  } as WindowCtx<WindowKey>;
+
+  return {
+    ctx: base,
+    present: (unitId) => {
+      const u = state.units[unitId];
+      return !!u && u.hp > 0;
+    },
+    resolveNumber: (expr, fallback) => {
+      const n = Number(expr);
+      return Number.isFinite(n) ? n : fallback;
+    },
+    chargesAvailable: (a) => !a.charges || a.charges.remaining > 0,
+    depthBase: 0,
+  };
+}
+
+/** 反射深度 > MAX → 该 automaton 的反伤不再触发（架构 §九 R6） */
+export function reflectionDepthAt(depthBase: number | undefined): number {
+  return depthBase ?? 0;
+}
+export function reflectionExhausted(depth: number): boolean {
+  return depth >= MAX_REFLECTION_DEPTH;
 }


### PR DESCRIPTION
## 战斗 v3 M3 — 效果系统

把「效果」从 v2 的任意 JS 脚本（`new Function` 执行）翻转为**声明式 automaton + 封闭微文法表达式**。**战斗内全链路零 `new Function` / `eval`**（C1 战斗内消解）。

### 交付物

| 文件 | 职责 |
|------|------|
| `automata/parser.ts` | 递归下降 parser + `ExprSyntaxError` 带列号 + 白名单外 token 词法期拒绝（A3-1） |
| `automata/interpreter.ts` | 零 eval AST 解释器 + `ExprEvalError` 错误隔离（A3-2） |
| `automata/compile.ts` | 三来源编译链 + 9 条编译期校验（A3-3） |
| `automata/builtins.ts` | 15 条内建映射（M-6 守方百分比修复） |
| `automata/index-active.ts` | buildIndex/updateIndex 排序 + 离场移除 |
| `automata/reflection.ts` | 反射专项 R4 preReduction / R6 depth=2 熔断 / R7 不放大 |
| `intents.ts` | validateBatch 批原子性（A3-7）+ applyIntents |
| `windows.ts` | 空转→实装（求值排序/在场过滤/错误隔离/预算 64） |
| `phases/attack.ts` + `reducer.ts` | damage.preview RequestChoice 冻结 frame + DeclareBlock 恢复重算（A3-5/A3-6） |
| `combat-item-validator.ts` | 新增 V3 共享常量，v2 运行时入口保留 |

### 验收断言（A3-1 ~ A3-8）

- [x] A3-1 parser 非法输入带列号，白名单外 token 拒绝
- [x] A3-2 evaluate 零 eval（no-nondeterminism 仍绿）
- [x] A3-3 编译期剔除不合规 automaton + errors[]
- [x] A3-4 modifier push-handler（ADR-29）
- [x] A3-5 damage.preview 全流程：RequestChoice → DeclareBlock → 重算 487→97
- [x] A3-6 无订阅者不暂停
- [x] A3-7 intent batch 原子性整批 reject
- [x] A3-8 第 24 场反伤 depth=2 熔断 + 湮灭

### 质量门

- `npm run test -- --run`: **5166 tests / 166 files 全绿**（combat-v3 新增 214）
- `npm run typecheck`: 0 错误
- `npx eslint`: 0 error

### 文档

- AGENTS.md 进度表：战斗 v3 → M3 完成 待 M3.5
- CHANGELOG 追加 M3 条目