### PR TITLE
波 0: npm 关死 + worktrees 入 ignore + AGENTS 勘正 (T0.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ dist-ui/
 .claude/scheduled_tasks.json
 .claude/plans/
 
+# 🔒 内容分离波 0 (D1/D45)：worktrees 挂完整工作副本（含全部世界书），整目录拷贝会泄内容。
+# 预防性 ignore —— 本机此刻没有该目录，但快照切仓前任何机器出现都立刻入 ignore。
+.claude/worktrees/
+
 # 系统文件
 .DS_Store
 Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,7 +419,7 @@ bash scripts/notify.sh "<Phase名称> 完成!" "<关键指标>"
 >
 > 🩹 **游玩链路真机第一轮逮到的（2026-08-05）**：出图端点那格 Base URL 是**自由文本**，一格连坑两轮，而**两次报错都指着无辜的地方** —— 填成 `https://api.novelai.net`（NAI 的**文本/账户**域）时，那台机器上 `/ai/generate-image` 还活着（所以是 400 不是 404）但模型枚举停在 V3，于是它对一个完全合法的 `nai-diffusion-4-5-full` 回 **「model must be a valid enum value」**，看起来像模型名写错；改对域名却漏掉 `https://` 时，BFF 的 `forward()` 回 **「invalid X-Target-Base-URL」**，看起来像 header 坏了。裁定：**出图地址由代码持有，用户只填令牌** —— `scene-image-seams` 不再读 `endpoint.baseUrl`，API 配置里出图端点的「主链接」与「模型」两格直接隐藏（`isImageEntry`）。`image-client` 仍收 `baseUrl`（自建镜像/测试替身）并新增 `resolveImageBaseUrl`：补协议、剃掉 BFF 自己会拼的 `/ai/generate-image`、文本域**只报错不改写**。同一轮还确认「弹回首页」不可能是组件异常 —— 全仓没有任何程序化跳首页的路径，`currentView` 初值就是 `home` 且只活在内存里，所以那是**整页重载**（待再现时取证）。
 >
-> 🩹 **实施中逮到的两处**：① `blurByDefault`（D46 打码）**声明了但没人传**，整条功能是死的 —— 根因是只有单组件测试，那种测试能证明逻辑对、**证明不了有人供值**，现已补从 ChatFlow 真渲染到底的链路测试。② `data/defaults/agent-config.json` 里有 **47 个 U+FFFD 坏字符**（16 段 / 6 个 agent），其中一处落在闭合 XML 标签的标签名里 —— **既有问题，本轮未修**，已另开任务。
+> 🩹 **实施中逮到的两处**：① `blurByDefault`（D46 打码）**声明了但没人传**，整条功能是死的 —— 根因是只有单组件测试，那种测试能证明逻辑对、**证明不了有人供值**，现已补从 ChatFlow 真渲染到底的链路测试。② `data/defaults/agent-config.json` 里曾有 **47 个 U+FFFD 坏字符**（16 段 / 6 个 agent，其中一处落在闭合 XML 标签的标签名里）—— **已于 2026-08-05 修复**（实测 U+FFFD:0 / ctrl:0 / JSON 可解析），`tests/encoding-invariants.test.ts` 把三条判据变成了常驻 CI 断言。
 >
 > 🟡 **工坊 P2 已实施（T1-T6），真机走查未做**：世界书条目正文的 EJS 现在**会在提示装配期求值**（ADR-30 两轴契约：只读 `stats` + 共写 `vars`，冲突 AI 赢；动态条目沉底、静态前缀字节稳定）。全语料冒烟 509 条目 / 61 动态 / **0 回退**（能力面别名层落地后 7 → 0，白名单已清空；语料门现按 **Legacy 与 QuickJS 双后端**各自跑双向白名单，基线一致），回退条目原文注入不阻断。代码位内嵌的 ST 值宏（`{{roll}}`/`{{random::}}`）已在编译期降成沙盒调用（`rewriteCodeMacros`），uid 358 出列。回退率 / 缓存命中字节 / 跨回合链尚未真机验证，设计全文见 `docs/planning/2026-07-31-workshop-phase2-ejs-design.md`。
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "description": "IndependentFront for Destined Journey — 命定之诗独立前端，多 Agent 文字 RPG 引擎",
   "main": "dist/sillytavern/index.js",
   "type": "module",
+  "private": true,
+  "files": [
+    "dist",
+    "dist-ui",
+    "public",
+    "src",
+    "server",
+    "scripts",
+    "docs"
+  ],
   "scripts": {
     "dev": "dev.bat",
     "build": "vite build",


### PR DESCRIPTION
## 内容-引擎分离 · 波 0 · T0.2（主会话任务）

设计真源：`docs/planning/2026-08-05-content-engine-separation-design.md`（v1.2，D1/D30/D39/D45）
实施计划：`docs/planning/2026-08-05-content-engine-separation-implementation-plan.md`（T0.2）

## 改动

- **package.json**: 加 `"private": true` + `files` 白名单（D39）。`.npmignore` 今天不排除 `data/`，误 publish 即泄露真实世界内容；files 白名单不列 data/reference/tests，双保险。
- **.gitignore**: 加 `.claude/worktrees/`（D1/D45）。预防性 ignore——worktrees 挂完整工作副本含全部世界书，整目录拷贝会泄内容（本机无该目录，快照切仓前任何机器出现都立刻入 ignore）。
- **AGENTS.md:422**: 勘正 agent-config.json 47 U+FFFD 记录（D30）。原文「本轮未修」过时——实测 U+FFFD:0 / ctrl:0 / JSON ok，`encoding-invariants.test.ts` 已成常驻 CI 断言。

## 验证

- typecheck ×3 ✅
- format:check（改动文件）✅
- lint（max-warnings 0）✅
- knip:ratchet ✅（133 已知无新增）
- test:run ✅（262 文件 / 6724 tests）

## 关联

- T0.1（轮换 SiliconFlow key）主人已完成
- T0.3（五项裁定）按设计默认推荐进行
- 后续波 1 起派子 agent