### PR TITLE
feat(ui): 设置页 UI/UX 修缮 + 字体自托管（两格字体设置 / 空态统一 / 间距 token 化）

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,61 @@
+# 第三方字体与图标 —— 许可与署名
+
+本仓库**自带并分发**下列字体与图标字体的二进制文件（`node_modules/@fontsource-variable/*`
+与 `node_modules/@fortawesome/fontawesome-free`，构建时由 Vite 输出到 `dist/assets/`）。
+四者的许可证全文随应用一起分发，位于 `public/licenses/`，在运行的应用里可通过
+`/licenses/<文件名>` 直接访问；设置页「关于」分区也列出了同一份清单。
+
+在 2026-08-05 之前，这些资源是从 Google Fonts 与 cdnjs **运行时加载**的。改为自托管的
+理由见 `docs/design.md` §7.5。
+
+## 分发中的字体
+
+| 字体                     | 版权方                     | 许可证                    | 许可证全文                                                                       |
+| ------------------------ | -------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| Noto Sans SC (Variable)  | Google Inc.                | SIL Open Font License 1.1 | [`public/licenses/OFL-Noto-Sans-SC.txt`](public/licenses/OFL-Noto-Sans-SC.txt)   |
+| Noto Serif SC (Variable) | Google Inc.                | SIL Open Font License 1.1 | [`public/licenses/OFL-Noto-Serif-SC.txt`](public/licenses/OFL-Noto-Serif-SC.txt) |
+| Cinzel (Variable)        | The Cinzel Project Authors | SIL Open Font License 1.1 | [`public/licenses/OFL-Cinzel.txt`](public/licenses/OFL-Cinzel.txt)               |
+| Font Awesome Free 6.7.2  | Fonticons, Inc.            | 见下（三段式）            | [`public/licenses/Font-Awesome-Free.txt`](public/licenses/Font-Awesome-Free.txt) |
+
+### SIL OFL 1.1 —— 三条我们必须守的
+
+1. **随分发附上版权声明与许可证全文。** 已办：`public/licenses/*.txt` 会原样进入 `dist/`
+   （Vite 把 `public/` 逐字复制），所以任何拿到构建产物的人都同时拿到了许可证。
+2. **不得单独售卖字体本身。** 字体只作为本应用的一部分分发。
+3. **保留字体名（Reserved Font Name）**：上述三款**均未声明** RFN —— 各自 LICENSE 里
+   第 33 行那句 `"Reserved Font Name" refers to …` 是 OFL 的**定义段落**，不是声明。
+   （核对方式：OFL 的 RFN 要写在版权行之后、形如 `with Reserved Font Name X`；三份文件里都没有。）
+   因此改名/改造也是允许的 —— 但我们两样都没做，原样分发。
+
+### Font Awesome Free 6.7.2 —— 三种许可，署名是硬要求
+
+| 部分                              | 许可证        | 我们的义务                                    |
+| --------------------------------- | ------------- | --------------------------------------------- |
+| 图标（本应用用到的 webfont 字形） | **CC BY 4.0** | **必须署名** —— 已在设置页「关于」分区标注    |
+| 字体文件                          | SIL OFL 1.1   | 附许可证全文（同上）                          |
+| CSS / JS 代码                     | MIT           | 保留版权声明（在 `Font-Awesome-Free.txt` 里） |
+
+🔴 CC BY 4.0 的署名义务是**唯一一条要求界面上可见**的 —— 光把许可证文件放进 `dist/`
+不够。署名写在 `AboutSection.vue`，删它之前先想清楚这一条。
+
+只打包用到的两套：`fontawesome.css` + `solid.css` + `regular.css`（`fa-solid` 221 处、
+`fa-regular` 2 处）。**不引 `brands.css`** —— 全仓零处使用，省掉 `fa-brands-400.woff2`。
+
+## 刻意**没有**自托管的字体
+
+CSS 里还出现下列字体名，它们**只是系统字体兜底**：本应用从不下载它们，用户机器上有就用、
+没有就落到下一级。它们全部是专有字体，**打包进仓库会构成侵权**，所以只能这样引用：
+
+| 字体                                        | 权利方                                | 用在哪                     |
+| ------------------------------------------- | ------------------------------------- | -------------------------- |
+| Monaco / Menlo                              | Apple                                 | 代码与正则展示区的等宽兜底 |
+| Consolas / Courier New                      | Microsoft / Monotype                  | 同上                       |
+| Palatino Linotype / Book Antiqua / Palatino | Monotype / Linotype                   | 首页英文副标               |
+| KaiTi / STKaiti / 楷体                      | Microsoft・北大方正 / Apple・常州华文 | 首页风味引文               |
+
+**按名字引用一款字体不是分发它**，所以现状合规；把这些 `.ttf` 放进仓库则不合规。
+这条边界别越过去。
+
+两款等宽字体（Cascadia Code、JetBrains Mono）其实是 OFL、可以自托管，但**目前也只是兜底**：
+自托管它们等于新增一笔现在并不发生的下载，只为了让代码/正则面板在缺字体的机器上更统一。
+要不要做是产品取舍，不是许可问题。

--- a/docs/design.md
+++ b/docs/design.md
@@ -59,6 +59,10 @@ border: 1px solid color-mix(in srgb, var(--theme-success) 30%, transparent);
 
 **层级约定**：分区大标题（设置页 section h3 等）用 `var(--theme-font-title)` + `1.3-1.4rem`，正文与列表保持无衬线，形成"手稿标题 + 工整正文"的古籍对比。
 
+> 🔴 这两个变量的取值**由用户在设置页决定**（正文字体 / 标题字体两格），主题不参与。
+> 写组件时照旧按语义选变量 —— 叙事与标题用 `--theme-font-title`，UI 标签用
+> `--theme-font-body` —— 不要硬写字体名，也不要假设 title 一定是衬线。详见 §7.4。
+
 ### 2.2 字号层级
 
 | 层级          | 字号                    | 用途                     |
@@ -328,26 +332,83 @@ Modal 打开：`<Transition name="modal">` — fade + scale(0.97→1)
 
 ---
 
-## 7.4 已知问题
+## 7.4 字体：设置严格压过主题（2026-08-05 定案）
 
-### 🐛 切换主题会改变字体，即便字体设置没动（未修复）
+> 本节此前是「已知问题 · 未修复」，记着两个待拍板的方案。**主人已拍板：走方案 A
+> 的严格版，并把三档单选拆成正文 / 标题两格独立设置。**
 
-**现象**：设置页「字体风格」保持不变，但切到某些主题后界面字体从无衬线变成衬线。
+### 规则
 
-**根因链**（`theme-store.ts` + `themes/*.css`）：
+**字体由设置页「外观主题」分区的两格决定，主题一律不参与。**
 
-1. `setFonts()` 只写 `--theme-font-body` 这一个内联变量，**且只在用户主动改下拉框时才执行**；
-2. `fated-poem-fonts` 只被 `setItem` 写入，**全项目没有任何读取点** —— 刷新后不恢复，`fonts` ref 永远重置为 `'sans'`，DOM 上也就没有内联覆盖；
-3. 没有内联覆盖时，`--theme-font-body` 由 `[data-theme="…"]` 块决定，而 `parchment` / `ivory` 把它定义成了 `'Noto Serif SC', serif`（`variables.css` 的 `:root` 是 `'Noto Sans SC', sans-serif`）。
+| 设置项       | 写的变量             | 出厂默认              | 影响面                                           |
+| ------------ | -------------------- | --------------------- | ------------------------------------------------ |
+| **正文字体** | `--theme-font-body`  | 无衬线 (Noto Sans SC) | UI 标签、表单、列表、说明文字                    |
+| **标题字体** | `--theme-font-title` | 衬线 (Noto Serif SC)  | 分区标题、叙事正文、角色名、物品名（111 处引用） |
 
-于是：**换主题 → 正文字体跟着变，而设置页仍显示原来的值**。
+`--theme-font-display`（Cinzel）**不可配置** —— 它是纯装饰拉丁字体，没有中文字形，
+只服务英文副标/章节数字。
 
-**为什么没顺手修**：涉及一个设计决策，需要主人拍板 ——
+### 三条硬约束
 
-- **方案 A**：主题只管颜色，字体变量从 `parchment` / `ivory` / `misty-lilac` 中删除，字体完全由设置控制（符合 §1「主题无关」原则，但三个主题会失去各自的字体性格）；
-- **方案 B**：保留主题字体作为「默认值」，但补上 `initFonts()` 读回 localStorage，并让 `setFonts()` 同时写 `--theme-font-title`，用户一旦设置过就恒定压过主题。
+1. **主题 CSS 里不许出现 `--theme-font-*` 声明。** 唯一允许的地方是
+   `themes/variables.css` 的 `:root`（没有 JS 时的兜底）。闸门：`themes/theme-fonts.test.ts`
+   逐文件扫描，注释里提这个名字可以，写成声明就红。
+2. **`initFonts()` 必须在挂载前跑**（`main.ts`，紧跟 `init()` / `initFontSize()`）。
+   它把两格写成 `<html>` 的**内联变量** —— 内联压得过任何 `[data-theme]` 规则，
+   「设置说了算」就是靠这个强制的。
+3. **默认值也要写内联变量**，不能因为「等于默认」就跳过。跳过等于在默认档上把
+   决定权又交还给主题。
 
