### PR TITLE
fix(embedding): 默认 embedding 模型名更正 —— Qwen3-VL-Embedding-8B → Qwen3-Embedding-8B

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npm run dev
 
 - Endpoint：`https://api.siliconflow.cn/v1`
 - API Key：在[硅基流动](https://cloud.siliconflow.cn/)注册后获取
-- 默认模型：`Qwen/Qwen3-VL-Embedding-8B`
+- 默认模型：`Qwen/Qwen3-Embedding-8B`
 
 每个创建后点「**连接测试**」确认通过。配完 API 列表应有 **3 个**。
 

--- a/docs/phases/phase4_plan.md
+++ b/docs/phases/phase4_plan.md
@@ -12,7 +12,7 @@
 
 - ❌ 废弃：code 层关键词粗筛 → Agent 精选
 - ✅ 新方案：Embedding 向量相似度检索
-  - 候选模型：Qwen/Qwen3-VL-Embedding-8B（或其他 OpenAI 兼容 embedding 端点）
+  - 候选模型：Qwen/Qwen3-Embedding-8B（或其他 OpenAI 兼容 embedding 端点）
   - 存入记忆时计算 embedding，召回时用余弦相似度排序
   - 配置每轮最大返回条数（如 20 条），即使有 2000 条记忆上下文也不爆炸
 

--- a/src/sillytavern/database.ts
+++ b/src/sillytavern/database.ts
@@ -285,7 +285,7 @@ class AppDatabase extends Dexie {
             s.plotSettings = DEFAULT_PLOT_SETTINGS;
           }
           if (s.embeddingEndpointId === undefined) s.embeddingEndpointId = null;
-          if (s.embeddingModel === undefined) s.embeddingModel = 'Qwen/Qwen3-VL-Embedding-8B';
+          if (s.embeddingModel === undefined) s.embeddingModel = 'Qwen/Qwen3-Embedding-8B';
           if (s.embeddingDimension === undefined) s.embeddingDimension = 4096;
           if (s.memoryCompressionThreshold === undefined) s.memoryCompressionThreshold = 100;
           // Fix: maxMemoriesRecall 默认改为 20

--- a/src/sillytavern/types.ts
+++ b/src/sillytavern/types.ts
@@ -634,7 +634,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   // Phase 4 新增
   plotSettings: DEFAULT_PLOT_SETTINGS,
   embeddingEndpointId: null,
-  embeddingModel: 'Qwen/Qwen3-VL-Embedding-8B',
+  embeddingModel: 'Qwen/Qwen3-Embedding-8B',
   embeddingDimension: 4096,
   memoryCompressionThreshold: 100,
   /** Phase 7e: 输出美化 */

--- a/src/ui/components/settings/ApiSection.vue
+++ b/src/ui/components/settings/ApiSection.vue
@@ -287,7 +287,7 @@ async function deleteApi(id: string) {
       </p>
       <p class="text-sm text-muted" style="margin: 0">
         Embedding 模型：推荐 <strong>硅基流动 (SiliconFlow)</strong> 的
-        <strong>Qwen3-VL-Embedding-8B</strong>，充个五块钱能玩到天荒地老。
+        <strong>Qwen3-Embedding-8B</strong>，充个五块钱能玩到天荒地老。
       </p>
     </AppCard>
 


### PR DESCRIPTION
## 背景

主人发现项目里默认 embedding 模型名字写错了：文本 embedding 根本不需要 **VL（视觉语言）** 变体，原名字 `Qwen3-VL-Embedding-8B` 会误导跟着配的用户。

## 更正

`Qwen/Qwen3-VL-Embedding-8B` → `Qwen/Qwen3-Embedding-8B`（5 处）

| 位置 | 类型 |
| --- | --- |
| `README.md` | 文档（用户最先看到的配 API 教程） |
| `docs/phases/phase4_plan.md` | 设计文档 |
| `src/sillytavern/types.ts` | `DEFAULT_SETTINGS.embeddingModel` 默认值 |
| `src/sillytavern/database.ts` | 迁移兜底默认值（仅 `undefined` 时填，不动已配置用户） |
| `src/ui/components/settings/ApiSection.vue` | 设置页「模型推荐」文案 |

## 不动的

- `tests/realtime_export/*.json`：历史 debug 导出快照，录制的是当时真实配置，改了等于篡改历史记录；且不面向用户不会误导人。
- 已配置过 embedding 的老用户：迁移只在 `embeddingModel === undefined` 时填默认值，不会覆盖用户已设的值。

## 影响

仅改默认值 + 文案。typecheck 过，无测试断言这个字符串。