### PR TITLE
feat(agent): 提示词更新中心 —— 默认更新后存量配置可见可同步

### DIFF
--- a/src/ui/components/settings/SettingsPage.vue
+++ b/src/ui/components/settings/SettingsPage.vue
@@ -18,6 +18,7 @@ import { getAgentSettings } from '../../stores/agent-settings';
 import { useWorldBookStore } from '../../stores/worldbook-store';
 import AppButton from '../shared/AppButton.vue';
 import AgentSection from './agent/AgentSection.vue';
+import AgentUpdateCenter from './agent/AgentUpdateCenter.vue';
 import { AGENT_LIST } from './agent/agent-list';
 import ApiSection from './ApiSection.vue';
 import WorldBookSection from './WorldBookSection.vue';
@@ -187,12 +188,15 @@ onMounted(() => {
 
             <!-- Agent 未选择时的提示 -->
             <section v-if="activeSection === 'agent' && !activeAgent" class="section centered">
-              <div style="text-align: center; padding: 60px 0">
+              <div style="text-align: center; padding: 60px 0 24px">
                 <p class="text-muted" style="font-size: 1.1rem">← 请从左侧选择一个 Agent</p>
                 <p class="text-sm text-muted" style="margin-top: 8px">
                   每个 Agent 需要单独配置模型和世界书上下文
                 </p>
               </div>
+              <!-- 提示词更新中心：项目默认更新后，用户存量配置不会自动跟新（fillMissing
+                   只填空位），这里给一个一键同步的入口。没有更新时组件自己不渲染。 -->
+              <AgentUpdateCenter />
             </section>
 
             <!-- ========== 世界书 (Phase 8) ========== -->

--- a/src/ui/components/settings/agent/AgentConfigPanel.test.ts
+++ b/src/ui/components/settings/agent/AgentConfigPanel.test.ts
@@ -136,7 +136,7 @@ describe('AgentConfigPanel —— 分叉与动作栏', () => {
     };
 
     const w = mountPanel('char_gen');
-    // 动作栏顺序：保存为默认 / 恢复默认 / 保存设置
+    // 动作栏顺序：保存为默认 / 恢复成最新 / 保存设置
     await w.findAllComponents(AppButton)[2].vm.$emit('click');
 
     const saved = getAgentSettings(mockSettings, 'char_gen');

--- a/src/ui/components/settings/agent/AgentConfigPanel.vue
+++ b/src/ui/components/settings/agent/AgentConfigPanel.vue
@@ -34,6 +34,7 @@ import { useSettingsStore, type PresetItem } from '../../../stores/settings-stor
 import { useUIStore } from '../../../stores/ui-store';
 import {
   AGENT_SETTINGS_DEFAULTS,
+  applyProjectDefaultToAgent,
   getAgentSettings,
   patchAgentSettings,
   resetAgentSettings,
@@ -150,12 +151,8 @@ async function restoreAgentDefaults() {
   // 优先查项目默认
   const pd = cfg.projectAgentDefaults?.agents?.[id];
   if (pd) {
-    // 不恢复模型选择 — 用户自己选的 API 和模型不应该被默认值覆盖
-    patchAgentSettings(s, id, {
-      worldBookEnabled: pd.worldBookEnabled ?? false,
-      worldBookIds: [...(pd.worldBookIds || [])],
-    });
     if (id === 'story') {
+      // story 走预设子系统：systemPrompt/template 由预设提供，这里只拉预设 + 世界书 + 旋钮
       s.activePresetId = pd.presetId || '';
       if (pd.preset) {
         const existing = s.presets.find((p) => p.id === pd.preset!.id);
@@ -171,48 +168,40 @@ async function restoreAgentDefaults() {
           }
         }
       }
+      // 不动 model / systemPrompt / template —— story 的提示词是预设，不是裸串。
+      // `applyProjectDefaultToAgent` 会写 systemPrompt，story 不用它。
+      patchAgentSettings(s, id, {
+        worldBookEnabled: pd.worldBookEnabled ?? false,
+        worldBookIds: [...(pd.worldBookIds || [])],
+        temperature: pd.temperature ?? AGENT_SETTINGS_DEFAULTS.temperature,
+        topP: pd.topP ?? AGENT_SETTINGS_DEFAULTS.topP,
+        freqPen: pd.freqPen ?? AGENT_SETTINGS_DEFAULTS.freqPen,
+        presPen: pd.presPen ?? AGENT_SETTINGS_DEFAULTS.presPen,
+        maxTokens: pd.maxTokens ?? AGENT_SETTINGS_DEFAULTS.maxTokens,
+        historyLayers: pd.historyLayers,
+        historySlice: pd.historySlice,
+      });
     } else {
-      patchAgentSettings(s, id, { systemPrompt: pd.systemPrompt || '' });
+      // 非 story：一键拉提示词/模板/世界书/旋钮（保留 model）。
+      // 与空态区「提示词更新中心」用同一个 helper —— 两处行为天然一致，改一个就够。
+      applyProjectDefaultToAgent(s, id, pd);
       agentPromptDraft.value = pd.systemPrompt || '';
-      // Restore template from project default（没给就删键，不是写空串）
-      patchAgentSettings(s, id, { template: pd.template || undefined });
       agentTemplateDraft.value = pd.template || '';
     }
-    // Q-18: 五个数值旋钮 + 两项历史注入配置一次写完，默认值只在
-    // AGENT_SETTINGS_DEFAULTS 出现一次（此前这里各写一遍 `?? 0.7 / ?? 16384`，
-    // 与下面的兜底分支、game-pipeline、create-store 共六份拷贝）。
-    //
-    // `historyLayers` / `historySlice` 传 undefined 即**删键** —— 项目默认没设时要把
-    // 「走引擎按 agent 类别的默认」那条语义还回去，不是写个 0 进去。
-    //
-    // 🔴 这里刻意**只碰数值项**：model 不动（用户自己选的 API 与模型不该被默认值覆盖，
-    // 这是本分支既有行为，与下面的出厂兜底分支不同）；worldBook / systemPrompt /
-    // template 上面已按 story 分支各自处理过，重写一遍会把刚 delete 掉的 template 键
-    // 又补成空串。
-    patchAgentSettings(s, id, {
-      temperature: pd.temperature ?? AGENT_SETTINGS_DEFAULTS.temperature,
-      topP: pd.topP ?? AGENT_SETTINGS_DEFAULTS.topP,
-      freqPen: pd.freqPen ?? AGENT_SETTINGS_DEFAULTS.freqPen,
-      presPen: pd.presPen ?? AGENT_SETTINGS_DEFAULTS.presPen,
-      maxTokens: pd.maxTokens ?? AGENT_SETTINGS_DEFAULTS.maxTokens,
-      historyLayers: pd.historyLayers,
-      historySlice: pd.historySlice,
-    });
     s.agentPromptEdited = false;
     s.agentDirty[id] = false;
-    ui.toast('已恢复项目默认设置', 'info');
+    ui.toast('已恢复成最新', 'info');
     return;
   }
 
   // 无项目默认 → 恢复出厂（不传来源即全部落 AGENT_SETTINGS_DEFAULTS）。
-  // 与上面的分支此前是两段只差取值来源的手抄，各写一遍 `?? 0.7 / ?? 16384`。
   resetAgentSettings(s, id);
   s.activePresetId = '';
   agentPromptDraft.value = '';
   agentTemplateDraft.value = '';
   s.agentPromptEdited = false;
   s.agentDirty[id] = false;
-  ui.toast('已恢复默认设置', 'info');
+  ui.toast('已恢复出厂默认', 'info');
 }
 </script>
 
@@ -231,7 +220,7 @@ async function restoreAgentDefaults() {
   <!-- 操作按钮 -->
   <div class="detail-actions">
     <AppButton variant="ghost" size="sm" @click="saveAsDefault">保存为默认</AppButton>
-    <AppButton variant="ghost" size="sm" @click="restoreAgentDefaults">恢复默认</AppButton>
+    <AppButton variant="ghost" size="sm" @click="restoreAgentDefaults">恢复成最新</AppButton>
     <AppButton variant="primary" size="sm" @click="saveAgentSettings">保存设置</AppButton>
   </div>
 </template>

--- a/src/ui/components/settings/agent/AgentUpdateCenter.test.ts
+++ b/src/ui/components/settings/agent/AgentUpdateCenter.test.ts
@@ -1,0 +1,183 @@
+/**
+ * AgentUpdateCenter.vue —— 提示词更新中心接线测试
+ *
+ * 核心行为：
+ *   · 用户提示词 === 当前默认 → 不渲染（让空态的「← 请从左侧选择」独占）
+ *   · 用户提示词 ≠ 当前默认 → 列出来 + per-agent「恢复成最新」
+ *   · 多于 1 条时额外渲染「全部恢复成最新」
+ *   · story 永远不进本中心（走预设，不是裸 systemPrompt 串）
+ *   · 「恢复成最新」后该条从列表消失（reactive 重算）
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { reactive } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+// ---- Mocks ----
+const mockSettings = reactive<Record<string, any>>({});
+const mockStore = {
+  settings: mockSettings,
+  projectAgentDefaults: null as { agents: Record<string, any> } | null,
+};
+vi.mock('../../../stores/settings-store', () => ({
+  useSettingsStore: () => mockStore,
+}));
+
+const mockToast = vi.fn();
+vi.mock('../../../stores/ui-store', () => ({
+  useUIStore: () => ({ toast: mockToast }),
+}));
+
+import AgentUpdateCenter from './AgentUpdateCenter.vue';
+import AppButton from '../../shared/AppButton.vue';
+import { getAgentSettings } from '../../../stores/agent-settings';
+
+function resetSettings() {
+  for (const k of Object.keys(mockSettings)) delete mockSettings[k];
+  Object.assign(mockSettings, { agents: {} });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setActivePinia(createPinia());
+  resetSettings();
+  mockStore.projectAgentDefaults = null;
+});
+
+function mountCenter() {
+  return mount(AgentUpdateCenter, { shallow: true });
+}
+
+describe('AgentUpdateCenter —— 渲染门控', () => {
+  it('没有项目默认时 → 不渲染', () => {
+    expect(mountCenter().find('.update-center').exists()).toBe(false);
+  });
+
+  it('用户提示词 === 当前默认 → 不渲染', () => {
+    mockStore.projectAgentDefaults = {
+      agents: { char_gen: { systemPrompt: '最新默认', template: '默认模板' } },
+    };
+    mockSettings.agents.char_gen = { systemPrompt: '最新默认', template: '默认模板' };
+    expect(mountCenter().find('.update-center').exists()).toBe(false);
+  });
+
+  it('用户提示词 ≠ 当前默认 → 渲染并列出', () => {
+    mockStore.projectAgentDefaults = {
+      agents: { char_gen: { systemPrompt: '新版默认', template: '新模板' } },
+    };
+    mockSettings.agents.char_gen = { systemPrompt: '旧版默认', template: '旧模板' };
+    const w = mountCenter();
+    expect(w.find('.update-center').exists()).toBe(true);
+    expect(w.find('.update-row-name').text()).toBe('角色生成');
+    // 只列 1 条时不显示「全部恢复成最新」
+    expect(w.findAll('.update-all')).toHaveLength(0);
+  });
+
+  it('多条差异 → 渲染「全部恢复成最新」', () => {
+    mockStore.projectAgentDefaults = {
+      agents: {
+        char_gen: { systemPrompt: '新版A' },
+        item_gen: { systemPrompt: '新版B' },
+        vars_update: { systemPrompt: '新版C' },
+      },
+    };
+    mockSettings.agents.char_gen = { systemPrompt: '旧版A' };
+    mockSettings.agents.item_gen = { systemPrompt: '旧版B' };
+    mockSettings.agents.vars_update = { systemPrompt: '旧版C' };
+    const w = mountCenter();
+    expect(w.findAll('.update-row')).toHaveLength(3);
+    expect(w.find('.update-all').exists()).toBe(true);
+  });
+
+  it('🔴 story 永不进本中心 —— 即使提示词不同也不列', () => {
+    mockStore.projectAgentDefaults = {
+      agents: {
+        story: { systemPrompt: 'story 默认', presetId: '', preset: null },
+        char_gen: { systemPrompt: 'char 默认' },
+      },
+    };
+    mockSettings.agents.story = { systemPrompt: 'story 用户版' };
+    mockSettings.agents.char_gen = { systemPrompt: 'char 用户版' };
+    const w = mountCenter();
+    // story 不列；char_gen 的提示词≠默认才列
+    const names = w.findAll('.update-row-name').map((n) => n.text());
+    expect(names).not.toContain('正文生成');
+    expect(names).toContain('角色生成');
+  });
+});
+
+describe('AgentUpdateCenter —— 恢复动作', () => {
+  it('per-agent「恢复成最新」→ 只同步那一个 + toast', async () => {
+    mockStore.projectAgentDefaults = {
+      agents: {
+        char_gen: { systemPrompt: '新版', template: '新模板', worldBookIds: [] },
+        item_gen: { systemPrompt: '新版B', template: '新模板B', worldBookIds: [] },
+      },
+    };
+    mockSettings.agents.char_gen = { systemPrompt: '旧版', model: 'deepseek-chat' };
+    mockSettings.agents.item_gen = { systemPrompt: '旧版B', model: 'glm-4' };
+
+    const w = mountCenter();
+    // 点 char_gen 那条的按钮
+    await w.findAllComponents(AppButton)[0].vm.$emit('click');
+
+    const charGen = getAgentSettings(mockSettings, 'char_gen');
+    expect(charGen.systemPrompt).toBe('新版');
+    expect(charGen.template).toBe('新模板');
+    // 🔴 model 保留不动
+    expect(charGen.model).toBe('deepseek-chat');
+    // item_gen 没被动
+    expect(getAgentSettings(mockSettings, 'item_gen').systemPrompt).toBe('旧版B');
+    expect(mockToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('🔴 恢复后该条从列表消失（reactive 重算）', async () => {
+    mockStore.projectAgentDefaults = {
+      agents: {
+        char_gen: { systemPrompt: '新版' },
+        item_gen: { systemPrompt: '新版B' },
+      },
+    };
+    mockSettings.agents.char_gen = { systemPrompt: '旧版' };
+    mockSettings.agents.item_gen = { systemPrompt: '旧版B' };
+
+    const w = mountCenter();
+    expect(w.findAll('.update-row')).toHaveLength(2);
+
+    await w.findAllComponents(AppButton)[0].vm.$emit('click');
+    expect(w.findAll('.update-row')).toHaveLength(1);
+  });
+
+  it('「全部恢复成最新」→ 同步所有（边遍历边改 reactive 源不跳条）+ 单 toast', async () => {
+    mockStore.projectAgentDefaults = {
+      agents: {
+        char_gen: { systemPrompt: '新版A', worldBookIds: [] },
+        item_gen: { systemPrompt: '新版B', worldBookIds: [] },
+        vars_update: { systemPrompt: '新版C', worldBookIds: [] },
+      },
+    };
+    mockSettings.agents.char_gen = { systemPrompt: '旧版A', model: 'm1' };
+    mockSettings.agents.item_gen = { systemPrompt: '旧版B', model: 'm2' };
+    mockSettings.agents.vars_update = { systemPrompt: '旧版C', model: 'm3' };
+
+    const w = mountCenter();
+    // 最后一个 AppButton 是「全部恢复成最新」（前面每条一个）
+    const buttons = w.findAllComponents(AppButton);
+    const restoreAllBtn = buttons[buttons.length - 1];
+    await restoreAllBtn.vm.$emit('click');
+
+    expect(getAgentSettings(mockSettings, 'char_gen').systemPrompt).toBe('新版A');
+    expect(getAgentSettings(mockSettings, 'item_gen').systemPrompt).toBe('新版B');
+    expect(getAgentSettings(mockSettings, 'vars_update').systemPrompt).toBe('新版C');
+    // 🔴 model 全保留
+    expect(getAgentSettings(mockSettings, 'char_gen').model).toBe('m1');
+    expect(getAgentSettings(mockSettings, 'item_gen').model).toBe('m2');
+    expect(getAgentSettings(mockSettings, 'vars_update').model).toBe('m3');
+    // 全部恢复后列表清空
+    expect(w.findAll('.update-row')).toHaveLength(0);
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(mockToast.mock.calls[0][0]).toContain('3');
+  });
+});

--- a/src/ui/components/settings/agent/AgentUpdateCenter.vue
+++ b/src/ui/components/settings/agent/AgentUpdateCenter.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+/**
+ * 提示词更新中心（Agent 分区空态区）。
+ *
+ * 🔴 解决的问题：`loadAgentProjectDefaults()` 每次开应用都拉**最新**的
+ *    `data/defaults/agent-config.json`，但 `fillMissingAgentSettings` 只填**空位**——
+ *    用户只要存过提示词（哪怕是上一版默认），新默认永远进不来，而且用户完全不知道。
+ *    本组件扫一遍非 story Agent，把「用户提示词 ≠ 当前默认」的那些列出来，给一个
+ *    一键「恢复成最新」。检测是简单字符串对比——既覆盖"默认更新了"、也覆盖"你改过"，
+ *    由用户自己决定要不要同步。
+ *
+ * story 不进本中心：它的提示词是预设（`prompts[]`），走 PresetManager 那条分叉，
+ *    同步机制完全不同（预设是结构化数组，不是单串）。
+ *
+ * 「恢复成最新」与 AgentConfigPanel 里的同名按钮**同一套逻辑**（都调
+ *    `applyProjectDefaultToAgent`）：只拉提示词/模板/世界书/旋钮，**保留 model**
+ *    （用户自己选的 API 和模型不该被默认值覆盖）。
+ */
+import { computed } from 'vue';
+import AppButton from '../../shared/AppButton.vue';
+import { useSettingsStore } from '../../../stores/settings-store';
+import { useUIStore } from '../../../stores/ui-store';
+import { applyProjectDefaultToAgent, getAgentSettings } from '../../../stores/agent-settings';
+import { AGENT_LIST, agentDisplayName } from './agent-list';
+
+const cfg = useSettingsStore();
+const s = cfg.settings;
+const ui = useUIStore();
+
+interface OutdatedAgent {
+  id: string;
+  name: string;
+}
+
+/**
+ * 列出提示词与当前默认不同的**非 story** Agent。
+ *
+ * `projectAgentDefaults` 是异步加载（app 启动时 fetch），加载完会 reactively
+ * 触发本 computed 重算。没有项目默认条目的 agent 跳过（没有"最新"可同步）。
+ */
+const outdatedAgents = computed<OutdatedAgent[]>(() => {
+  const defaults = cfg.projectAgentDefaults?.agents;
+  if (!defaults) return [];
+  const out: OutdatedAgent[] = [];
+  for (const entry of AGENT_LIST) {
+    if (entry.id === 'story') continue;
+    const pd = defaults[entry.id];
+    if (!pd) continue;
+    const userPrompt = getAgentSettings(s, entry.id).systemPrompt;
+    if (userPrompt !== (pd.systemPrompt ?? '')) {
+      out.push({ id: entry.id, name: entry.name });
+    }
+  }
+  return out;
+});
+
+function restoreOne(id: string) {
+  const pd = cfg.projectAgentDefaults?.agents?.[id];
+  if (!pd) return;
+  applyProjectDefaultToAgent(s, id, pd);
+}
+
+function restoreOneWithToast(id: string) {
+  restoreOne(id);
+  ui.toast(`「${agentDisplayName(id)}」已恢复成最新`, 'success');
+}
+
+function restoreAll() {
+  // 复制一份再遍历：restoreOne 会改 settings → outdatedAgents 即时缩空，
+  // 边遍历边改 reactive 源会跳过部分条目
+  const snapshot = [...outdatedAgents.value];
+  for (const { id } of snapshot) restoreOne(id);
+  if (snapshot.length > 0) {
+    ui.toast(`已恢复 ${snapshot.length} 个 Agent 到最新默认`, 'success');
+  }
+}
+</script>
+
+<template>
+  <div v-if="outdatedAgents.length > 0" class="update-center">
+    <div class="update-center-head">
+      <h3>提示词更新中心</h3>
+      <p class="section-desc">
+        以下 {{ outdatedAgents.length }} 个 Agent
+        的提示词与你保存的版本不同（可能是项目默认更新了，或你曾自定义过）。点「恢复成最新」同步到当前默认——API
+        与模型选择保留不动。
+      </p>
+    </div>
+    <div class="update-list">
+      <div v-for="a in outdatedAgents" :key="a.id" class="update-row">
+        <span class="update-row-name">{{ a.name }}</span>
+        <AppButton variant="secondary" size="sm" @click="restoreOneWithToast(a.id)"
+          >恢复成最新</AppButton
+        >
+      </div>
+    </div>
+    <div v-if="outdatedAgents.length > 1" class="update-all">
+      <AppButton variant="primary" size="sm" @click="restoreAll">全部恢复成最新</AppButton>
+    </div>
+  </div>
+</template>
+
+<style scoped src="../settings-chrome.css"></style>
+
+<style scoped>
+.update-center {
+  margin-top: 8px;
+  padding: 20px;
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  background: color-mix(in srgb, var(--theme-primary) 6%, var(--theme-card-bg));
+}
+.update-center-head {
+  margin-bottom: 16px;
+}
+.update-center-head h3 {
+  font-family: var(--theme-font-title);
+  font-size: 1.15rem;
+  margin: 0 0 6px;
+  color: var(--theme-text-primary);
+}
+.update-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.update-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-radius: var(--theme-radius-sm);
+  background: var(--theme-content-bg);
+  border: 1px solid var(--theme-card-border);
+}
+.update-row-name {
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--theme-text-primary);
+}
+.update-all {
+  margin-top: 14px;
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/src/ui/stores/agent-settings.test.ts
+++ b/src/ui/stores/agent-settings.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   AGENT_SETTINGS_DEFAULTS,
+  applyProjectDefaultToAgent,
   fillMissingAgentSettings,
   getAgentSettings,
   listConfiguredAgents,
@@ -208,5 +209,57 @@ describe('fillMissingAgentSettings', () => {
     const b: Record<string, any> = { agents: { story: { historyLayers: 0 } } };
     fillMissingAgentSettings(b, 'story', { historyLayers: 4 });
     expect(b.agents.story.historyLayers).toBe(0);
+  });
+});
+
+describe('applyProjectDefaultToAgent', () => {
+  it('🔴 model 保留不动（用户自己选的 API 与模型不该被默认值覆盖）', () => {
+    const b: Record<string, any> = { agents: { char_gen: { model: 'deepseek-chat' } } };
+    applyProjectDefaultToAgent(b, 'char_gen', { systemPrompt: '新版', model: 'ignored-model' });
+    expect(getAgentSettings(b, 'char_gen').model).toBe('deepseek-chat');
+  });
+
+  it('拉提示词/模板/世界书/旋钮到来源的值', () => {
+    const b: Record<string, any> = { agents: { char_gen: { model: 'm', systemPrompt: '旧' } } };
+    applyProjectDefaultToAgent(b, 'char_gen', {
+      systemPrompt: '新版',
+      template: '{{X}}',
+      worldBookEnabled: true,
+      worldBookIds: ['wb1'],
+      temperature: 0.3,
+      maxTokens: 8192,
+    });
+    const got = getAgentSettings(b, 'char_gen');
+    expect(got.systemPrompt).toBe('新版');
+    expect(got.template).toBe('{{X}}');
+    expect(got.worldBookEnabled).toBe(true);
+    expect(got.worldBookIds).toEqual(['wb1']);
+    expect(got.temperature).toBe(0.3);
+    expect(got.maxTokens).toBe(8192);
+  });
+
+  it('🔴 template 空串 → 删键（不是写空串），把「走引擎默认」语义还回去', () => {
+    const b: Record<string, any> = {
+      agents: { char_gen: { model: 'm', template: '{{旧}}' } },
+    };
+    applyProjectDefaultToAgent(b, 'char_gen', { template: '' });
+    expect('template' in b.agents.char_gen).toBe(false);
+  });
+
+  it('historyLayers/historySlice 来源没给就删键', () => {
+    const b: Record<string, any> = {
+      agents: { char_gen: { model: 'm', historyLayers: 3, historySlice: 500 } },
+    };
+    applyProjectDefaultToAgent(b, 'char_gen', { systemPrompt: 'x' });
+    expect('historyLayers' in b.agents.char_gen).toBe(false);
+    expect('historySlice' in b.agents.char_gen).toBe(false);
+  });
+
+  it('来源缺项时旋钮落 AGENT_SETTINGS_DEFAULTS（与其它路径同源）', () => {
+    const b: Record<string, any> = { agents: { char_gen: { model: 'm' } } };
+    applyProjectDefaultToAgent(b, 'char_gen', {});
+    const got = getAgentSettings(b, 'char_gen');
+    expect(got.temperature).toBe(AGENT_SETTINGS_DEFAULTS.temperature);
+    expect(got.maxTokens).toBe(AGENT_SETTINGS_DEFAULTS.maxTokens);
   });
 });

--- a/src/ui/stores/agent-settings.ts
+++ b/src/ui/stores/agent-settings.ts
@@ -171,6 +171,39 @@ export function resetAgentSettings(
 }
 
 /**
+ * 把一个**非 story** Agent 的设置从项目默认值「拉到最新」—— 只动提示词/模板/
+ * 世界书/旋钮，**保留 `model`**（用户自己选的 API 和模型不该被默认值覆盖）。
+ *
+ * 与 `resetAgentSettings` 的区别：后者连 `model` 一起重置（连 API 选择都抹掉），
+ * 本函数刻意不动 model。这是「恢复默认」/「恢复成最新」按钮的既有语义，也是
+ * 空态区「提示词更新中心」批量更新用的同一套逻辑 —— 两处复用本函数，避免漂移。
+ *
+ * 🔴 不处理 story：story 的提示词是预设（`prompts[]`），走 PresetManager 那条
+ *    分叉，本函数不碰它。story 的「恢复默认」在 AgentConfigPanel 里单独处理。
+ */
+export function applyProjectDefaultToAgent(
+  bag: SettingsBag,
+  agentId: string,
+  pd: Partial<AgentSettingsEntry>,
+): void {
+  patchAgentSettings(bag, agentId, {
+    worldBookEnabled: pd.worldBookEnabled ?? false,
+    worldBookIds: [...(pd.worldBookIds ?? [])],
+    systemPrompt: pd.systemPrompt ?? '',
+    // 空串 → 删键（把「走引擎默认」的语义还回去），不是写空串
+    template: pd.template || undefined,
+    temperature: pd.temperature ?? AGENT_SETTINGS_DEFAULTS.temperature,
+    topP: pd.topP ?? AGENT_SETTINGS_DEFAULTS.topP,
+    freqPen: pd.freqPen ?? AGENT_SETTINGS_DEFAULTS.freqPen,
+    presPen: pd.presPen ?? AGENT_SETTINGS_DEFAULTS.presPen,
+    maxTokens: pd.maxTokens ?? AGENT_SETTINGS_DEFAULTS.maxTokens,
+    // 来源没给就删键 —— historyLayers/historySlice 的「键存在」会挡掉引擎按类别给的默认
+    historyLayers: pd.historyLayers,
+    historySlice: pd.historySlice,
+  });
+}
+
+/**
  * 对**尚未被用户配置过**的项补上来源里的值（项目默认值加载器用）。
  *
  * 与 `resetAgentSettings` 的区别：这个只填空位，不覆盖用户已改过的项。


### PR DESCRIPTION
## 问题

`loadAgentProjectDefaults()` 每次开应用都拉**最新**的 `agent-config.json`，但 `fillMissingAgentSettings` **只填空位**——用户只要存过提示词（哪怕是上一版默认），新默认永远进不来，而且用户完全不知道。既检测不了"默认更新了"，也分不清"用户自定义"vs"老默认残留"。

## 改动

### `AgentUpdateCenter.vue` (新)
Agent 分区空态区（`← 请从左侧选择一个 Agent` 下方）新增「提示词更新中心」：
- 扫描所有**非 story** agent，列出`用户提示词 ≠ 当前默认`的那些
- per-agent「恢复成最新」按钮 + 多于 1 条时的「全部恢复成最新」
- 无差异时组件不渲染，保留原有空态提示

### `applyProjectDefaultToAgent` helper (agent-settings.ts 新增)
拉提示词/模板/世界书/旋钮到项目默认，**保留 model**（用户的 API 选择不被覆盖）。空模板→删键（保留"走引擎默认"语义）。AgentConfigPanel 与 AgentUpdateCenter 共用同一套逻辑，避免漂移。

### `AgentConfigPanel.vue`
- 「恢复默认」→ **「恢复成最新」**（更清楚它拉的是项目最新默认）
- 非 story 恢复路径改用 `applyProjectDefaultToAgent` 去重（原本 4 段 patch 合成 1 调用）
- toast 文案同步改

### story 不进本中心
story 的提示词是结构化的预设 `prompts[]`，走 PresetManager 那条分叉，不是裸 `systemPrompt` 串，同步机制完全不同——本 PR 不处理，留作后续任务。

## 验证
- typecheck 干净（本地仅 `*.property.test.ts` 因缺 fast-check 报错，CI 有，非本 PR 文件）
- 46 相关测试全绿：agent-settings +5 / AgentUpdateCenter +8 / AgentConfigPanel 11 不退步
- Prettier 全过
- 🔴 核心契约被测试钉住：model 保留、template 空串删键、historyLayers 缺省删键、恢复后 reactive 列表重算