-无论选哪个，**`fated-poem-fonts` 写了不读**这一条都是要修的。
+### 修掉的三处（症状全都不在改动处）
+
+1. `setFonts()` 往 `fated-poem-fonts` **写了却没有任何读取点** —— 刷新后 ref 重置、
+   DOM 无内联覆盖，字体退回主题说了算，而下拉框仍显示用户选的值。补 `initFonts()`。
+2. `parchment` / `ivory` 把 `--theme-font-body` 定义成衬线 —— 换主题悄悄改掉正文字体。
+   已从主题 CSS 移除（`misty-lilac` 那两行只是原样重复 `:root`，一并删掉，
+   留着会诱使人以为「主题可以定字体」）。
+3. `mixed` 档写的是 `'Noto Sans SC', 'Noto Serif SC', sans-serif` —— 一条字体栈，
+   有中文字形的字符全部命中第一个，**渲染出来和 `sans` 一模一样**。三个选项实际只有
+   两种结果。拆成两格后这一档自然消失。
+
+### 字体从哪来 —— 自托管，零外部请求（2026-08-05）
+
+2026-08-05 之前，字体与图标从两个 CDN **运行时加载**（`fonts.googleapis.com` 与
+`cdnjs.cloudflare.com`）。现已全部自托管，`index.html` 里**一条外链都不剩**。
+
+| 资源                                       | 包                              | 许可                                 |
+| ------------------------------------------ | ------------------------------- | ------------------------------------ |
+| Noto Sans SC / Noto Serif SC / Cinzel      | `@fontsource-variable/*`        | SIL OFL 1.1                          |
+| Font Awesome Free 6.7.2（solid + regular） | `@fortawesome/fontawesome-free` | 图标 CC BY 4.0 · 字体 OFL · 代码 MIT |
+
+**为什么必须改**：CDN 失败时**没有任何报错** —— `font-display: swap` 安静地落到系统字体，
+图标退化成方框，而设置页仍显示「衬线」。`fonts.googleapis.com` 在中国大陆长期不可达，
+对一款中文游戏来说，这意味着相当一部分玩家从来没见过设计里那套字体。§1「玄墨基调」
+写着「暖色由强调色**与字体**承载」，而那一半此前是挂在一条会静默失效的外链上的。
+
+**用变量字体而不是逐字重静态包**：静态包 4 字重 × 2 中文族约 34MB，变量包一共 10.6MB
+覆盖 100–900 全区间。两者都保留 Google 的 unicode-range 切片（每族 101 个子集），
+浏览器只下载正文用到的那几片。
+
+🔴 **族名带 `Variable` 后缀**（`'Noto Sans SC Variable'`）。写成不带后缀的名字不会报错，
+只会安静地退回系统字体 —— 与它替掉的那个 bug 一模一样的失败形态。闸门：
+`tests/theme-fonts-invariant.test.ts` 逐条断言第一顺位必须带后缀。
+
+🔴 **署名是许可义务，不是装饰**：Font Awesome 图标按 CC BY 4.0 授权，要求署名可见 ——
+写在设置页「关于」分区，删之前先读 `THIRD-PARTY-NOTICES.md`。许可证全文随 `dist` 分发在
+`/licenses/`（`public/licenses/` 被 Vite 逐字复制）。
+
+🔴 **CSS 里那批专有系统字体不能打包**（Monaco / Menlo / Consolas / Courier New /
+Palatino Linotype / KaiTi / STKaiti）。它们只是兜底：本应用从不下载，用户机器上有就用。
+**按名字引用不是分发**，把 `.ttf` 放进仓库才是侵权。这条边界别越过去。
+
+闸门：`tests/no-external-assets.test.ts`（无外链 / 只引用到的 FA 分册 / 许可证与署名齐全）。
+
+### 旧设置怎么迁
+
+旧的三档只影响正文，从没碰过 `--theme-font-title`。所以**照用户实际看到的样子迁**：
+`'serif'` → 正文衬线；`'sans'` / `'mixed'` → 正文无衬线；标题一律取默认衬线。
+迁移只在两个新键都没设过时发生（`theme-store.fonts.test.ts` 钉住）。
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -1,18 +1,20 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-CN" data-theme="obsidian">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>命定之诗与黄昏之歌</title>
-  <link rel="icon" type="image/png" sizes="256x256" href="/favicon.png" />
-  <link rel="apple-touch-icon" href="/favicon.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Noto+Serif+SC:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-</head>
-<body>
-  <div id="app"></div>
-  <script type="module" src="/src/ui/main.ts"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>命定之诗与黄昏之歌</title>
+    <link rel="icon" type="image/png" sizes="256x256" href="/favicon.png" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
+    <!--
+    字体与图标一律**自托管**，这里不留任何外部 <link>（2026-08-05）。
+    以前这里挂着 fonts.googleapis.com 与 cdnjs 两个 CDN —— 那两条外链在被墙或离线时
+    不会报错，只会静默落到系统字体：设置页显示「衬线」而屏幕上是黑体，图标全变成方框。
+    现在 @font-face 由 src/ui/main.ts 引入的 @fontsource-variable/* 提供。
+    许可与署名见根目录 THIRD-PARTY-NOTICES.md，全文随 dist 分发在 /licenses/。
+  --></head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/ui/main.ts"></script>
+  </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fontsource-variable/cinzel": "^5.3.0",
+        "@fontsource-variable/noto-sans-sc": "^5.3.0",
+        "@fontsource-variable/noto-serif-sc": "^5.3.0",
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@hono/node-server": "^2.0.12",
         "dexie": "^4.4.3",
         "fflate": "^0.8.3",
@@ -914,6 +918,42 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/cinzel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/cinzel/-/cinzel-5.3.0.tgz",
+      "integrity": "sha512-eFcU0TwaAP5QESF2pV8VoOPJJXJ6sSGm/6mXMwqTdMBPAJMaLhfa6oISHuOtFeddsoHP9RYm4Io0j1j3mNEz2Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-sans-sc": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-sc/-/noto-sans-sc-5.3.0.tgz",
+      "integrity": "sha512-lNar1dF7Ik/lHNPo/7JWG0TolXY29LtsqYgMvEysooZ5bsO9uH4shJmRrwyJ3PjyTPljhpMJEK0jDuLSU4vJ1w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-serif-sc": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-serif-sc/-/noto-serif-sc-5.3.0.tgz",
+      "integrity": "sha512-7LcN2NEf4HDjoSkGWc79WqDDyMK8JvSPdA/gsHjJpZ8l9A9mcK/GQTazp3klmkBwJooy0eqeNvlmaZFXPupHrA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@fontsource-variable/cinzel": "^5.3.0",
+    "@fontsource-variable/noto-sans-sc": "^5.3.0",
+    "@fontsource-variable/noto-serif-sc": "^5.3.0",
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@hono/node-server": "^2.0.12",
     "dexie": "^4.4.3",
     "fflate": "^0.8.3",

--- a/public/licenses/Font-Awesome-Free.txt
+++ b/public/licenses/Font-Awesome-Free.txt
@@ -1,0 +1,165 @@
+Fonticons, Inc. (https://fontawesome.com)
+
+--------------------------------------------------------------------------------
+
+Font Awesome Free License
+
+Font Awesome Free is free, open source, and GPL friendly. You can use it for
+commercial projects, open source projects, or really almost whatever you want.
+Full Font Awesome Free license: https://fontawesome.com/license/free.
+
+--------------------------------------------------------------------------------
+
+# Icons: CC BY 4.0 License (https://creativecommons.org/licenses/by/4.0/)
+
+The Font Awesome Free download is licensed under a Creative Commons
+Attribution 4.0 International License and applies to all icons packaged
+as SVG and JS file types.
+
+--------------------------------------------------------------------------------
+
+# Fonts: SIL OFL 1.1 License
+
+In the Font Awesome Free download, the SIL OFL license applies to all icons
+packaged as web and desktop font files.
+
+Copyright (c) 2024 Fonticons, Inc. (https://fontawesome.com)
+with Reserved Font Name: "Font Awesome".
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+SIL OPEN FONT LICENSE
+Version 1.1 - 26 February 2007
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting — in part or in whole — any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+# Code: MIT License (https://opensource.org/licenses/MIT)
+
+In the Font Awesome Free download, the MIT license applies to all non-font and
+non-icon files.
+
+Copyright 2024 Fonticons, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+# Attribution
+
+Attribution is required by MIT, SIL OFL, and CC BY licenses. Downloaded Font
+Awesome Free files already contain embedded comments with sufficient
+attribution, so you shouldn't need to do anything additional when using these
+files normally.
+
+We've kept attribution comments terse, so we ask that you do not actively work
+to remove them from files, especially code. They're a great way for folks to
+learn about Font Awesome.
+
+--------------------------------------------------------------------------------
+
+# Brand Icons
+
+All brand icons are trademarks of their respective owners. The use of these
+trademarks does not indicate endorsement of the trademark holder by Font
+Awesome, nor vice versa. **Please do not use brand logos for any purpose except
+to represent the company, product, or service to which they refer.**

--- a/public/licenses/OFL-Cinzel.txt
+++ b/public/licenses/OFL-Cinzel.txt
@@ -1,0 +1,93 @@
+Copyright 2020 The Cinzel Project Authors (https://github.com/NDISCOVER/Cinzel)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/public/licenses/OFL-Noto-Sans-SC.txt
+++ b/public/licenses/OFL-Noto-Sans-SC.txt
@@ -1,0 +1,93 @@
+Google Inc.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/public/licenses/OFL-Noto-Serif-SC.txt
+++ b/public/licenses/OFL-Noto-Serif-SC.txt
@@ -1,0 +1,93 @@
+Google Inc.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -168,8 +168,15 @@ src/ui/                              ← Vue 3 + Pinia + Vite 前端（单 URL �
 │   ├── home/HomePage.vue            ← 游戏标题画面
 │   ├── settings/                    ← [Q-25] 13 个分区**全部**是一行子组件
 │   │   ├── SettingsPage.vue         ← 纯壳层（1995 → 约 415 行）：页头 + 主导航 + Agent 子导航
-│   │   │                               只留 activeSection / activeAgent / selectAgent /
-│   │   │                               agentModelOf 与 wb.init()（世界书分区也靠它）
+│   │   │                               只留 activeSection / activeAgent / selectSection /
+│   │   │                               selectAgent / restoreAgent / agentModelOf 与
+│   │   │                               wb.init()（世界书分区也靠它）
+│   │   │                               🔴 进 Agent 分区**恢复** `s.activeAgent`，别置 null：
+│   │   │                                  此前主导航每个按钮都无条件清掉它（含「Agent 配置」
+│   │   │                                  自己），而进分区必须点那一下 —— 于是持久化的选择
+│   │   │                                  永远读不回来，每次都落在空态。重挂载由 `v-if` 保证，
+│   │   │                                  不需要拿一次用户点击去换。恢复前先对 AGENT_LIST 验，
+│   │   │                                  查不到就退空态（陈旧 id 会让页头渲染成空白）
 │   │   │                               🔴 主导航末尾那条「创意工坊」**不是分区**：它 navigate 去
 │   │   │                                  工坊页，故不进 `navItems`、也没有对应的 `activeSection`
 │   │   │                                  值。塞进那张表 = 多一个点了只出现空白右栏的选项
@@ -180,8 +187,8 @@ src/ui/                              ← Vue 3 + Pinia + Vite 前端（单 URL �
 │   │   │   │                            （保存/恢复默认/存为项目默认）+ 三张卡。别的分区
 │   │   │   │                            传不同 agentId 即可复用；**多根**，外框靠宿主 section
 │   │   │   │                            🔴 草稿载入必须 watch(..., { immediate: true })：
-│   │   │   │                               主导航每次点击都把 activeAgent 置 null，本组件
-│   │   │   │                               永远是新挂载，普通 watch 不触发 → 文本框空着渲染
+│   │   │   │                               分区整块是 `v-if`，每次进分区本组件都是
+│   │   │   │                               新挂载，普通 watch 不触发 → 文本框空着渲染
 │   │   │   │                               → 「保存设置」把空串写进用户提示词
 │   │   │   │                               （回归测试 AgentConfigPanel.test.ts 第一条）
 │   │   │   ├── AgentParamsCard.vue   ← API 池 + 7 个 LLM 旋钮 + 世界书卡（共用 agentCfg/setAgentField）

--- a/src/ui/components/settings/AboutSection.vue
+++ b/src/ui/components/settings/AboutSection.vue
@@ -40,7 +40,47 @@ import { VERSION } from '@engine/index';
         </div></AppCard
       >
     </div>
-    <p class="text-muted text-sm text-center" style="margin-top: 16px">
+    <!--
+      🔴 字体与图标署名 —— **不是可选装饰，是许可义务**（2026-08-05 自托管起）。
+      Font Awesome 的图标按 **CC BY 4.0** 授权，该协议要求署名，而且是唯一一条
+      要求**界面上可见**的：把许可证文件放进 dist 不足以满足它。
+      三款字体是 SIL OFL 1.1，要求随分发附上许可证全文 —— 那部分靠 /licenses/ 下的
+      静态文件满足，这里的链接是让人找得到它们。
+      删这一段之前先读 THIRD-PARTY-NOTICES.md。
+    -->
+    <AppCard padding="md" class="about-licenses">
+      <h4>字体与图标</h4>
+      <p class="card-desc">
+        本应用自带并分发下列字体，不从任何 CDN 加载。许可证全文随应用一起分发。
+      </p>
+      <div class="about-table">
+        <div class="about-row">
+          <span>Noto Sans SC / Noto Serif SC</span>
+          <span>
+            © Google Inc. ·
+            <a href="/licenses/OFL-Noto-Sans-SC.txt" target="_blank" rel="noopener">OFL 1.1</a>
+          </span>
+        </div>
+        <div class="about-row">
+          <span>Cinzel</span>
+          <span>
+            © The Cinzel Project Authors ·
+            <a href="/licenses/OFL-Cinzel.txt" target="_blank" rel="noopener">OFL 1.1</a>
+          </span>
+        </div>
+        <div class="about-row">
+          <span>Font Awesome Free 6.7.2</span>
+          <span>
+            © Fonticons, Inc. ·
+            <a href="/licenses/Font-Awesome-Free.txt" target="_blank" rel="noopener"
+              >图标 CC BY 4.0</a
+            >
+          </span>
+        </div>
+      </div>
+    </AppCard>
+
+    <p class="about-footer text-muted text-sm text-center">
       《命定之诗》Fated Poem — 多 Agent 协作文字 RPG 引擎<br />© 2026 命定之诗创作组
     </p>
   </section>
@@ -76,5 +116,20 @@ import { VERSION } from '@engine/index';
 }
 .about-row span:first-child {
   color: var(--theme-text-muted);
+}
+.about-footer {
+  margin-top: var(--theme-spacing-lg);
+}
+/* 署名卡：整行宽（不进上面那个 auto-fill 网格），字号比引擎信息小一号 */
+.about-licenses .about-row {
+  font-size: 0.8rem;
+  gap: var(--theme-spacing-md);
+}
+.about-licenses a {
+  color: var(--theme-primary);
+  text-decoration: none;
+}
+.about-licenses a:hover {
+  text-decoration: underline;
 }
 </style>

