### PR TITLE
fix(char-gen): 删掉形状不符的 chat 回退路径 —— CharGenClient 收窄为纯 Agentic

### DIFF
--- a/src/sillytavern/char-gen-agent.test.ts
+++ b/src/sillytavern/char-gen-agent.test.ts
@@ -136,20 +136,43 @@ function makeItemGenOutput(overrides: Partial<ItemGenOutput> = {}): ItemGenOutpu
   };
 }
 
+/**
+ * 不调工具、一轮返回最终输出的 CharGenClient。
+ *
+ * 🔴 只 mock `chatWithTools` —— `CharGenClient` 已不再有 `chat`（2026-08-04）：
+ *   本链在生产里恒定走 Agentic 路径，那条曾经的 `client.chat(messages)` 回退路
+ *   签名与 `AgentClient.chat(request: ChatRequest)` 不符（数组当 request 传，
+ *   `request.messages` 恒 undefined），且永不执行。mock 若还留 `chat`，等于在测试里
+ *   养一条生产没有的路径。
+ */
 function makeMockClient(
   response: string | object,
   overrides: Partial<CharGenClient> = {},
 ): CharGenClient {
   const rawResponse = typeof response === 'string' ? response : JSON.stringify(response);
   return {
-    chat: vi.fn().mockResolvedValue({
-      output: typeof response === 'string' ? response : JSON.stringify(response),
+    chatWithTools: vi.fn().mockResolvedValue({
+      output: rawResponse,
       rawResponse,
       tokensUsed: 500,
       cacheHit: false,
       duration: 1000,
     }),
     ...overrides,
+  };
+}
+
+/** 只产错误结果的 client（错误分支专用） */
+function makeErrorClient(error: string): CharGenClient {
+  return {
+    chatWithTools: vi.fn().mockResolvedValue({
+      output: null,
+      rawResponse: '',
+      tokensUsed: 0,
+      cacheHit: false,
+      duration: 100,
+      error,
+    }),
   };
 }
 
@@ -540,21 +563,30 @@ describe('callCharGenAgent', () => {
     expect(result.name).toBe('艾琳');
     expect(result.race).toBe('精灵');
     expect(result.attributes.str).toBe(4);
-    expect(mockClient.chat).toHaveBeenCalledTimes(1);
+    expect(mockClient.chatWithTools).toHaveBeenCalledTimes(1);
+  });
+
+  // 🔴 回归钉子（2026-08-04）：送进 client 的必须是 `{ messages, tools, tool_choice }`
+  //   形状的 **request 对象**、且 messages 非空。此前本链另有一条 `client.chat(messages)`
+  //   回退路径把**数组本身**当 request 传，`AgentClient` 那边 `request.messages` 读出 undefined。
+  //   回退路径已删，这条断言钉住剩下的唯一路径别再退化成"发一次没有任何消息的请求"。
+  it('送出的 request 必须带非空 messages（而非把数组当 request 传）', async () => {
+    const mockClient = makeMockClient(makeCharGenOutput());
+    await callCharGenAgent(makeRequest(), makeDeps(mockClient));
+
+    const [sentRequest] = (mockClient.chatWithTools as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(Array.isArray(sentRequest)).toBe(false);
+    expect(Array.isArray(sentRequest.messages)).toBe(true);
+    expect(sentRequest.messages.length).toBeGreaterThan(0);
+    for (const m of sentRequest.messages) {
+      expect(typeof m.role).toBe('string');
+      expect(typeof m.content).toBe('string');
+    }
+    expect(sentRequest.tool_choice).toBe('auto');
   });
 
   it('API 返回错误时应抛出异常', async () => {
-    const mockClient: CharGenClient = {
-      chat: vi.fn().mockResolvedValue({
-        output: null,
-        rawResponse: '',
-        tokensUsed: 0,
-        cacheHit: false,
-        duration: 100,
-        error: 'Network error',
-      }),
-    };
-    const deps = makeDeps(mockClient);
+    const deps = makeDeps(makeErrorClient('Network error'));
 
     await expect(callCharGenAgent(makeRequest(), deps)).rejects.toThrow('char_gen Agent 调用失败');
   });
@@ -591,21 +623,22 @@ describe('callItemGenAgent', () => {
     expect(result.skills).toHaveLength(1);
     expect(result.equipment).toHaveLength(1);
     expect(result.inventory).toHaveLength(1);
-    expect(mockClient.chat).toHaveBeenCalledTimes(1);
+    expect(mockClient.chatWithTools).toHaveBeenCalledTimes(1);
+  });
+
+  // 同 callCharGenAgent 的回归钉子 —— item_gen 侧也删过一条形状不符的 chat 回退路径
+  it('送出的 request 必须带非空 messages（而非把数组当 request 传）', async () => {
+    const mockClient = makeMockClient(makeItemGenOutput());
+    await callItemGenAgent(makeCharGenOutput(), makeRequest(), makeDeps(mockClient));
+
+    const [sentRequest] = (mockClient.chatWithTools as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(Array.isArray(sentRequest)).toBe(false);
+    expect(Array.isArray(sentRequest.messages)).toBe(true);
+    expect(sentRequest.messages.length).toBeGreaterThan(0);
   });
 
   it('API 错误时应返回空物品数据 (不阻断流程)', async () => {
-    const mockClient: CharGenClient = {
-      chat: vi.fn().mockResolvedValue({
-        output: null,
-        rawResponse: '',
-        tokensUsed: 0,
-        cacheHit: false,
-        duration: 100,
-        error: 'Timeout',
-      }),
-    };
-    const deps = makeDeps(mockClient);
+    const deps = makeDeps(makeErrorClient('Timeout'));
 
     const result = await callItemGenAgent(makeCharGenOutput(), makeRequest(), deps);
     expect(result.skills).toHaveLength(0);
@@ -638,8 +671,8 @@ describe('runCharGenChain', () => {
     expect(result.patches).toBeDefined();
     expect(result.patches.length).toBeGreaterThan(0);
     expect(result.narrativeSummary).toContain('艾琳');
-    expect(charClient.chat).toHaveBeenCalledTimes(1);
-    expect(itemClient.chat).toHaveBeenCalledTimes(1);
+    expect(charClient.chatWithTools).toHaveBeenCalledTimes(1);
+    expect(itemClient.chatWithTools).toHaveBeenCalledTimes(1);
   });
 
   it('应可选地调用 stateManager.commitChatState', async () => {
@@ -704,8 +737,8 @@ describe('runCharGenForCombat', () => {
     // 产出 SummonedUnitDefinition
     expect(def).toBeDefined();
     expect(def.name).toBe('艾琳');
-    expect(charClient.chat).toHaveBeenCalledTimes(1);
-    expect(itemClient.chat).toHaveBeenCalledTimes(1);
+    expect(charClient.chatWithTools).toHaveBeenCalledTimes(1);
+    expect(itemClient.chatWithTools).toHaveBeenCalledTimes(1);
   });
 
   it('返回的 definition 字段齐全（参战时机/持续/预算）', async () => {
@@ -800,13 +833,6 @@ function makeAgenticMockClient(
   finalOutput: string,
 ): CharGenClient {
   return {
-    chat: vi.fn().mockResolvedValue({
-      output: 'mock chat response',
-      rawResponse: 'mock chat response',
-      tokensUsed: 0,
-      cacheHit: false,
-      duration: 0,
-    }),
     chatWithTools: vi.fn().mockImplementation(async (request, toolExecutor, _options) => {
       const conversation = [...request.messages];
 
@@ -941,37 +967,14 @@ describe('callCharGenAgent (Agentic 路径)', () => {
   });
 
   it('Agentic 路径失败应抛出异常', async () => {
-    const mockClient: CharGenClient = {
-      chat: vi.fn().mockResolvedValue({
-        output: 'mock chat response',
-        rawResponse: 'mock chat response',
-        tokensUsed: 0,
-        cacheHit: false,
-        duration: 0,
-      }),
-      chatWithTools: vi.fn().mockResolvedValue({
-        output: null,
-        rawResponse: '',
-        tokensUsed: 0,
-        cacheHit: false,
-        duration: 100,
-        error: 'API timeout',
-      }),
-    };
-    const deps = makeDeps(mockClient);
+    const deps = makeDeps(makeErrorClient('API timeout'));
 
     await expect(callCharGenAgent(makeRequest(), deps)).rejects.toThrow('char_gen Agent 调用失败');
   });
 
-  it('应回退到旧路径 (无 chatWithTools 时)', async () => {
-    // makeMockClient 只提供 chat，不提供 chatWithTools → 应走旧路径
-    const mockClient = makeMockClient(makeCharGenOutput());
-    const deps = makeDeps(mockClient);
-
-    const result = await callCharGenAgent(makeRequest(), deps);
-    expect(result.name).toBe('艾琳');
-    expect(mockClient.chat).toHaveBeenCalledTimes(1);
-  });
+  // 🪦 '应回退到旧路径 (无 chatWithTools 时)' 已删（2026-08-04）：那条回退路在生产不可达
+  //    （唯一的 clientFactory 恒定带 chatWithTools），且签名与 AgentClient.chat 不符。
+  //    `chatWithTools` 现为 CharGenClient 必填项 —— 缺失是编译错误，不再需要运行时用例。
 });
 
 // ── Agentic callItemGenAgent 测试 ──
@@ -1019,24 +1022,7 @@ describe('callItemGenAgent (Agentic 路径)', () => {
   });
 
   it('Agentic 路径失败应返回空物品（不阻断流程）', async () => {
-    const mockClient: CharGenClient = {
-      chat: vi.fn().mockResolvedValue({
-        output: 'mock chat response',
-        rawResponse: 'mock chat response',
-        tokensUsed: 0,
-        cacheHit: false,
-        duration: 0,
-      }),
-      chatWithTools: vi.fn().mockResolvedValue({
-        output: null,
-        rawResponse: '',
-        tokensUsed: 0,
-        cacheHit: false,
-        duration: 100,
-        error: 'Timeout',
-      }),
-    };
-    const deps = makeDeps(mockClient);
+    const deps = makeDeps(makeErrorClient('Timeout'));
 
     const result = await callItemGenAgent(makeCharGenOutput(), makeRequest(), deps);
     expect(result.skills).toHaveLength(0);

--- a/src/sillytavern/char-gen-agent.ts
+++ b/src/sillytavern/char-gen-agent.ts
@@ -90,19 +90,25 @@ export interface CharGenAgentDeps {
 /**
  * CharGen 客户端接口 — 抽象的 API 调用层。
  * 生产环境使用 AgentClient，测试使用 mock。
+ *
+ * 🔴 2026-08-04: `chatWithTools` 是**必填**，且本接口不再声明 `chat`。
+ *   此前 `chatWithTools` 可选 + 一条 `client.chat(messages)` 回退路径，而回退路径
+ *   声明的是 `chat(messages: Array<…>)`、真正的 `AgentClient.chat` 收的是
+ *   `chat(request: ChatRequest)`（messages 在 request 里）—— 形状不符，走上去
+ *   `request.messages` 是 undefined，`ensureUserMessage` 读 `.length` 抛 TypeError，
+ *   被 chat 的重试循环吞成 `{ error }`，最终报成一句和真因无关的「char_gen Agent 调用失败」。
+ *
+ *   那条路在生产里**不可达**：唯一的 clientFactory 是 `GamePipeline.getClientFactory()`，
+ *   它返回的包装对象恒定带 `chatWithTools`（内部委托 `AgentClient.chatWithTools`，
+ *   是类方法、不是可选属性），也没有任何开关能摘掉它 —— `AgentConfig.toolsEnabled`
+ *   是 orchestrator 的概念，本链自带 clientFactory、根本不读它。
+ *
+ *   所以不修签名而是**删接口**：把 `chatWithTools` 提成必填，未来任何新 client
+ *   少实现它当场编译不过，不必再靠一条永不执行的回退路径兜底。
  */
 export interface CharGenClient {
-  chat(messages: Array<{ role: string; content: string }>): Promise<{
-    output: string | null;
-    rawResponse: string;
-    tokensUsed: number;
-    cacheHit: boolean;
-    duration: number;
-    error?: string;
-  }>;
-
-  /** 🆕 Phase 8.5 Agentic: 多轮 function calling 路径 */
-  chatWithTools?: (
+  /** Phase 8.5 Agentic: 多轮 function calling —— 本链唯一的调用路径 */
+  chatWithTools: (
     request: {
       messages: Array<{ role: string; content: string }>;
       tools: ToolDefinition[];
@@ -205,42 +211,28 @@ export async function callCharGenAgent(
 
   const client = deps.clientFactory('char_gen', request.endpoint, request.saveId);
 
-  // 🆕 Phase 8.5: 优先走 Agentic 路径（function calling 多轮循环）
-  if (client.chatWithTools) {
-    const tools = getToolsForAgent('char_gen');
-    const toolContext: ToolExecutionContext = {
-      characters: request.context.characters ?? [],
-      variables: request.context.variables ?? {},
-      saveId: request.saveId,
-    };
+  // Phase 8.5 Agentic 路径（function calling 多轮循环）—— 唯一路径，见 CharGenClient 注释
+  const tools = getToolsForAgent('char_gen');
+  const toolContext: ToolExecutionContext = {
+    characters: request.context.characters ?? [],
+    variables: request.context.variables ?? {},
+    saveId: request.saveId,
+  };
 
-    const result = await client.chatWithTools(
-      { messages, tools, tool_choice: 'auto' },
-      async (name, args) => executeToolCall(name, args, toolContext),
-      { maxRounds: 10 },
-    );
-
-    if (result.error) {
-      throw new Error(`char_gen Agent 调用失败: ${result.error}`);
-    }
-
-    const rawOutput = result.output ?? result.rawResponse;
-    const parsed = parseCharGenOutput(rawOutput);
-    parsed.rawXml = rawOutput;
-    return parsed;
-  }
-
-  // 回退: 旧路径（无工具，直接 chat）
-  const result = await client.chat(messages);
+  const result = await client.chatWithTools(
+    { messages, tools, tool_choice: 'auto' },
+    async (name, args) => executeToolCall(name, args, toolContext),
+    { maxRounds: 10 },
+  );
 
   if (result.error) {
     throw new Error(`char_gen Agent 调用失败: ${result.error}`);
   }
 
   const rawOutput = result.output ?? result.rawResponse;
-  const fallbackParsed = parseCharGenOutput(rawOutput);
-  fallbackParsed.rawXml = rawOutput;
-  return fallbackParsed;
+  const parsed = parseCharGenOutput(rawOutput);
+  parsed.rawXml = rawOutput;
+  return parsed;
 }
 
 /**
@@ -293,32 +285,19 @@ export async function callItemGenAgent(
 
   const client = deps.clientFactory('item_gen', request.endpoint, request.saveId);
 
-  // 🆕 Phase 8.5: 优先走 Agentic 路径（function calling 多轮循环）
-  if (client.chatWithTools) {
-    const tools = getToolsForAgent('item_gen');
-    const toolContext: ToolExecutionContext = {
-      characters: request.context.characters ?? [],
-      variables: request.context.variables ?? {},
-      saveId: request.saveId,
-    };
+  // Phase 8.5 Agentic 路径（function calling 多轮循环）—— 唯一路径，见 CharGenClient 注释
+  const tools = getToolsForAgent('item_gen');
+  const toolContext: ToolExecutionContext = {
+    characters: request.context.characters ?? [],
+    variables: request.context.variables ?? {},
+    saveId: request.saveId,
+  };
 
-    const result = await client.chatWithTools(
-      { messages, tools, tool_choice: 'auto' },
-      async (name, args) => executeToolCall(name, args, toolContext),
-      { maxRounds: 10 },
-    );
-
-    if (result.error) {
-      // item_gen 失败不阻断流程 — 返回空物品数据
-      return { skills: [], equipment: [], inventory: [] };
-    }
-
-    const rawOutput = result.output ?? result.rawResponse;
-    return parseItemGenOutput(rawOutput);
-  }
-
-  // 回退: 旧路径（无工具，直接 chat）
-  const result = await client.chat(messages);
+  const result = await client.chatWithTools(
+    { messages, tools, tool_choice: 'auto' },
+    async (name, args) => executeToolCall(name, args, toolContext),
+    { maxRounds: 10 },
+  );
 
   if (result.error) {
     // item_gen 失败不阻断流程 — 返回空物品数据


### PR DESCRIPTION
## 背景

`CharGenClient.chat` 声明为 `chat(messages: Array<…>)`，而真正的 `AgentClient.chat` 收的是 `chat(request: ChatRequest)`（`messages` 在 `request` 里）。走上这条回退路时数组被当成 `request`，`request.messages` 读出 `undefined`，`ensureUserMessage` 读 `.length` 抛 TypeError，被 `chat()` 的重试循环吞成 `{ error }`，最终报成一句和真因无关的「char_gen Agent 调用失败」。

由实施图像生成 v1（`txt-2-img-v1`）时的子 agent 顺手发现，与图像功能无关。

## 可达性结论：不可达

生产里 `CharGenAgentDeps.clientFactory` 只有一个来源 —— `GamePipeline.getClientFactory()`（`src/ui/lib/game-pipeline.ts:780`）。它返回的 LogClient 包装对象**无条件**带 `chatWithTools`（`:869`），内部委托 `AgentClient.chatWithTools`，那是类方法而非可选属性。四个生产调用点（`1395` / `1490` / `1531` / `1608`）与 `combat-v3` 的 `runCharGenForCombat`（`coordinator.ts:393` 把同一个工厂 `as never` 转过去）全走这一个工厂。

也没有开关能摘掉它：`AgentConfig.toolsEnabled` 是 orchestrator 的概念（`agent-orchestrator.ts:410`），char_gen 链自带 clientFactory、根本不读它。

## 改动

因为不可达，选择**删接口**而非修签名：

- `CharGenClient` 去掉 `chat`，`chatWithTools` 由可选提成**必填** —— 未来任何新 client 少实现它是编译错误，不必再靠一条永不执行的路兜底
- `callCharGenAgent` / `callItemGenAgent` 删掉两段 `if (client.chatWithTools) { … } // 回退` 分支
- 接口上留注释记录为什么不可达、为什么删而不是改签名

测试侧：

- `makeMockClient` 改为只 mock `chatWithTools`（留着 `chat` 等于在测试里养一条生产没有的路）
- 新增 `makeErrorClient` 收拢四处重复的错误 mock
- 删掉 `'应回退到旧路径 (无 chatWithTools 时)'` 并留墓碑注释
- **新增两条回归钉子**（char_gen + item_gen）：断言送进 client 的是 `{ messages, tools, tool_choice }` 形状的 request 对象、`Array.isArray(sentRequest) === false`、`messages` 非空且每条有 `role`/`content`。数组当 request 传的话第一条断言就红

## 验证

- `npm run typecheck` — 零错误
- `npm test -- --run` — **218 test files / 5935 passed / 4 skipped**，全绿
- 两个改动文件已跑 Prettier，`git diff --numstat` 确认是真改动不是行尾

## 未处理（同形状缺陷）

同一份逐字拷贝的接口还在两处，本次刻意未动：

- `ItemGenChainClient`（`src/sillytavern/item-gen-chain.ts:78`），回退在 `:265`
- `CraftGenClient`（`src/sillytavern/craft-gen-chain.ts:90`），回退在 `:212` 与 `:334`

两者用的是同一个 `getClientFactory()`，所以同样不可达、同样形状不符。

🤖 Generated with [Claude Code](https://claude.com/claude-code)