--- a/src/ui/components/settings/ApiSection.vue
+++ b/src/ui/components/settings/ApiSection.vue
@@ -287,16 +287,15 @@ async function deleteApi(id: string) {
           </div>
         </div></AppCard
       >
-      <p
-        v-if="s.apiPool.length === 0"
-        class="text-muted text-sm"
-        style="text-align: center; padding: 24px"
-      >
-        还没有配置 API，点击右上角"添加 API"开始
-      </p>
+      <div v-if="s.apiPool.length === 0" class="empty-tab">
+        还没有配置任何 API 端点
+        <span class="empty-tab-hint">
+          点击右上角「＋ 添加 API」填入端点地址与密钥，Agent 才能选到模型
+        </span>
+      </div>
     </div>
     <!-- 模型推荐 -->
-    <AppCard padding="md" class="embedding-hint" style="margin-top: 16px">
+    <AppCard padding="md" class="embedding-hint">
       <p class="text-sm text-muted" style="margin: 0 0 6px"><strong>模型推荐</strong></p>
       <p class="text-sm text-muted" style="margin: 0 0 4px">
         对话模型：推荐 <strong>DeepSeek V4 Flash</strong>（快速便宜）或
@@ -417,7 +416,7 @@ async function deleteApi(id: string) {
             高级设置
           </button>
           <div v-if="showAdvancedApi" class="advanced-body">
-            <label class="form-label" style="margin-top: 8px">
+            <label class="form-label form-label-stacked">
               <span class="form-check-row">
                 <input v-model="apiForm.enableThinking" type="checkbox" />
                 开启思维链 (DeepSeek thinking)
@@ -560,5 +559,9 @@ async function deleteApi(id: string) {
 }
 .form-check-row input[type='checkbox'] {
   accent-color: var(--theme-primary);
+}
+/* 同一张表单里紧接着上一格的 form-label */
+.form-label-stacked {
+  margin-top: var(--theme-spacing-sm);
 }
 </style>

--- a/src/ui/components/settings/BeautifierSection.vue
+++ b/src/ui/components/settings/BeautifierSection.vue
@@ -219,7 +219,7 @@ function importRules() {
 
     <template v-else>
       <!-- 全局开关 -->
-      <AppCard padding="md" style="margin-top: 16px">
+      <AppCard padding="md">
         <h4>全局开关</h4>
         <div class="toggle-row">
           <span>启用输出美化</span>
@@ -231,11 +231,9 @@ function importRules() {
       </AppCard>
 
       <!-- 自动管理 -->
-      <AppCard v-if="autoManagedRules.length > 0" padding="md" style="margin-top: 12px">
+      <AppCard v-if="autoManagedRules.length > 0" padding="md">
         <h4>自动管理</h4>
-        <p class="text-muted text-sm" style="margin-bottom: 12px">
-          由世界书或角色自动激活，不可手动操作。
-        </p>
+        <p class="card-desc">由世界书或角色自动激活，不可手动操作。</p>
         <div v-for="rule in autoManagedRules" :key="rule.id" class="rule-item rule-locked">
           <div class="rule-header">
             <span class="rule-lock-icon">—</span>
@@ -247,11 +245,9 @@ function importRules() {
       </AppCard>
 
       <!-- 已启用 -->
-      <AppCard v-if="manualEnabledRules.length > 0" padding="md" style="margin-top: 12px">
+      <AppCard v-if="manualEnabledRules.length > 0" padding="md">
         <h4>已启用</h4>
-        <p class="text-muted text-sm" style="margin-bottom: 12px">
-          当前生效的规则，可手动启用/禁用。
-        </p>
+        <p class="card-desc">当前生效的规则，可手动启用/禁用。</p>
         <div v-for="rule in manualEnabledRules" :key="rule.id" class="rule-item">
           <div class="rule-header">
             <label class="toggle-label">
@@ -285,7 +281,7 @@ function importRules() {
       </AppCard>
 
       <!-- 可用规则库 -->
-      <AppCard padding="md" style="margin-top: 12px">
+      <AppCard padding="md">
         <div class="library-header" @click="toggleLibrary">
           <h4 style="margin: 0; cursor: pointer">
             可用规则库 · {{ disabledRules.length }} 条未启用
@@ -332,17 +328,14 @@ function importRules() {
             </div>
           </div>
         </template>
-        <div
-          v-if="libraryExpanded && disabledGrouped.length === 0"
-          class="text-muted text-sm"
-          style="text-align: center; padding: 16px"
-        >
-          暂无可用规则
+        <div v-if="libraryExpanded && disabledGrouped.length === 0" class="empty-tab">
+          预设规则库里的规则都已启用
+          <span class="empty-tab-hint">这里只列还没启用的，暂时空着说明没有可加的了</span>
         </div>
       </AppCard>
 
       <!-- 自定义规则 -->
-      <AppCard padding="md" style="margin-top: 12px">
+      <AppCard padding="md">
         <div
           style="
             display: flex;
@@ -354,14 +347,12 @@ function importRules() {
           <h4 style="margin: 0">自定义规则</h4>
           <AppButton variant="primary" size="sm" @click="openAdd">＋ 添加规则</AppButton>
         </div>
-        <p
-          v-if="userRules.length === 0"
-          class="text-muted text-sm"
-          style="text-align: center; padding: 24px"
-        >
-          暂无自定义规则<br />
-          <span style="font-size: 0.75rem">点击右上角添加，用正则表达式自定义输出美化</span>
-        </p>
+        <div v-if="userRules.length === 0" class="empty-tab">
+          还没有自定义规则
+          <span class="empty-tab-hint">
+            点击右上角「＋ 添加规则」，用正则表达式把模型输出里的片段改写成卡片或样式
+          </span>
+        </div>
         <div v-for="rule in userRules" :key="rule.id" class="rule-item">
           <div class="rule-header">
             <label class="toggle-label">
@@ -398,7 +389,7 @@ function importRules() {
       </AppCard>
 
       <!-- 导入/导出 -->
-      <div style="display: flex; gap: 8px; margin-top: 12px; justify-content: flex-end">
+      <div class="rule-form-actions">
         <AppButton variant="secondary" size="sm" @click="exportRules">导出规则</AppButton>
         <AppButton variant="secondary" size="sm" @click="importRules">导入规则</AppButton>
       </div>
@@ -607,5 +598,33 @@ function importRules() {
 .toggle-input:checked + .toggle-slider::before {
   transform: translateX(18px);
   background: var(--theme-primary-text);
+}
+/* ═══ 本该来自 settings-chrome.css 的两条 ═══
+ *
+ * 🔴 本分区是 13 个里**唯一没有** `<style scoped src="./settings-chrome.css">` 的，
+ *    所以共用外壳的规则一条都够不着（父组件的 scoped 样式只能命中子组件根节点）。
+ *    直接补 import 会把共用的 `.toggle-slider` 也带进来，而本分区自带一套**不同实现**
+ *    （`::before` 做旋钮、开启时是金色；共用那套是 `::after`、开启时是绿色），
+ *    两套叠在一起会出现两个旋钮。统一成一套是独立一件事，需要真机走查，不在本轮。
+ *
+ *    所以这里只把本轮用到的两条照抄过来。**这是权宜之计，不是范例** ——
+ *    改 settings-chrome.css 里的对应规则时，记得这里还有一份。
+ */
+.section > .app-card {
+  margin-top: var(--theme-spacing-lg);
+}
+.card-desc {
+  margin: 0 0 var(--theme-spacing-md);
+  font-size: 0.85rem;
+  color: var(--theme-text-muted);
+  line-height: 1.55;
+}
+
+/* 规则表单底部的确认/取消 */
+.rule-form-actions {
+  display: flex;
+  gap: var(--theme-spacing-sm);
+  margin-top: var(--theme-spacing-md);
+  justify-content: flex-end;
 }
 </style>

--- a/src/ui/components/settings/DataSection.vue
+++ b/src/ui/components/settings/DataSection.vue
@@ -156,7 +156,7 @@ async function clearAll() {
         <p class="text-muted text-sm">
           将所有存档、角色、记忆、剧情导出为 JSON 文件（不含音频库与素材库）
         </p>
-        <AppButton variant="secondary" size="sm" style="margin-top: 8px" @click="exportAll"
+        <AppButton variant="secondary" size="sm" class="card-action" @click="exportAll"
           >导出全部数据</AppButton
         ></AppCard
       ><AppCard padding="md"
@@ -164,7 +164,7 @@ async function clearAll() {
         <p class="text-muted text-sm">
           从 JSON 文件恢复数据，将合并到现有数据库（同样不含音频与素材）
         </p>
-        <AppButton variant="secondary" size="sm" style="margin-top: 8px" @click="importAll"
+        <AppButton variant="secondary" size="sm" class="card-action" @click="importAll"
           >导入数据</AppButton
         ></AppCard
       ><AppCard padding="md"
@@ -202,7 +202,7 @@ async function clearAll() {
           <AppButton
             variant="secondary"
             size="sm"
-            style="margin-top: 8px"
+            class="card-action"
             :disabled="cleanableCount === 0"
             @click="showImageCleanConfirm = true"
             >清理图片文件</AppButton
@@ -216,11 +216,7 @@ async function clearAll() {
         <p class="text-muted text-sm">
           永久删除所有存档、角色、记忆、设置，以及上传的音频曲库与播放列表、素材库。不可撤销。
         </p>
-        <AppButton
-          variant="danger"
-          size="sm"
-          style="margin-top: 8px"
-          @click="showClearConfirm = true"
+        <AppButton variant="danger" size="sm" class="card-action" @click="showClearConfirm = true"
           >清除所有数据</AppButton
         ></AppCard
       >

--- a/src/ui/components/settings/MessagesSection.vue
+++ b/src/ui/components/settings/MessagesSection.vue
@@ -27,7 +27,7 @@ function eventFilterLabel(key: string | number): string {
     <h3>消息显示</h3>
     <p class="section-desc">控制对话流中系统通知的可见性。关闭后对应类型的消息将不在正文中渲染。</p>
 
-    <AppCard padding="md" style="margin-top: 16px">
+    <AppCard padding="md">
       <h4>全局开关</h4>
       <div class="toggle-row">
         <span>显示系统通知</span>
@@ -38,11 +38,9 @@ function eventFilterLabel(key: string | number): string {
       </div>
     </AppCard>
 
-    <AppCard padding="md" style="margin-top: 12px">
+    <AppCard padding="md">
       <h4>分类控制</h4>
-      <p class="text-muted text-sm" style="margin-bottom: 12px">
-        选择哪些类型的系统事件在对话流中展示
-      </p>
+      <p class="card-desc">选择哪些类型的系统事件在对话流中展示</p>
       <div class="event-filter-grid">
         <div v-for="(enabled, key) in s.systemEventFilters" :key="key" class="toggle-row">
           <span>{{ eventFilterLabel(key) }}</span>

--- a/src/ui/components/settings/PlotSection.vue
+++ b/src/ui/components/settings/PlotSection.vue
@@ -64,7 +64,7 @@ const plotDifficultyOptions = [
       </div></AppCard
     >
     <!-- 模式 & 参数 -->
-    <AppCard padding="md" class="detail-card" style="margin-top: 16px"
+    <AppCard padding="md" class="detail-card"
       ><h4>剧情模式 & 参数</h4>
       <div class="form-grid">
         <label class="form-label"
@@ -179,7 +179,6 @@ const plotDifficultyOptions = [
       padding="md"
       class="detail-card plot-preview-card"
       :class="{ 'plot-revealed': showPlotPreview }"
-      style="margin-top: 16px"
     >
       <div class="plot-preview-header">
         <h4>剧情大纲预览</h4>
@@ -199,7 +198,7 @@ const plotDifficultyOptions = [
         <p class="text-muted text-sm"><strong>第五年 — 终章：命定之诗</strong></p>
         <p class="text-muted text-sm">完成主线任务，世界线尘埃落定，角色结局生成...</p>
       </div>
-      <p class="text-xs text-muted" style="margin-top: 8px">
+      <p class="text-xs text-muted plot-note">
         以上为示例大纲。实际内容由 AI 在游戏开始时生成。点击可切换模糊/清晰。
       </p>
     </AppCard>
@@ -282,5 +281,9 @@ const plotDifficultyOptions = [
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+/* 大纲预览下方的补充说明 */
+.plot-note {
+  margin-top: var(--theme-spacing-sm);
 }
 </style>

--- a/src/ui/components/settings/SettingsPage.agent-nav.test.ts
+++ b/src/ui/components/settings/SettingsPage.agent-nav.test.ts
@@ -1,0 +1,62 @@
+/**
+ * 设置页 Agent 子导航 —— 「上次选的那个」要能回得来
+ *
+ * 修的 bug：主导航里**每一个**按钮（包括「Agent 配置」自己）都无条件
+ * `activeAgent = null`。而 `activeSection` 初值是 'api'，想进 Agent 分区必须点那
+ * 一下 —— 于是 `s.activeAgent` 变成一个存了却永远读不回来的值，用户每次进来都落在
+ * 「← 请从左侧选择一个 Agent」空态。持久化白做，还白搭一次点击。
+ *
+ * 两层守：
+ *   1. 纯函数 `resolveAgentSelection` 的行为（陈旧 id / 空值 / D53 的 image_prompt）
+ *   2. 接线本身 —— 源码断言，照本目录既有做法（mount 整个设置页要拖进 API 池 /
+ *      世界书 / Agent 一整片启动逻辑）
+ */
+import { describe, it, expect } from 'vitest';
+import source from '@ui/components/settings/SettingsPage.vue?raw';
+import { AGENT_LIST, resolveAgentSelection } from '@ui/components/settings/agent/agent-list';
+
+describe('resolveAgentSelection', () => {
+  it('清单里有的 id 原样放行', () => {
+    expect(resolveAgentSelection('story')).toBe('story');
+    for (const a of AGENT_LIST) expect(resolveAgentSelection(a.id)).toBe(a.id);
+  });
+
+  it('清单里没有的陈旧 id → null（否则页头渲染成空白，子导航无一项高亮）', () => {
+    expect(resolveAgentSelection('已经下线的_agent')).toBeNull();
+  });
+
+  it('image_prompt → null —— 它按 D53 刻意不在 AGENT_LIST 里', () => {
+    expect(AGENT_LIST.some((a) => a.id === 'image_prompt')).toBe(false);
+    expect(resolveAgentSelection('image_prompt')).toBeNull();
+  });
+
+  it('空值一律 null，不抛', () => {
+    expect(resolveAgentSelection(null)).toBeNull();
+    expect(resolveAgentSelection(undefined)).toBeNull();
+    expect(resolveAgentSelection('')).toBeNull();
+  });
+});
+
+describe('SettingsPage 主导航接线', () => {
+  it('导航点击走 selectSection，模板里不再内联置 null', () => {
+    // 只看 <template>：bug 本体是那个内联 handler，而 <script> 的注释里正记着
+    // 它长什么样 —— 拿整份源码做否定断言会被自己的注释绊倒
+    const template = source.slice(source.indexOf('<template>'), source.indexOf('</template>'));
+    expect(template).toContain('@click="selectSection(item.key)"');
+    expect(template).not.toContain('activeAgent = null');
+  });
+
+  it('进 Agent 分区时恢复持久化的选择，而不是清掉它', () => {
+    const start = source.indexOf('function selectSection');
+    expect(start).toBeGreaterThan(-1);
+    const body = source.slice(start, source.indexOf('\n}', start));
+    expect(body).toContain("key === 'agent'");
+    expect(body).toContain('resolveAgentSelection(s.activeAgent)');
+    // 别把置 null 搬进函数体里 —— 那是同一个 bug 换个地方待着
+    expect(body).not.toContain('= null');
+  });
+
+  it('初值也过同一道校验，不直接吃 s.activeAgent', () => {
+    expect(source).toContain('ref<string | null>(resolveAgentSelection(s.activeAgent))');
+  });
+});

--- a/src/ui/components/settings/SettingsPage.vue
+++ b/src/ui/components/settings/SettingsPage.vue
@@ -19,7 +19,7 @@ import { useWorldBookStore } from '../../stores/worldbook-store';
 import AppButton from '../shared/AppButton.vue';
 import AgentSection from './agent/AgentSection.vue';
 import AgentUpdateCenter from './agent/AgentUpdateCenter.vue';
-import { AGENT_LIST } from './agent/agent-list';
+import { AGENT_LIST, resolveAgentSelection } from './agent/agent-list';
 import ApiSection from './ApiSection.vue';
 import WorldBookSection from './WorldBookSection.vue';
 import PlotSection from './PlotSection.vue';
@@ -82,16 +82,40 @@ const navItems: { key: Section; label: string; icon: string }[] = [
   { key: 'about', label: '关于', icon: 'fa-solid fa-circle-info' },
 ];
 
-/** 子导航当前选中的 Agent（null = 显示「未选择」空态） */
-const activeAgent = ref<string | null>(s.activeAgent);
+/**
+ * 子导航当前选中的 Agent（null = 显示「未选择」空态）。
+ *
+ * 读回来的持久化值先过 `resolveAgentSelection` —— 陈旧 id 的判定是纯函数，
+ * 连同「为什么不能原样用」的理由一起放在 `agent-list.ts`。
+ */
+const activeAgent = ref<string | null>(resolveAgentSelection(s.activeAgent));
+
+/**
+ * 切主分区。
+ *
+ * 🔴 进 Agent 分区时**恢复上次选中的那个**，不要置 null。此前这里对每一个导航项
+ *    都无条件 `activeAgent = null`（含「Agent 配置」自己），于是 `s.activeAgent`
+ *    成了一个**存了却永远读不到**的值：`activeSection` 初值是 'api'，想进 Agent
+ *    分区必须点一下那个按钮，而那一下正好把选择清掉 —— 每次都落在
+ *    「← 请从左侧选择一个 Agent」空态，持久化白做。
+ *
+ *    置 null 当初是为了「强制重挂载，好让草稿的 immediate watch 触发」。那件事
+ *    本来就由 `v-if` 保证：整个 Agent 分区随 `activeSection` 挂载/卸载，进来时
+ *    永远是新挂载，`AgentConfigPanel` 的 `watch(..., { immediate: true })` 照常
+ *    在挂载那一刻用正确的 agentId 触发。所以这里不需要拿一次用户点击去换它。
+ */
+function selectSection(key: Section) {
+  activeSection.value = key;
+  if (key === 'agent') activeAgent.value = resolveAgentSelection(s.activeAgent);
+}
 
 /**
  * 选一个 Agent。
  *
  * 只做**页面骨架**该做的两件事：记住选了谁、把它持久化。草稿载入随
  * `AgentConfigPanel` 的 `watch(agentId, …, { immediate: true })` 走 ——
- * 本组件每次进 Agent 分区都会把 `activeAgent` 置 null（下方主导航），
- * 所以那边永远是新挂载，immediate 会在同一时刻触发。
+ * 分区整块是 `v-if`，进来时永远是新挂载，immediate 会在同一时刻触发；
+ * 在分区内换 Agent 则走 prop 变化，同一条 watch 照常触发。
  */
 function selectAgent(agentId: string) {
   activeAgent.value = agentId;
@@ -132,10 +156,7 @@ onMounted(() => {
           :key="item.key"
           class="nav-item"
           :class="{ 'nav-active': activeSection === item.key }"
-          @click="
-            activeSection = item.key;
-            activeAgent = null;
-          "
+          @click="selectSection(item.key)"
         >
           <span class="nav-icon"><i :class="item.icon" aria-hidden="true"></i></span>
           <span class="nav-label">{{ item.label }}</span>
@@ -188,11 +209,12 @@ onMounted(() => {
 
             <!-- Agent 未选择时的提示 -->
             <section v-if="activeSection === 'agent' && !activeAgent" class="section centered">
-              <div style="text-align: center; padding: 60px 0 24px">
-                <p class="text-muted" style="font-size: 1.1rem">← 请从左侧选择一个 Agent</p>
-                <p class="text-sm text-muted" style="margin-top: 8px">
-                  每个 Agent 需要单独配置模型和世界书上下文
-                </p>
+              <div class="empty-tab">
+                <i class="fa-solid fa-robot empty-tab-icon" aria-hidden="true"></i>
+                请从左侧选择一个 Agent
+                <span class="empty-tab-hint">
+                  每个 Agent 单独配置 API 池、采样参数与可见的世界书；名字旁的角标是它配好了没有
+                </span>
               </div>
               <!-- 提示词更新中心：项目默认更新后，用户存量配置不会自动跟新（fillMissing
                    只填空位），这里给一个一键同步的入口。没有更新时组件自己不渲染。 -->

--- a/src/ui/components/settings/ThemeSection.vue
+++ b/src/ui/components/settings/ThemeSection.vue
@@ -2,9 +2,15 @@
 /**
  * 外观主题分区 —— 10 套主题 + 字体 / 字号 / 悬停延迟 / 减少动态效果
  * （Q-25 从 SettingsPage.vue 抽出）
+ *
+ * 🔴 字体是**两格独立设置**（正文 / 标题），不是一个三档单选。旧的「字体风格」
+ *    只写 `--theme-font-body`，`mixed` 那档渲染出来与 `sans` 完全一样（它只是
+ *    一条字体栈，有中文字形的字符全部命中第一个）—— 三个选项实际只有两种结果。
+ *    拆成两格之后，「标题字体」才第一次能碰到 `--theme-font-title`
+ *    （叙事正文、角色名、物品名、全部分区标题，共 111 处引用）。
  */
 import AppCard from '../shared/AppCard.vue';
-import { useThemeStore } from '../../stores/theme-store';
+import { useThemeStore, type FontFamilyChoice } from '../../stores/theme-store';
 import { useUIStore } from '../../stores/ui-store';
 import { useSettingsStore } from '../../stores/settings-store';
 
@@ -15,6 +21,11 @@ const s = useSettingsStore().settings;
 function selectTheme(id: string) {
   theme.apply(id);
   ui.toast(`主题：${theme.currentTheme?.nameZh}`, 'success');
+}
+
+/** `<select>` 的值收窄成字体选项 —— 两个下拉框共用，省掉模板里的 `as any` */
+function asFontChoice(e: Event): FontFamilyChoice {
+  return (e.target as HTMLSelectElement).value === 'serif' ? 'serif' : 'sans';
 }
 </script>
 
@@ -46,19 +57,33 @@ function selectTheme(id: string) {
         ><span v-if="t.id === theme.current" class="theme-check">✓</span>
       </button>
     </div>
-    <AppCard padding="md" style="margin-top: 16px"
+    <AppCard padding="md"
       ><div class="form-grid">
         <label class="form-label"
-          >字体风格
-          <p class="form-hint">衬线体更有古典文学感，无衬线体更适合长时间阅读</p>
+          >正文字体
+          <p class="form-hint">
+            界面标签、表单、列表与说明文字。无衬线更适合长时间阅读，也是默认值。
+          </p>
           <select
             class="form-input"
-            :value="theme.fonts"
-            @change="theme.setFonts(($event.target as HTMLSelectElement).value as any)"
+            :value="theme.fontBody"
+            @change="theme.setFontBody(asFontChoice($event))"
           >
             <option value="sans">无衬线 (Noto Sans SC)</option>
             <option value="serif">衬线 (Noto Serif SC)</option>
-            <option value="mixed">混合</option>
+          </select></label
+        ><label class="form-label"
+          >标题字体
+          <p class="form-hint">
+            分区标题、叙事正文、角色名与物品名。衬线体是古籍手稿观感的来源，改成无衬线会让全站失去这层对比。
+          </p>
+          <select
+            class="form-input"
+            :value="theme.fontTitle"
+            @change="theme.setFontTitle(asFontChoice($event))"
+          >
+            <option value="serif">衬线 (Noto Serif SC)</option>
+            <option value="sans">无衬线 (Noto Sans SC)</option>
           </select></label
         ><label class="form-label"
           >字体大小

--- a/src/ui/components/settings/WorldBookEditor.vue
+++ b/src/ui/components/settings/WorldBookEditor.vue
@@ -40,12 +40,12 @@
       >
     </div>
 
-    <!-- 空状态 -->
-    <div v-if="sortedEntries.length === 0" class="empty-state">
-      <i class="fa-solid fa-book-open empty-icon" aria-hidden="true"></i>
-      <p class="empty-title">暂无条目</p>
-      <p class="empty-desc">点击「新建条目」开始添加世界书内容</p>
-      <button class="add-btn" @click="addEntry">新建条目</button>
+    <!-- 空状态（全站唯一一套 `.empty-tab`，见 styles/utilities.css） -->
+    <div v-if="sortedEntries.length === 0" class="empty-tab">
+      <i class="fa-solid fa-book-open empty-tab-icon" aria-hidden="true"></i>
+      这本世界书还没有条目
+      <span class="empty-tab-hint">条目是注入给 AI 的知识块，按关键词或常驻方式生效</span>
+      <button class="empty-tab-action" @click="addEntry">新建条目</button>
     </div>
 
     <!-- 条目表格 -->
@@ -458,33 +458,9 @@ watch(
   gap: 6px;
 }
 
-/* ===== 空状态 ===== */
-.empty-state {
-  text-align: center;
-  padding: 48px 16px;
-  border: 2px dashed var(--theme-card-border);
-  border-radius: var(--theme-radius-md, 8px);
-}
-
-.empty-icon {
-  font-size: 2.5rem;
-  color: var(--theme-text-muted);
-  margin-bottom: 12px;
-  opacity: 0.5;
-}
-
-.empty-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--theme-text-primary);
-  margin: 0 0 4px;
-}
-
-.empty-desc {
-  font-size: 0.85rem;
-  color: var(--theme-text-muted);
-  margin: 0 0 16px;
-}
+/* 空状态的样式**不在这里** —— 全站唯一一份 `.empty-tab` 在 styles/utilities.css
+ * （design.md §5.2）。本组件原先自带一套 `.empty-state` / `.empty-icon` /
+ * `.empty-title` / `.empty-desc`，是设置页三种空态方言里的第三种。 */
 
 /* ===== 条目表格 ===== */
 .entry-table {

--- a/src/ui/components/settings/WorldBookSection.vue
+++ b/src/ui/components/settings/WorldBookSection.vue
@@ -227,10 +227,13 @@ async function handleWorldBookUpdate(updated: WorldBook) {
       </div>
 
       <AppCard v-if="wb.books.length === 0" padding="md">
-        <p class="text-muted text-sm" style="text-align: center; padding: 40px 0">
-          暂无世界书<br />
-          <span style="font-size: 0.75rem">点击右上角"导入ST世界书"或"新建世界书"开始</span>
-        </p>
+        <div class="empty-tab">
+          <i class="fa-solid fa-book-open empty-tab-icon" aria-hidden="true"></i>
+          还没有任何世界书
+          <span class="empty-tab-hint">
+            用右上角「导入 ST 世界书」读入一份 SillyTavern 的 JSON，或「新建世界书」从空白开始
+          </span>
+        </div>
       </AppCard>
 
       <div v-else class="worldbook-list">

--- a/src/ui/components/settings/agent/AgentConfigPanel.test.ts
+++ b/src/ui/components/settings/agent/AgentConfigPanel.test.ts
@@ -5,7 +5,7 @@
  *
  *   `watch(() => props.agentId, loadDrafts, { immediate: true })`
  *
- * 主导航每次点击都会把 `activeAgent` 置 null，所以本组件永远是新挂载的 ——
+ * Agent 分区在 SettingsPage 里是 `v-if`，每次进分区本组件都是新挂载的 ——
  * 少了 `immediate`，两个 textarea 会空着渲染，用户随手点一下「保存设置」就把
  * **空串**写进了自己的 systemPrompt。这条 bug 不会让类型检查变红、也不会让页面
  * 报错，只会静默吃掉用户的提示词。所以下面第一组用例是真正的看门人。

--- a/src/ui/components/settings/agent/AgentConfigPanel.vue
+++ b/src/ui/components/settings/agent/AgentConfigPanel.vue
@@ -17,11 +17,15 @@
  *    仍由 `AgentSection` 的**单根** `<section>` 负责，见那边的文件头。
  *
  * 🔴 草稿载入必须是 `watch(..., { immediate: true })`，**immediate 不是可选项**：
- *    主导航每次点击都把 `activeAgent` 置 null（SettingsPage 的 nav 里），
- *    所以本组件永远是**新挂载**的。普通 watch 在挂载时不触发，两个 textarea 会
- *    空着渲染，接着「保存设置」把空串写进用户的提示词。抽壳之后这条 watch 必须
- *    留在**本组件**（草稿在这里，宿主看不见它们）——
+ *    整个 Agent 分区在 SettingsPage 里是 `v-if`，随 `activeSection` 挂载/卸载，
+ *    所以每次进分区本组件都是**新挂载**的。普通 watch 在挂载时不触发，两个
+ *    textarea 会空着渲染，接着「保存设置」把空串写进用户的提示词。抽壳之后这条
+ *    watch 必须留在**本组件**（草稿在这里，宿主看不见它们）——
  *    回归测试见 `AgentConfigPanel.test.ts` 第一条。
+ *
+ *    （历史：这里原先写的理由是「主导航每次点击都把 activeAgent 置 null」。那个
+ *    置 null 已经删掉了 —— 它让持久化的 Agent 选择永远读不回来。结论没变，
+ *    是 `v-if` 在保证新挂载，不是那次置 null。）
  */
 import { computed, ref, watch } from 'vue';
 import AppButton from '../../shared/AppButton.vue';

--- a/src/ui/components/settings/agent/AgentParamsCard.vue
+++ b/src/ui/components/settings/agent/AgentParamsCard.vue
@@ -219,7 +219,7 @@ void ref;
   <AppCard padding="md" class="detail-card">
     <h4>世界书配置</h4>
     <p class="form-hint">启用该 Agent 的世界书上下文注入。选择要关联的世界书。</p>
-    <div class="key-row" style="margin-bottom: 8px">
+    <div class="key-row key-row-stacked">
       <label class="toggle-label">
         <span class="text-sm text-secondary">启用世界书</span>
         <input
@@ -295,5 +295,9 @@ void ref;
   flex: 1;
   font-size: 14px;
   font-weight: 500;
+}
+/* 竖直堆叠的 key-row（上面还有一行同类控件时留一跳） */
+.key-row-stacked {
+  margin-bottom: var(--theme-spacing-sm);
 }
 </style>

--- a/src/ui/components/settings/agent/AgentPromptCard.vue
+++ b/src/ui/components/settings/agent/AgentPromptCard.vue
@@ -109,7 +109,7 @@ async function insertPlaceholder(key: string) {
     </div>
 
     <!-- Section 3: Template Preview -->
-    <div style="margin-top: 12px">
+    <div class="prompt-block">
       <AppButton variant="ghost" size="sm" @click="showTemplatePreview = !showTemplatePreview">
         {{ showTemplatePreview ? '收起预览' : '模板预览' }}
       </AppButton>
@@ -157,5 +157,9 @@ async function insertPlaceholder(key: string) {
 .placeholder-badge:hover {
   transform: translateY(-1px);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+/* 提示词卡内的下一块（占位符徽章 / 预览面板之类） */
+.prompt-block {
+  margin-top: var(--theme-spacing-md);
 }
 </style>

--- a/src/ui/components/settings/agent/AgentSection.vue
+++ b/src/ui/components/settings/agent/AgentSection.vue
@@ -13,8 +13,8 @@
  *    `AgentConfigPanel` 是多根的，它必须待在这层 `<section>` 里面才有外框。
  *
  * 🔴 草稿的 `watch(..., { immediate: true })` 在 `AgentConfigPanel` 里，别搬回来：
- *    主导航每次点击都把 `activeAgent` 置 null（SettingsPage 的 nav 里），
- *    所以这条链上的组件永远是**新挂载**的，普通 watch 在挂载时不触发，
+ *    本分区在 SettingsPage 里是 `v-if`，随 `activeSection` 挂载/卸载，所以这条链上
+ *    的组件每次进分区都是**新挂载**的，普通 watch 在挂载时不触发，
  *    两个 textarea 会空着渲染，接着「保存设置」把空串写进用户的提示词。
  */
 import { computed } from 'vue';

--- a/src/ui/components/settings/agent/PresetManager.vue
+++ b/src/ui/components/settings/agent/PresetManager.vue
@@ -430,7 +430,7 @@ void reactive;
     </div>
 
     <!-- Phase 10e: Story Agent template preview -->
-    <div style="margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap">
+    <div class="preset-actions">
       <AppButton variant="ghost" size="sm" @click="showStoryPreview = !showStoryPreview">
         {{ showStoryPreview ? '收起模板预览' : '模板预览' }}
       </AppButton>
@@ -764,5 +764,12 @@ void reactive;
 .preset-empty {
   padding: 24px;
   text-align: center;
+}
+/* 预设卡底部的一排动作按钮 */
+.preset-actions {
+  margin-top: var(--theme-spacing-md);
+  display: flex;
+  gap: var(--theme-spacing-sm);
+  flex-wrap: wrap;
 }
 </style>

--- a/src/ui/components/settings/agent/agent-list.ts
+++ b/src/ui/components/settings/agent/agent-list.ts
@@ -63,6 +63,24 @@ export const AGENT_LIST: readonly AgentListEntry[] = [
   { id: 'plot_outline', name: '大纲生成', desc: '主线/支线模式下生成剧情大纲和事件树', stage: 5 },
 ];
 
+/**
+ * 把**持久化的** Agent 选择解析成一个当前仍然有效的 id（查不到 → null）。
+ *
+ * `settings.activeAgent` 存在 localStorage 里，而本清单是会改的（新增 / 改名 /
+ * 下线一个 Agent）。直接拿旧值去渲染，`AgentSection` 的页头会是**空白** ——
+ * 它取的是 `AGENT_LIST.find(...)?.name` —— 子导航里也没有任何一项高亮，
+ * 于是用户面对的是一个说不出自己是谁的配置面。查不到就退回「未选择」空态。
+ *
+ * 🔴 与 `agentDisplayName` 的「查不到就原样显示 id」**刻意相反**：那个是在已经
+ *    决定要显示某个 Agent 之后尽量说点什么，这个是在决定**要不要显示**。
+ *    一个不在清单里的 id 没有子导航项可高亮，让它进去只会得到半个界面。
+ *    顺带接住 `image_prompt` —— 它按 D53 刻意不在 AGENT_LIST 里。
+ */
+export function resolveAgentSelection(persisted: string | null | undefined): string | null {
+  if (!persisted) return null;
+  return AGENT_LIST.some((a) => a.id === persisted) ? persisted : null;
+}
+
 /** 找一个 Agent 的展示名；查不到就把 id 原样显示出来，不吞掉未知 Agent */
 export function agentDisplayName(agentId: string | null): string {
   if (!agentId) return '';

--- a/src/ui/components/settings/assets/AssetLibrary.vue
+++ b/src/ui/components/settings/assets/AssetLibrary.vue
@@ -543,21 +543,8 @@ function onGroupKey(g: AssetGroup, e: KeyboardEvent): void {
 }
 
 /* ═══ 空态 ═══ */
-.empty-tab {
-  padding: var(--theme-spacing-2xl) 0;
-  text-align: center;
-  color: var(--theme-text-muted);
-  font-size: 0.8125rem;
-  font-style: italic;
-  line-height: 1.7;
-}
-.empty-tab::before {
-  content: '—';
-  display: block;
-  margin-bottom: var(--theme-spacing-sm);
-  font-size: 1.25rem;
-  opacity: 0.3;
-}
+/* 空态样式在 styles/utilities.css（全站唯一一份 `.empty-tab`，design.md §5.2）——
+ * 本组件原先自带一份拷贝，三份之间已经开始漂移（padding xl vs 2xl / 多一条 line-height）。 */
 .conv-code {
   font-family: 'Cascadia Code', monospace;
   font-size: 0.75rem;

--- a/src/ui/components/settings/audio/AudioLibrary.vue
+++ b/src/ui/components/settings/audio/AudioLibrary.vue
@@ -663,20 +663,8 @@ async function audition(t: AudioTrack): Promise<void> {
 }
 
 /* ═══ 空态 ═══ */
-.empty-tab {
-  padding: var(--theme-spacing-xl) 0;
-  text-align: center;
-  color: var(--theme-text-muted);
-  font-size: 0.8125rem;
-  font-style: italic;
-}
-.empty-tab::before {
-  content: '—';
-  display: block;
-  margin-bottom: var(--theme-spacing-sm);
-  font-size: 1.25rem;
-  opacity: 0.3;
-}
+/* 空态样式在 styles/utilities.css（全站唯一一份 `.empty-tab`，design.md §5.2）——
+ * 本组件原先自带一份拷贝，三份之间已经开始漂移（padding xl vs 2xl / 多一条 line-height）。 */
 
 /* ═══ 无障碍：视觉隐藏（保留在无障碍树里） ═══ */
 .sr-only {

--- a/src/ui/components/settings/audio/AudioPlaylists.vue
+++ b/src/ui/components/settings/audio/AudioPlaylists.vue
@@ -288,20 +288,8 @@ function resetDrag(): void {
 }
 
 /* ═══ 空态 ═══ */
-.empty-tab {
-  padding: var(--theme-spacing-xl) 0;
-  text-align: center;
-  color: var(--theme-text-muted);
-  font-size: 0.8125rem;
-  font-style: italic;
-}
-.empty-tab::before {
-  content: '—';
-  display: block;
-  margin-bottom: var(--theme-spacing-sm);
-  font-size: 1.25rem;
-  opacity: 0.3;
-}
+/* 空态样式在 styles/utilities.css（全站唯一一份 `.empty-tab`，design.md §5.2）——
+ * 本组件原先自带一份拷贝，三份之间已经开始漂移（padding xl vs 2xl / 多一条 line-height）。 */
 
 /* ═══ 播放列表 ═══ */
 .playlist-grid {

--- a/src/ui/components/settings/image/ImagePresetList.vue
+++ b/src/ui/components/settings/image/ImagePresetList.vue
@@ -516,11 +516,18 @@ function summarize(row: ImagePreset): string {
   color: var(--theme-primary);
   margin-right: 4px;
 }
-/* 只有本档外貌的角色（v1.3）—— 与上面那张表刻意分开，两者的归属不同 */
+/* 只有本档外貌的角色（v1.3）—— 与上面那张表刻意分开，两者的归属不同
+ *
+ * 🔴 边框一律 `--theme-card-border`（design.md 禁令表）：这里原本写的是
+ *    `--theme-border`，那个 token 全仓没有定义，且没写 fallback ——
+ *    整条声明 invalid at computed-value time，`border-top-style` 退回初始值
+ *    `none`，于是**这条线根本没画出来**。而它承担的正是 D60/D61 的语义：
+ *    把「有基线预设的角色」与「只有本档临时外貌的角色」分开。唯一说明
+ *    两张表归属不同的视觉线索，此前是隐形的。 */
 .session-only {
   margin-top: var(--theme-spacing-md);
   padding-top: var(--theme-spacing-md);
-  border-top: 1px solid var(--theme-border);
+  border-top: 1px solid var(--theme-card-border);
 }
 .session-only-head {
   margin: 0 0 4px;
@@ -592,21 +599,7 @@ function summarize(row: ImagePreset): string {
   border: 1px solid color-mix(in srgb, var(--theme-primary) 30%, transparent);
 }
 
-/* 空态：装饰符 + 斜体（design.md §5.2） */
-.empty-tab {
-  padding: 32px 0;
-  text-align: center;
-  color: var(--theme-text-muted);
-  font-size: 0.8125rem;
-  font-style: italic;
-}
-.empty-tab::before {
-  content: '—';
-  display: block;
-  margin-bottom: var(--theme-spacing-sm);
-  font-size: 1.25rem;
-  opacity: 0.3;
-}
+/* 空态样式在 styles/utilities.css（全站唯一一份 `.empty-tab`，design.md §5.2） */
 
 .confirm-text {
   margin: 0;

--- a/src/ui/components/settings/settings-chrome.css
+++ b/src/ui/components/settings/settings-chrome.css
@@ -19,6 +19,36 @@
  *    重复一份只会让人以为改这里就够了。
  */
 
+/* ═══ 分区纵向节奏 ═══
+ *
+ * 分区里**块与块之间的间距由这一条规则给**，模板里不要再写
+ * `style="margin-top: 16px"`。收编前设置页有 45 处内联间距，而「首卡 16、次卡 12」
+ * 是一条从没写下来的约定 —— 于是有的分区守、有的不守，实际出现过 8 / 12 / 16 / 20 /
+ * 24 / 40 / 60 七种值。design.md §3.1 早就规定间距一律取 `--theme-spacing-*`。
+ *
+ * 🔴 那些内联的 `margin-top: 16px` 里，**第一张卡上的那个从来没生效过**:
+ *    `.section-desc` 的 `margin-bottom: 20px` 与它是相邻兄弟，外边距合并取
+ *    max(20, 16) = 20px。抄了七八遍的一个值，其中一半是死的 —— 这正是内联间距
+ *    最典型的下场：没人能一眼看出哪个数字真的在起作用。
+ */
+.section > .app-card {
+  margin-top: var(--theme-spacing-lg);
+}
+
+/* 卡片里紧跟 `h4` 的那行说明 —— 与 `.section-desc` 是同一件事，只是低一级。
+   此前写成 `class="text-muted text-sm" style="margin-bottom: 12px"`，三处各抄一遍。 */
+.card-desc {
+  margin: 0 0 var(--theme-spacing-md);
+  font-size: 0.85rem;
+  color: var(--theme-text-muted);
+  line-height: 1.55;
+}
+
+/* 卡片内「说明 → 动作按钮」之间那一跳（存档数据分区有四处一模一样的 8px） */
+.card-action {
+  margin-top: var(--theme-spacing-sm);
+}
+
 /* ═══ 分区标题与描述 ═══ */
 .section > h3 {
   font-family: var(--theme-font-title);

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -7,6 +7,28 @@ import { installUnlockListener } from './lib/audio-singleton';
 import { installProductionEjsBackend } from '@engine/ejs-backend';
 import { setEngineSettingsProvider } from '@engine/engine-settings';
 import { useSettingsStore } from './stores/settings-store';
+// 字体与图标 —— **自托管**，零外部请求（2026-08-05，替掉 index.html 里的两个 CDN）。
+//
+// 🔴 必须排在所有样式表**之前**：`@font-face` 得先登记，否则首屏那一瞬按兜底字体排版，
+//    字体到位后再回流一次（CJK 字面宽度差很大，那一跳很显眼）。
+//
+// 用的是 **variable** 包（`@fontsource-variable/*`）而不是逐字重的静态包：
+// 静态包 4 个字重 × 2 个中文族约 34MB，变量包一共 10.6MB 就覆盖 100–900 全区间。
+// 两个包都保留了 Google 的 unicode-range 切片（每族 101 个子集），所以浏览器仍然
+// 只下载正文真正用到的那几片，不是一次拉整族。
+//
+// 🔴 字体族名是 `'Noto Sans SC Variable'`（带 Variable 后缀），与静态包不同 ——
+//    `themes/variables.css` 与 `stores/theme-store.ts` 的字体栈必须写这个名字，
+//    写成 `'Noto Sans SC'` 不会报错，只会安静地退回系统字体。
+import '@fontsource-variable/noto-sans-sc';
+import '@fontsource-variable/noto-serif-sc';
+import '@fontsource-variable/cinzel';
+// Font Awesome 只引用到的两套：fa-solid（221 处）+ fa-regular（2 处）。
+// **刻意不引 brands.css** —— 全仓零处使用，省掉 fa-brands-400.woff2。
+import '@fortawesome/fontawesome-free/css/fontawesome.css';
+import '@fortawesome/fontawesome-free/css/solid.css';
+import '@fortawesome/fontawesome-free/css/regular.css';
+
 import './styles/base.css';
 import './styles/transitions.css';
 import './styles/utilities.css';
@@ -33,6 +55,9 @@ app.use(pinia);
 const themeStore = useThemeStore();
 themeStore.init();
 themeStore.initFontSize();
+// 🔴 必须跟着 init() 一起跑：这两格是「设置严格压过主题」的执行点，少了它，
+//    字体退回 [data-theme] 说了算，而设置页的下拉框仍显示用户选的值（design.md §7.4）
+themeStore.initFonts();
 
 // 引擎读设置的注入缝（Q-06）。
 //

--- a/src/ui/stores/theme-store.fonts.test.ts
+++ b/src/ui/stores/theme-store.fonts.test.ts
@@ -1,0 +1,147 @@
+/**
+ * theme-store 的两格字体设置 —— design.md §7.4 那条 bug 的回归测试
+ *
+ * 原来的形状有三处缺陷，这里逐条钉住：
+ *   1. `setFonts()` 往 `fated-poem-fonts` **写了却没人读** —— 全项目没有 initFonts()，
+ *      刷新后 ref 重置成默认、DOM 上也没有内联覆盖，于是字体退回主题说了算，
+ *      而设置页的下拉框仍显示用户选的值。
+ *   2. `parchment` / `ivory` 把 `--theme-font-body` 定义成衬线 —— 换个主题就悄悄
+ *      换掉正文字体。字体已从主题 CSS 全部移除（那三处的断言在 themes 那边）。
+ *   3. `mixed` 档写的是 `'Noto Sans SC', 'Noto Serif SC', sans-serif` —— 一条字体栈，
+ *      有中文字形的字符全部命中第一个，所以它渲染出来和 `sans` 一模一样。
+ *      三个选项实际只有两种结果，现在拆成正文/标题两格。
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useThemeStore } from './theme-store';
+
+// 与 theme-store 的 FONT_STACKS 一字不差。带 `Variable` 后缀是因为自托管走
+// @fontsource-variable/*，漏掉后缀会安静地退回系统字体（不报错，只是字变了）。
+const SANS = "'Noto Sans SC Variable', 'Noto Sans SC', sans-serif";
+const SERIF = "'Noto Serif SC Variable', 'Noto Serif SC', serif";
+
+/** 直接读 `<html>` 上的内联变量 —— 「设置压过主题」靠的就是它 */
+function inlineVar(slot: 'body' | 'title'): string {
+  return document.documentElement.style.getPropertyValue(`--theme-font-${slot}`);
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  localStorage.clear();
+  document.documentElement.removeAttribute('style');
+});
+
+describe('出厂默认', () => {
+  it('正文无衬线、标题衬线（design.md §2.1 的手稿标题 + 工整正文）', () => {
+    const theme = useThemeStore();
+    theme.initFonts();
+    expect(theme.fontBody).toBe('sans');
+    expect(theme.fontTitle).toBe('serif');
+    expect(inlineVar('body')).toBe(SANS);
+    expect(inlineVar('title')).toBe(SERIF);
+  });
+
+  it('默认值也写内联变量 —— 这是「主题改不动字体」的执行点，不能因为等于默认就跳过', () => {
+    useThemeStore().initFonts();
+    expect(inlineVar('body')).not.toBe('');
+    expect(inlineVar('title')).not.toBe('');
+  });
+});
+
+describe('两格互不干扰', () => {
+  it('改标题不动正文', () => {
+    const theme = useThemeStore();
+    theme.initFonts();
+    theme.setFontTitle('sans');
+    expect(inlineVar('title')).toBe(SANS);
+    expect(inlineVar('body')).toBe(SANS); // 正文本来就是 sans，没被连带改成 serif
+    expect(theme.fontBody).toBe('sans');
+  });
+
+  it('改正文不动标题 —— 旧实现里标题根本碰不到，这是新增的那一格', () => {
+    const theme = useThemeStore();
+    theme.initFonts();
+    theme.setFontBody('serif');
+    expect(inlineVar('body')).toBe(SERIF);
+    expect(inlineVar('title')).toBe(SERIF);
+    theme.setFontTitle('sans');
+    expect(inlineVar('title')).toBe(SANS);
+    expect(inlineVar('body')).toBe(SERIF);
+  });
+});
+
+describe('持久化（bug 的另一半：写了没人读）', () => {
+  it('设过之后能读回来', () => {
+    useThemeStore().setFontBody('serif');
+    useThemeStore().setFontTitle('sans');
+
+    setActivePinia(createPinia());
+    document.documentElement.removeAttribute('style');
+    const fresh = useThemeStore();
+    fresh.initFonts();
+
+    expect(fresh.fontBody).toBe('serif');
+    expect(fresh.fontTitle).toBe('sans');
+    expect(inlineVar('body')).toBe(SERIF);
+    expect(inlineVar('title')).toBe(SANS);
+  });
+
+  it('localStorage 里的垃圾值退回默认，不抛', () => {
+    localStorage.setItem('fated-poem-font-body', 'comic-sans');
+    localStorage.setItem('fated-poem-font-title', '');
+    const theme = useThemeStore();
+    expect(() => theme.initFonts()).not.toThrow();
+    expect(theme.fontBody).toBe('sans');
+    expect(theme.fontTitle).toBe('serif');
+  });
+});
+
+describe('旧的三档单选迁移 —— 照用户实际看到的样子迁，不是照字面', () => {
+  it("legacy 'serif' → 正文衬线，标题仍是默认衬线", () => {
+    localStorage.setItem('fated-poem-fonts', 'serif');
+    const theme = useThemeStore();
+    theme.initFonts();
+    expect(theme.fontBody).toBe('serif');
+    expect(theme.fontTitle).toBe('serif');
+  });
+
+  it("legacy 'mixed' → 正文无衬线（它渲染出来本来就等于 sans，不是第三种结果）", () => {
+    localStorage.setItem('fated-poem-fonts', 'mixed');
+    const theme = useThemeStore();
+    theme.initFonts();
+    expect(theme.fontBody).toBe('sans');
+    expect(theme.fontTitle).toBe('serif');
+  });
+
+  it("legacy 'sans' → 两格都是默认", () => {
+    localStorage.setItem('fated-poem-fonts', 'sans');
+    const theme = useThemeStore();
+    theme.initFonts();
+    expect(theme.fontBody).toBe('sans');
+    expect(theme.fontTitle).toBe('serif');
+  });
+
+  it('已经有新键时不再看旧键 —— 迁移只在两格都没设过时发生', () => {
+    localStorage.setItem('fated-poem-fonts', 'serif');
+    localStorage.setItem('fated-poem-font-body', 'sans');
+    const theme = useThemeStore();
+    theme.initFonts();
+    expect(theme.fontBody).toBe('sans');
+  });
+});
+
+describe('主题不再定义字体（§1 主题无关）', () => {
+  it('apply() 只写 data-theme，不碰字体变量', () => {
+    const theme = useThemeStore();
+    theme.initFonts();
+    theme.setFontBody('serif');
+    theme.apply('parchment');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('parchment');
+    // 换主题之后正文仍是用户选的衬线，而不是被主题接管
+    expect(inlineVar('body')).toBe(SERIF);
+    theme.apply('obsidian');
+    expect(inlineVar('body')).toBe(SERIF);
+  });
+});

--- a/src/ui/stores/theme-store.ts
+++ b/src/ui/stores/theme-store.ts
@@ -82,9 +82,47 @@ export const THEME_LIST: ThemeDefinition[] = [
   },
 ];
 
+/**
+ * 字体族选项 —— 只有这两个，因为 index.html 只加载了这两套中文字形
+ * （Cinzel 是纯装饰拉丁字体，没有中文字形，只服务 `--theme-font-display`，
+ * 不进用户可选项）。
+ */
+export type FontFamilyChoice = 'sans' | 'serif';
+
+/**
+ * 选项 → 真正写进 CSS 变量的字体栈。
+ *
+ * 🔴 第一顺位是带 `Variable` 后缀的族名：自托管走 `@fontsource-variable/*`
+ *    （main.ts 引入），它注册的 `@font-face` 就叫 `'Noto Sans SC Variable'`。
+ *    漏掉后缀不会报错，只会安静地退回系统字体。
+ *    第二顺位留不带后缀的名字，给「自托管文件没到位但系统装了同名字体」兜底。
+ *
+ * 与 `themes/variables.css` 的 `:root` 三行是同一套值（那边是没有 JS 时的兜底），
+ * 改一处要同步另一处 —— `tests/theme-fonts-invariant.test.ts` 会对着这条断言。
+ */
+const FONT_STACKS: Record<FontFamilyChoice, string> = {
+  sans: "'Noto Sans SC Variable', 'Noto Sans SC', sans-serif",
+  serif: "'Noto Serif SC Variable', 'Noto Serif SC', serif",
+};
+
+/**
+ * 出厂默认：**正文无衬线、标题衬线**。
+ *
+ * 与 `themes/variables.css` 的 `:root` 一致（那份仍是没有 JS 时的兜底），
+ * 也就是 design.md §2.1 的「手稿标题 + 工整正文」对比。
+ */
+const DEFAULT_FONT_BODY: FontFamilyChoice = 'sans';
+const DEFAULT_FONT_TITLE: FontFamilyChoice = 'serif';
+
+const LS_FONT_BODY = 'fated-poem-font-body';
+const LS_FONT_TITLE = 'fated-poem-font-title';
+/** 旧的三档单选（'sans' | 'serif' | 'mixed'），只在迁移时读一次 */
+const LS_FONTS_LEGACY = 'fated-poem-fonts';
+
 export const useThemeStore = defineStore('theme', () => {
   const current = ref('obsidian');
-  const fonts = ref<'serif' | 'sans' | 'mixed'>('sans');
+  const fontBody = ref<FontFamilyChoice>(DEFAULT_FONT_BODY);
+  const fontTitle = ref<FontFamilyChoice>(DEFAULT_FONT_TITLE);
   const fontSize = ref('16');
 
   function setFontSize(size: string) {
@@ -131,33 +169,93 @@ export const useThemeStore = defineStore('theme', () => {
     }
   }
 
-  function setFonts(mode: 'serif' | 'sans' | 'mixed') {
-    fonts.value = mode;
-    document.documentElement.style.setProperty(
-      '--theme-font-body',
-      mode === 'serif'
-        ? "'Noto Serif SC', serif"
-        : mode === 'mixed'
-          ? "'Noto Sans SC', 'Noto Serif SC', sans-serif"
-          : "'Noto Sans SC', sans-serif",
-    );
+  /**
+   * 写一格字体。
+   *
+   * 🔴 **一律写内联变量，哪怕值就是出厂默认**。内联样式压得过任何 `[data-theme]`
+   *    规则，所以「设置说了算」这件事是靠这两行内联变量强制的 —— 主题 CSS 想改字体
+   *    也改不动。这正是「严格按设置」的执行点，别改成「和默认值相同就不写」：
+   *    那等于把决定权在默认档上又交还给主题。
+   */
+  function applyFontVar(slot: 'body' | 'title', choice: FontFamilyChoice) {
+    if (typeof document === 'undefined') return;
+    document.documentElement.style.setProperty(`--theme-font-${slot}`, FONT_STACKS[choice]);
+  }
+
+  function persist(key: string, value: string) {
     try {
-      localStorage.setItem('fated-poem-fonts', mode);
+      localStorage.setItem(key, value);
     } catch {
-      /* */
+      // 隐私模式 / 配额满：记不住而已，本次设置已经生效，不值得打断用户
     }
+  }
+
+  /** 正文字体（UI 标签、表单、列表、说明文字） */
+  function setFontBody(choice: FontFamilyChoice) {
+    fontBody.value = choice;
+    applyFontVar('body', choice);
+    persist(LS_FONT_BODY, choice);
+  }
+
+  /** 标题字体（分区标题、叙事正文、角色名/物品名 —— `--theme-font-title` 的全部 111 处） */
+  function setFontTitle(choice: FontFamilyChoice) {
+    fontTitle.value = choice;
+    applyFontVar('title', choice);
+    persist(LS_FONT_TITLE, choice);
+  }
+
+  function readChoice(key: string): FontFamilyChoice | null {
+    try {
+      const v = localStorage.getItem(key);
+      return v === 'sans' || v === 'serif' ? v : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 读回两格字体设置并落到 DOM 上。**必须在挂载前调用一次**（main.ts）。
+   *
+   * 🔴 这个函数此前**根本不存在**，是 design.md §7.4 那条 bug 的一半：`setFonts()`
+   *    往 `fated-poem-fonts` 写了值，而全项目没有任何读取点 —— 刷新后 ref 重置成默认、
+   *    DOM 上也没有内联覆盖，于是字体退回主题说了算，而下拉框还显示着用户选的值。
+   *    另一半是 parchment/ivory 把 `--theme-font-body` 改成了衬线（已从主题 CSS 移除）。
+   *
+   * 迁移：旧的三档单选只影响正文（`mixed` 那档写的是 `'Noto Sans SC', 'Noto Serif SC',
+   * sans-serif` —— 有中文字形的字符全部命中第一个，所以它渲染出来和 `sans` 一模一样）。
+   * 因此 legacy 'serif' → 正文衬线，其余 → 正文无衬线；标题一律取默认衬线，
+   * 因为旧实现从来没碰过 `--theme-font-title`。**照用户实际看到的样子迁**，不是照字面。
+   */
+  function initFonts() {
+    let body = readChoice(LS_FONT_BODY);
+    const title = readChoice(LS_FONT_TITLE);
+
+    if (body === null && title === null) {
+      try {
+        const legacy = localStorage.getItem(LS_FONTS_LEGACY);
+        if (legacy) body = legacy === 'serif' ? 'serif' : 'sans';
+      } catch {
+        // 读不到旧值就当没设过，走默认
+      }
+    }
+
+    setFontBody(body ?? DEFAULT_FONT_BODY);
+    setFontTitle(title ?? DEFAULT_FONT_TITLE);
   }
 
   return {
     current,
-    fonts,
+    fontBody,
+    fontTitle,
     fontSize,
     currentTheme,
     THEME_LIST,
     apply,
     init,
+    initFonts,
     initFontSize,
-    setFonts,
+    setFontBody,
+    setFontTitle,
     setFontSize,
   };
 });

--- a/src/ui/styles/utilities.css
+++ b/src/ui/styles/utilities.css
@@ -158,6 +158,77 @@
   color: var(--theme-quality-unique);
 }
 
+/* ===== 空态（design.md §5.2）— 全站唯一一份 =====
+ *
+ * 放在全局工具层而不是 settings-chrome.css: 空态不是「设置页外壳」，游戏页面板、
+ * 工坊列表同样要用，而 `<style scoped src>` 那条路会给每个引用它的组件复制一份。
+ *
+ * 收编前设置页有**三种方言**:
+ *   · `.empty-tab` —— audio/ 与 assets/ 各抄了一份，且已经开始漂移
+ *     （padding `xl` vs `2xl`、其中一份多一条 line-height）
+ *   · 内联 `style="text-align: center; padding: 24px"` + 纯文字 —— API / 世界书 /
+ *     输出美化 / Agent 四处，padding 各写各的（16 / 24 / 40 / 60px），
+ *     既没有装饰符也没有斜体
+ *   · WorldBookEditor 的 `.empty-state`（图标 + 标题 + 描述 + CTA 按钮）
+ *
+ * 🔴 空态要**教会用户这个界面**，不是通报「这里没东西」。所以但凡说得出下一步的，
+ *    都要带 `.empty-tab-hint`；能一键开始的再加 `.empty-tab-action`。
+ *    光一句「暂无数据」是这套里唯一不许出现的写法。
+ */
+.empty-tab {
+  padding: var(--theme-spacing-2xl) 0;
+  text-align: center;
+  color: var(--theme-text-muted);
+  font-size: 0.8125rem;
+  font-style: italic;
+  line-height: 1.7;
+}
+.empty-tab::before {
+  content: '—';
+  display: block;
+  margin-bottom: var(--theme-spacing-sm);
+  font-size: 1.25rem;
+  opacity: 0.3;
+}
+/* 图标变体：有图标时它替代那道 `—`，不要两个装饰符叠着 */
+.empty-tab-icon {
+  display: block;
+  margin-bottom: var(--theme-spacing-sm);
+  font-size: 1.75rem;
+  opacity: 0.25;
+}
+.empty-tab:has(.empty-tab-icon)::before {
+  content: none;
+}
+/* 「怎么开始」那一行 —— 不斜体: 它是操作指引，不是氛围文字 */
+.empty-tab-hint {
+  display: block;
+  margin-top: var(--theme-spacing-xs);
+  font-size: 0.75rem;
+  font-style: normal;
+  opacity: 0.9;
+}
+.empty-tab-action {
+  margin-top: var(--theme-spacing-md);
+  padding: 8px 18px;
+  min-height: 36px; /* design.md §4.1 触摸目标下限 */
+  border: 1px solid var(--theme-primary);
+  border-radius: var(--theme-radius-sm);
+  background: var(--theme-primary);
+  color: var(--theme-primary-text);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-style: normal;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    filter var(--theme-transition-fast),
+    border-color var(--theme-transition-fast);
+}
+.empty-tab-action:hover {
+  filter: brightness(1.1);
+}
+
 /* 品质色点 — 与 .quality-* 文字色类组合使用: <span class="quality-dot quality-rare"> */
 .quality-dot {
   display: inline-block;

--- a/src/ui/themes/ivory.css
+++ b/src/ui/themes/ivory.css
@@ -55,8 +55,7 @@
   --theme-tag-contract-bg: rgba(208, 72, 104, 0.1);
   --theme-tag-contract-text: #a03050;
 
-  --theme-font-title: 'Noto Serif SC', serif;
-  --theme-font-body: 'Noto Serif SC', serif;
+  /* 🔴 字体**不在主题里定义** —— 理由同 parchment.css，见那里的注释与 design.md §7.4 */
 
   --theme-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
   --theme-shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);

--- a/src/ui/themes/misty-lilac.css
+++ b/src/ui/themes/misty-lilac.css
@@ -50,8 +50,8 @@
   --theme-currency-silver: #b0a8b8;
   --theme-currency-copper: #c88050;
 
-  --theme-font-title: 'Noto Serif SC', serif;
-  --theme-font-body: 'Noto Sans SC', sans-serif;
+  /* 🔴 字体**不在主题里定义** —— 理由同 parchment.css。本主题这两行原本只是把
+     `:root` 的值原样重复了一遍（无实际效果），但留着会诱使人以为「主题可以定字体」 */
 
   --theme-shadow-sm: 0 1px 3px rgba(100, 60, 130, 0.08);
   --theme-shadow-md: 0 2px 8px rgba(100, 60, 130, 0.12);

--- a/src/ui/themes/parchment.css
+++ b/src/ui/themes/parchment.css
@@ -59,8 +59,10 @@
   --theme-ascension-power: rgba(255, 152, 0, 0.1);
   --theme-ascension-law: rgba(156, 39, 176, 0.1);
 
-  --theme-font-title: 'Noto Serif SC', serif;
-  --theme-font-body: 'Noto Serif SC', serif;
+  /* 🔴 字体**不在主题里定义**（design.md §1「主题无关」/ §7.4）：字体由设置页的
+     「正文字体 / 标题字体」两格严格决定，theme-store 的 initFonts() 把它们写成
+     `<html>` 的内联变量。本主题此前把 `--theme-font-body` 改成衬线，于是换主题会
+     悄悄改掉正文字体，而设置页的下拉框还显示着原来的值 —— 主题只管颜色。 */
 
   --theme-shadow-sm: 0 1px 3px rgba(139, 115, 85, 0.12);
   --theme-shadow-md: 0 2px 8px rgba(139, 115, 85, 0.18);

--- a/src/ui/themes/variables.css
+++ b/src/ui/themes/variables.css
@@ -79,10 +79,19 @@
   /* 排版
      font-title:   标题/叙事衬线 — 中文古籍感的真正来源（思源宋体）
      font-display: 纯装饰衬线 — 仅用于英文副标/章节数字（Cinzel 无中文字形）
-     font-body:    UI 标签/正文无衬线 */
-  --theme-font-title: 'Noto Serif SC', serif;
-  --theme-font-display: 'Cinzel', 'Noto Serif SC', serif;
-  --theme-font-body: 'Noto Sans SC', sans-serif;
+     font-body:    UI 标签/正文无衬线
+
+     🔴 第一顺位必须是带 `Variable` 后缀的族名 —— 自托管用的是 @fontsource-variable/*，
+        它注册的 `@font-face` 就叫 `'Noto Sans SC Variable'`。写成 `'Noto Sans SC'`
+        不会报任何错，只会安静地退回系统字体（正是 2026-08-05 之前 CDN 挂掉时的症状）。
+        第二顺位保留不带后缀的名字：万一自托管文件没到位，系统里装了同名字体还能顶上。
+
+     🟡 这三行是**没有 JS 时的兜底**。真正生效的是 theme-store.initFonts() 写在
+        `<html>` 上的内联变量（design.md §7.4：字体严格由设置决定，主题不参与）。
+        改这里的值，记得同步 stores/theme-store.ts 的 FONT_STACKS。 */
+  --theme-font-title: 'Noto Serif SC Variable', 'Noto Serif SC', serif;
+  --theme-font-display: 'Cinzel Variable', 'Cinzel', 'Noto Serif SC Variable', serif;
+  --theme-font-body: 'Noto Sans SC Variable', 'Noto Sans SC', sans-serif;
 
   /* 间距 */
   --theme-spacing-xs: 4px;

--- a/tests/no-external-assets.test.ts
+++ b/tests/no-external-assets.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 「零外部资源」闸门 —— 字体与图标必须自托管（2026-08-05）。
+ *
+ * ## 为什么值得单开一条
+ * 2026-08-05 之前，`index.html` 挂着两个 CDN：`fonts.googleapis.com`（Noto Sans SC /
+ * Noto Serif SC / Cinzel）与 `cdnjs.cloudflare.com`（Font Awesome）。**它们失败时不报错** ——
+ * `font-display: swap` 会安安静静落到系统字体，图标退化成方框，而设置页的「标题字体」
+ * 仍然写着「衬线」。对一款中文游戏来说这不是边缘情况：`fonts.googleapis.com`
+ * 在中国大陆长期不可达，也就是说**相当一部分玩家从来没见过设计里那套字体**。
+ *
+ * 加上离线、CDN 故障、企业代理拦截，这条外部依赖没有任何一处能报警。
+ * 所以把「不许再出现外链」变成断言，而不是靠 code review 记住。
+ *
+ * ## 它挡不住什么
+ * 只扫源码里的静态引用。运行时拼出来的 URL、以及工坊正则 iframe 里用户自己装的规则
+ * （`beautifier-frame.ts` 的 CSP 刻意放行 `font-src http: https:`）不在范围内 ——
+ * 那是另一份威胁模型，见 AGENTS.md 里工坊执行边界那一节。
+ */
+
+const REPO_ROOT = join(__dirname, '..');
+
+function read(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), 'utf8');
+}
+
+describe('index.html 不引用任何外部资源', () => {
+  const html = read('index.html');
+
+  it('没有 <link>/<script> 指向 http(s)', () => {
+    const tags = html.match(/<(?:link|script)\b[^>]*>/gi) ?? [];
+    const external = tags.filter((t) => /\b(?:href|src)\s*=\s*["']?https?:/i.test(t));
+    expect(external).toEqual([]);
+  });
+
+  it('点名挡住那两个回来过的域名', () => {
+    // 注释里提到它们是允许的（本文件与 index.html 的注释正是在解释为什么不能用），
+    // 所以只在**标签**里找，不在整份文本里找。
+    const tags = (html.match(/<[^>]+>/g) ?? []).filter((t) => !t.startsWith('<!--'));
+    const joined = tags.join('\n');
+    expect(joined).not.toContain('fonts.googleapis.com');
+    expect(joined).not.toContain('fonts.gstatic.com');
+    expect(joined).not.toContain('cdnjs.cloudflare.com');
+  });
+
+  it('preconnect 也一并没有了（留着就是在说这里还要连外网）', () => {
+    expect(html).not.toMatch(/rel\s*=\s*["']preconnect["']/i);
+  });
+});
+
+describe('字体与图标从本地包引入', () => {
+  const main = read('src/ui/main.ts');
+
+  it('三款字体走 @fontsource-variable/*', () => {
+    expect(main).toContain("import '@fontsource-variable/noto-sans-sc'");
+    expect(main).toContain("import '@fontsource-variable/noto-serif-sc'");
+    expect(main).toContain("import '@fontsource-variable/cinzel'");
+  });
+
+  it('Font Awesome 只引 solid + regular，不引 brands（全仓零处使用）', () => {
+    // 只看 **import 语句**：main.ts 的注释里正解释着「刻意不引 brands.css」，
+    // 拿整份文本做否定断言会被自己的注释绊倒（这一轮已经栽过两次）。
+    const imports = (main.match(/^\s*import\s+.*$/gm) ?? []).join('\n');
+    expect(imports).toContain('@fortawesome/fontawesome-free/css/fontawesome.css');
+    expect(imports).toContain('@fortawesome/fontawesome-free/css/solid.css');
+    expect(imports).toContain('@fortawesome/fontawesome-free/css/regular.css');
+    expect(imports).not.toContain('brands.css');
+  });
+
+  it('字体 import 排在样式表之前（否则首屏按兜底字体排版再回流一次）', () => {
+    const firstFont = main.indexOf('@fontsource-variable');
+    const firstStyle = main.indexOf("'./styles/base.css'");
+    expect(firstFont).toBeGreaterThan(-1);
+    expect(firstStyle).toBeGreaterThan(-1);
+    expect(firstFont).toBeLessThan(firstStyle);
+  });
+
+  it('package.json 把四个包记成生产依赖（devDependencies 会在构建时缺席）', () => {
+    const pkg = JSON.parse(read('package.json')) as { dependencies?: Record<string, string> };
+    const deps = pkg.dependencies ?? {};
+    expect(Object.keys(deps)).toEqual(
+      expect.arrayContaining([
+        '@fontsource-variable/noto-sans-sc',
+        '@fontsource-variable/noto-serif-sc',
+        '@fontsource-variable/cinzel',
+        '@fortawesome/fontawesome-free',
+      ]),
+    );
+  });
+});
+
+describe('许可与署名（OFL 1.1 + CC BY 4.0）', () => {
+  it('四份许可证全文随 dist 分发（public/ 被 Vite 逐字复制）', () => {
+    for (const f of [
+      'OFL-Noto-Sans-SC.txt',
+      'OFL-Noto-Serif-SC.txt',
+      'OFL-Cinzel.txt',
+      'Font-Awesome-Free.txt',
+    ]) {
+      expect(read(join('public', 'licenses', f)).length).toBeGreaterThan(1000);
+    }
+  });
+
+  it('署名在界面上可见 —— CC BY 4.0 唯一一条光靠文件满足不了的义务', () => {
+    const about = read('src/ui/components/settings/AboutSection.vue');
+    expect(about).toContain('Fonticons, Inc.');
+    expect(about).toContain('CC BY 4.0');
+    expect(about).toContain('/licenses/Font-Awesome-Free.txt');
+    // 三款 OFL 字体的入口也要能点到
+    expect(about).toContain('/licenses/OFL-Noto-Sans-SC.txt');
+    expect(about).toContain('/licenses/OFL-Cinzel.txt');
+  });
+
+  it('THIRD-PARTY-NOTICES.md 在，且写明了不能自托管的那批系统字体', () => {
+    const notices = read('THIRD-PARTY-NOTICES.md');
+    expect(notices).toContain('SIL Open Font License 1.1');
+    expect(notices).toContain('CC BY 4.0');
+    // 专有系统字体：只能按名字引用，不能打包
+    for (const proprietary of ['Monaco', 'Consolas', 'Palatino', 'KaiTi']) {
+      expect(notices).toContain(proprietary);
+    }
+  });
+});

--- a/tests/theme-fonts-invariant.test.ts
+++ b/tests/theme-fonts-invariant.test.ts
@@ -1,0 +1,85 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 字体不变式闸门 —— 主题 CSS 里**不许出现 `--theme-font-*` 声明**（design.md §1 / §7.4）。
+ *
+ * ## 为什么值得单开一条
+ * `parchment` 与 `ivory` 曾把 `--theme-font-body` 定义成衬线，于是**换个主题就会悄悄
+ * 改掉正文字体**，而设置页的字体下拉框仍显示着原来的值。症状不在主题文件里，而在一个
+ * 看起来毫不相干的下拉框上 —— 这种「因果分居两处」的缺陷，肉眼审查和组件测试都抓不到。
+ *
+ * 字体的唯一决定者是设置页那两格（正文 / 标题），`theme-store.initFonts()` 把它们写成
+ * `<html>` 的**内联变量**，内联压得过任何 `[data-theme]` 规则。主题只管颜色。
+ * 行为侧的断言在 `src/ui/stores/theme-store.fonts.test.ts`；本闸门守的是「别再往主题里
+ * 写字体」这条源码约束 —— 写了虽然已经不生效，但会让下一个人以为主题能定字体。
+ *
+ * ## 为什么在 tests/ 而不是 src/ui/themes/
+ * 初版放在 `src/ui/themes/` 并用 Vite 的 `?raw` 读 CSS —— **那样是假绿的**：
+ * vitest 默认 `css: false`，`.css?raw` 一律返回**空串**，于是「不含字体声明」这条
+ * 对每个文件都轻松通过，闸门整个是死的。（发现它靠的是同一批断言里那条
+ * 「variables.css 仍提供三个兜底」—— 空串让它红了。**一条只会变绿的断言证明不了任何事**，
+ * 每个扫描类测试都该配一条「扫到的东西非空」的反向断言。）
+ *
+ * `tests/` 不在 tsconfig 的 include 里，所以这里能直接用 `node:fs` 读到真文件 ——
+ * 与 `encoding-invariants.test.ts` 同一个理由、同一个位置。
+ */
+
+const THEME_DIR = join(__dirname, '..', 'src', 'ui', 'themes');
+/** 唯一允许声明字体的文件：`:root` 兜底（没有 JS 时用）+ 不可配置的装饰体 */
+const ALLOWED = 'variables.css';
+
+/** 只找**声明**（`--theme-font-x:`）。注释里提这个名字是允许的 —— 那几处注释正是在
+ *  解释为什么不能写，删掉反而让下一个人重新踩一遍 */
+function fontDeclarations(css: string): string[] {
+  return css
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('*'))
+    .filter((line) => /^\s*--theme-font-[a-z]+\s*:/.test(line))
+    .map((line) => line.trim());
+}
+
+const themeFiles = readdirSync(THEME_DIR).filter((f) => f.endsWith('.css') && f !== ALLOWED);
+
+describe('主题 CSS 不定义字体', () => {
+  it('确实扫到了 10 套主题（防止 glob/路径写错让闸门空转）', () => {
+    expect(themeFiles.length).toBe(10);
+  });
+
+  it('读到的确实是非空内容（初版栽在这：?raw 读 CSS 返回空串，闸门整个是死的）', () => {
+    // 逐个非空即可证伪「读出来全是空串」。**不设更高的下限**：`obsidian.css` 只有
+    // 一行注释（默认主题的值都在 variables.css 的 `:root` 里），它合法地就是很小。
+    for (const f of themeFiles) {
+      expect(readFileSync(join(THEME_DIR, f), 'utf8').length).toBeGreaterThan(0);
+    }
+    // 再加一条总量断言：万一将来读取方式又换了、退化成「每个文件一个字符」
+    const total = themeFiles.reduce(
+      (n, f) => n + readFileSync(join(THEME_DIR, f), 'utf8').length,
+      0,
+    );
+    expect(total).toBeGreaterThan(5000);
+  });
+
+  it.each(themeFiles)('%s 不声明 --theme-font-*', (file) => {
+    const css = readFileSync(join(THEME_DIR, file), 'utf8');
+    expect(fontDeclarations(css)).toEqual([]);
+  });
+
+  it('字体栈第一顺位带 Variable 后缀 —— 自托管注册的就是这个族名', () => {
+    // 漏掉后缀不会报任何错，只会安静地退回系统字体。所以单独钉一条。
+    const css = readFileSync(join(THEME_DIR, ALLOWED), 'utf8');
+    for (const decl of fontDeclarations(css)) {
+      expect(decl).toMatch(/:\s*'[^']+ Variable'/);
+    }
+  });
+
+  it('variables.css 仍提供三个兜底，且正文无衬线 / 标题衬线', () => {
+    const css = readFileSync(join(THEME_DIR, ALLOWED), 'utf8');
+    expect(fontDeclarations(css)).toEqual([
+      "--theme-font-title: 'Noto Serif SC Variable', 'Noto Serif SC', serif;",
+      "--theme-font-display: 'Cinzel Variable', 'Cinzel', 'Noto Serif SC Variable', serif;",
+      "--theme-font-body: 'Noto Sans SC Variable', 'Noto Sans SC', sans-serif;",
+    ]);
+  });
+});


### PR DESCRIPTION
本轮聚焦设置页的 UI/UX，外加一件从中牵出来的正事：**字体不再依赖 CDN**。

## 1. 字体：设置严格压过主题，且自托管

`docs/design.md` §7.4 那条「换主题会改字体」的已知问题定案（主人拍板：设置说了算）。
三处缺陷，症状全都不在改动处：

| 缺陷 | 症状 |
| --- | --- |
| `setFonts()` 往 `fated-poem-fonts` **写了却没有任何读取点** | 刷新后字体退回主题说了算，而下拉框仍显示用户选的值 |
| `parchment` / `ivory` 把 `--theme-font-body` 定义成衬线 | 换个主题就悄悄换掉正文字体 |
| `mixed` 档是一条字体栈，中文字符全部命中第一个 | 三个选项实际只有两种结果，`mixed` 渲染出来等于 `sans` |

改成**正文字体 / 标题字体两格独立设置**（默认正文无衬线、标题衬线）。执行点是
`initFonts()` 把两格写成 `<html>` 内联变量 —— 内联压得过任何 `[data-theme]` 规则。
**默认值也照写**：跳过等于在默认档上把决定权交还给主题。旧设置照用户实际看到的样子迁移。

## 2. 自托管，零外部请求

`index.html` 原本挂着 `fonts.googleapis.com` 与 `cdnjs.cloudflare.com`。**它们失败时不报错** ——
`font-display: swap` 安静落到系统字体、图标变方框，而设置页仍写着「衬线」。
`fonts.googleapis.com` 在中国大陆长期不可达，对一款中文游戏来说这不是边缘情况。

- `@fontsource-variable/*`（Noto Sans SC / Noto Serif SC / Cinzel）+ `@fortawesome/fontawesome-free@6.7.2`
- **FA 钉在 6.x**：7.x 有图标改名风险，而 `fa-solid` 全仓 221 处
- **变量字体而非逐字重静态包**：静态 4 字重 × 2 中文族约 34MB，变量包 10.6MB 覆盖 100–900
- 两者都保留 unicode-range 切片 —— 真机实测首屏注册 **206 个 `@font-face`、只取 15 个文件 901KB**，`externalRequests: []`

🔴 族名带 `Variable` 后缀。漏掉不报错，只会安静退回系统字体 —— 与它替掉的那个 bug 同一种形状。

### 许可（已逐条核对）

| 资源 | 许可 | 义务 |
| --- | --- | --- |
| Noto Sans SC / Noto Serif SC / Cinzel | SIL OFL 1.1（**均未声明 RFN**） | 随分发附许可证全文 ✅ |
| Font Awesome Free 6.7.2 | 图标 **CC BY 4.0** · 字体 OFL · 代码 MIT | **署名必须界面可见** ✅ |

许可证全文随 dist 分发在 `/licenses/`；署名渲染在设置页「关于」分区 ——
**CC BY 4.0 是唯一一条光靠 dist 里的文件满足不了的义务**。

CSS 里那批专有系统字体（Monaco / Consolas / Palatino / KaiTi 等）**只是兜底、从不下载**：
按名字引用不是分发，打包才是侵权。这条边界写进了 `THIRD-PARTY-NOTICES.md`，
免得下一个人「顺手补全」自托管。

## 3. 设置页 UI/UX

- **一条隐形的分隔线**：`ImagePresetList` 用了不存在的 `--theme-border` 且无 fallback →
  整条声明 invalid at computed-value time、`border-top-style` 退回 `none`。
  区分「基线预设」与「本档临时外貌」两张表的唯一视觉线索**根本没画出来**。
- **Agent 选择存了却读不回来**：主导航每个按钮都无条件 `activeAgent = null`（含「Agent 配置」
  自己），而进该分区必须点那一下 —— 每次都落在空态。重挂载本来就由 `v-if` 保证。
- **空态三种方言归一**：`.empty-tab` 提到全局 `utilities.css`，转换 6 处内联空态、删 4 份重复定义。
- **间距 token 化**：45 → 26 处。顺带发现「首卡 `margin-top: 16px`」**从来没生效过**（与
  `.section-desc` 的 `margin-bottom: 20px` 外边距合并），抄了七八遍有一半是死的。
  余下 26 处是 `margin: 0` 重置与刻度外的值，换 token 等于改视觉，刻意不动。

## 闸门

新增 `tests/no-external-assets.test.ts` 与 `tests/theme-fonts-invariant.test.ts`。

🔴 后者初版放在 `src/ui/themes/` 用 `?raw` 读 CSS，**那样是假绿的**：vitest 默认 `css: false`，
`.css?raw` 一律返回空串，「不含字体声明」对每个文件都轻松通过。现移到 `tests/` 用 `node:fs`，
并配一条「读到的内容非空」反向断言 —— 一条只会变绿的断言证明不了任何事。

## 验证

- typecheck ✅ · lint（`--max-warnings 0`）✅ · knip 棘轮 ✅（133 已知，无新增）
- **261 文件 / 6704 tests 全绿**（+36 新增）
- `vite build` ✅ 产物零 `url(http…)`，202 个 woff2 + 许可证就位
- 编码闸门：43 个提交文件 0 U+FFFD / 0 控制字符

## 未做

- **视觉走查未做** —— 本会话 Browser 面板始终不可用，以上全是 DOM/网络证据，没有截图
- `BeautifierSection` 是 13 个分区里唯一没有 `settings-chrome.css` 的，其 `h3` 与 `.section-desc`
  一直是浏览器默认样式，且自带一套开启时是金色的 toggle（其余九个是绿色）。**既有问题**，
  统一它要删它那套重复 CSS，属于看得见的改动，另开任务
- `game/` 下 10 处 `font-family: system-ui` 硬编码不跟随「正文字体」设置；另有 10 份
  `.empty-tab` 拷贝散在 `game/` `workshop/` `shared/`（且已漂移）

🤖 Generated with [Claude Code](https://claude.com/claude-code)