### PR TITLE
波 1 T3: presets 撤出 localStorage + Dexie 三态护栏

### DIFF
--- a/src/sillytavern/database.test.ts
+++ b/src/sillytavern/database.test.ts
@@ -1167,6 +1167,89 @@ describe('exportAllData / importAllData', () => {
     });
   });
 
+  // 内容-引擎分离波 1 / D22：presets 三态护栏 —— 此前 presets 与 lorebooks/settings
+  // 死表同段无条件 clear，手编/裁剪备份（删 presets 字段）导入会静默清空 Dexie 预设表。
+  describe('importAllData × D22 presets 三态语义', () => {
+    /** 预置：两条用户预设（先清掉 initializeDatabase 默认播种的那条） */
+    async function seedPresets() {
+      await getDatabase().presets.clear();
+      await getDatabase().presets.bulkPut([
+        {
+          id: 'preset_user_a',
+          name: '用户预设A',
+          settings: { prompts: [{ name: 'A', content: 'aaa', role: 'system' }] },
+          createdAt: 1000,
+          updatedAt: 1000,
+        },
+        {
+          id: 'preset_user_b',
+          name: '用户预设B',
+          settings: { prompts: [{ name: 'B', content: 'bbb', role: 'system' }] },
+          createdAt: 2000,
+          updatedAt: 2000,
+        },
+      ]);
+    }
+
+    it('缺 presets 字段（手编/裁剪备份）：整张表逐行原样保留', async () => {
+      await seedPresets();
+      const legacyBackup: any = await exportAllData();
+      delete legacyBackup.presets;
+      legacyBackup.version = 14;
+      expect('presets' in legacyBackup).toBe(false);
+
+      await expect(importAllData(legacyBackup)).resolves.toBeUndefined();
+
+      const db = getDatabase();
+      expect(await db.presets.count()).toBe(2);
+      expect((await db.presets.get('preset_user_a'))!.name).toBe('用户预设A');
+      expect((await db.presets.get('preset_user_b'))!.name).toBe('用户预设B');
+    });
+
+    it('presets: [] （字段存在但为空）：表被清空', async () => {
+      await seedPresets();
+      const backup = await exportAllData();
+      backup.presets = [];
+
+      await importAllData(backup);
+
+      expect(await getDatabase().presets.count()).toBe(0);
+    });
+
+    it('presets 含数据：正常覆盖（旧的 seed 行被替换）', async () => {
+      await seedPresets();
+      const backup = await exportAllData();
+      backup.presets = [
+        {
+          id: 'preset_from_backup',
+          name: '备份里的预设',
+          settings: { prompts: [{ name: 'X', content: 'xxx', role: 'system' }] },
+          createdAt: 5000,
+          updatedAt: 5000,
+        },
+      ];
+
+      await importAllData(backup);
+
+      const db = getDatabase();
+      expect(await db.presets.count()).toBe(1);
+      expect((await db.presets.get('preset_from_backup'))!.name).toBe('备份里的预设');
+      expect(await db.presets.get('preset_user_a')).toBeUndefined();
+    });
+
+    it('exportAllData / importAllData 往返保留 presets', async () => {
+      await seedPresets();
+      const backup = await exportAllData();
+      expect(backup.presets).toHaveLength(2);
+
+      await getDatabase().presets.clear();
+      await importAllData(backup);
+
+      const rows = await getDatabase().presets.toArray();
+      expect(rows.map((r) => r.id).sort()).toEqual(['preset_user_a', 'preset_user_b']);
+    });
+  });
+
   describe('importAllData × v16 regexStorage 三态语义', () => {
     async function seedV16Table() {
       await getDatabase().regexStorage.bulkPut([

--- a/src/sillytavern/database.ts
+++ b/src/sillytavern/database.ts
@@ -768,13 +768,25 @@ async function doImportAllData(
   // `lorebooks` 与 `settings` 是死表（无生产读写，见 Q-06 与 AGENTS.md 架构图）。
   // 这里仍然照搬**只为老备份往返不丢字节**：老包里带着这两张表的行，导入时丢掉
   // 就等于这份备份进去再出来变小了。新包里它们是空数组，clear + bulkPut([]) 是 no-op。
-  await db.transaction('rw', db.lorebooks, db.presets, db.settings, async () => {
+  await db.transaction('rw', db.lorebooks, db.settings, async () => {
     await db.lorebooks.clear();
-    await db.presets.clear();
     await db.settings.clear();
     if (Array.isArray(backup.lorebooks)) await db.lorebooks.bulkPut(backup.lorebooks);
-    if (Array.isArray(backup.presets)) await db.presets.bulkPut(backup.presets);
     if (Array.isArray(backup.settings)) await db.settings.bulkPut(backup.settings);
+  });
+
+  // 🔴 内容-引擎分离波 1 / D22：presets 拆出 lorebooks/settings 事务，改三态护栏。
+  //   此前与死表同段无条件 clear —— 手编/裁剪过的备份（删了 presets 字段）导入会
+  //   静默清空 Dexie 预设表。改三态语义（与 v14/v15 同款）：
+  //   · undefined（字段缺席，手编备份）→ 整张表原样不动，连 clear 都不执行
+  //   · []（字段存在但为空）          → 合法的「确实没有预设」，照常 clear
+  //   · 有数据                         → 清空后整表覆盖
+  //   注：「旧备份抹掉 pack 预设」的真正救济是 D18 reconcilePackState（T5），不是这条护栏。
+  await db.transaction('rw', db.presets, async () => {
+    if (backup.presets !== undefined) {
+      await db.presets.clear();
+      if (Array.isArray(backup.presets)) await db.presets.bulkPut(backup.presets);
+    }
   });
 
   await db.transaction('rw', db.memories, db.plotEvents, db.characters, async () => {

--- a/src/ui/components/settings/SettingsPage.engine-imports.test.ts
+++ b/src/ui/components/settings/SettingsPage.engine-imports.test.ts
@@ -34,20 +34,17 @@ import * as engineDatabase from '@engine/database';
 //   · 走 `@ui` / `@engine` 别名而不是相对路径算术 —— 本文件挪窝也不用改，
 //     真解析不到时是**导入期硬报错**，不会退化成静默通过。
 import dataSectionSource from '@ui/components/settings/DataSection.vue?raw';
-import presetManagerSource from '@ui/components/settings/agent/PresetManager.vue?raw';
-// 🔴 `restoreAgentDefaults` 那处随配置面从 AgentSection 抽进了 AgentConfigPanel
-//    （AgentSection 现在只剩外框 + 页头，一处动态导入都不剩）——
-//    扫错文件会退化成"扫了个空文件然后全绿"，正是本测试最怕的失败形态。
-import agentConfigPanelSource from '@ui/components/settings/agent/AgentConfigPanel.vue?raw';
 import databaseSource from '@engine/database.ts?raw';
 
-/** 会用到 `await import('@engine/…')` 的设置页 SFC */
+/**
+ * 会用到 `await import('@engine/…')` 的设置页 SFC。
+ *
+ * 🔴 内容-引擎分离波 1 / D22：PresetManager.vue 与 AgentConfigPanel.vue 的预设
+ *    读写已收口到 `usePresets` composable（静态 import），不再有动态引擎导入 ——
+ *    两者从这张表退出。设置页里仍走动态导入的只剩 DataSection（导出/导入/清除）。
+ */
 const SOURCES: { file: string; source: string }[] = [
   { file: 'DataSection.vue', source: dataSectionSource },
-  // Q-25 第 9 步：预设子系统那 6 处与 restoreAgentDefaults 那 1 处随 Agent 分区搬走了，
-  // SettingsPage 自己已经一处动态引擎导入都不剩 —— 所以它退出这张表。
-  { file: 'agent/PresetManager.vue', source: presetManagerSource },
-  { file: 'agent/AgentConfigPanel.vue', source: agentConfigPanelSource },
 ];
 
 /** 本测试能对照的引擎模块（静态 import 拿到真实导出面） */
@@ -90,11 +87,10 @@ describe('设置页各分区的动态引擎导入', () => {
     expect(sites.every((s) => s.names.length > 0)).toBe(true);
   });
 
-  it('🔴 两个文件都各自抓到了（拆分后别只剩一个文件在被扫）', () => {
-    // Q-25 把 exportAll / importAll / clearAll 挪进了 DataSection，把预设子系统
-    // 挪进了 agent/PresetManager。若哪天有人把 SOURCES 里的某一行删了、或分区又
-    // 搬了家，这条会立刻红 —— 否则测试会"扫了一个空文件然后全绿"，
-    // 正是本测试最怕的失败形态。
+  it('🔴 SOURCES 里的每个文件都各自抓到了动态导入（搬走/空扫别让它静默全绿）', () => {
+    // 设置页的重活（导出/导入/清除）仍在 DataSection 里走动态引擎导入。
+    // 若哪天有人把 SOURCES 里的某一行删了、或分区又搬了家，这条会立刻红 ——
+    // 否则测试会"扫了一个空文件然后全绿"，正是本测试最怕的失败形态。
     for (const { file } of SOURCES) {
       expect(
         sites.some((s) => s.file === file),

--- a/src/ui/components/settings/agent/AgentConfigPanel.vue
+++ b/src/ui/components/settings/agent/AgentConfigPanel.vue
@@ -36,6 +36,7 @@ import { agentDisplayName, getDefaultTemplateForAgent } from './agent-list';
 import { buildAgentDefaultEntry } from './agent-defaults';
 import { useSettingsStore, type PresetItem } from '../../../stores/settings-store';
 import { useUIStore } from '../../../stores/ui-store';
+import { usePresets } from '../../../composables/usePresets';
 import {
   AGENT_SETTINGS_DEFAULTS,
   applyProjectDefaultToAgent,
@@ -50,13 +51,19 @@ const props = defineProps<{ agentId: string }>();
 const cfg = useSettingsStore();
 const s = cfg.settings;
 const ui = useUIStore();
+const { presets: presetList, upsertPreset } = usePresets();
 
 const agentPromptDraft = ref('');
 const agentTemplateDraft = ref('');
 
-/** 当前选中的预设 —— 与 PresetManager 各算一次（对 store 的一行派生，不穿 prop） */
+/**
+ * 当前选中的预设 —— 与 PresetManager 各算一次（对 store 的一行派生，不穿 prop）。
+ *
+ * 内容-引擎分离波 1 / D22：预设真源是 Dexie（经 usePresets composable 的共享 ref），
+ * 不再读 `s.presets` localStorage 镜像。
+ */
 const activePreset = computed(
-  () => (s.presets as PresetItem[]).find((p) => p.id === s.activePresetId) ?? null,
+  () => presetList.value.find((p) => p.id === s.activePresetId) ?? null,
 );
 
 /** 载入两个草稿：用户自定义 → 项目默认（agent-config.json）→ 引擎内置模板 */
@@ -127,7 +134,9 @@ async function saveAsDefault() {
     promptDraft: agentPromptDraft.value,
     templateDraft: agentTemplateDraft.value,
     activePresetId: s.activePresetId || '',
-    activePreset: activePreset.value,
+    // ChatPreset 与 PresetItem 结构同形（id/name/description?/settings/createdAt/updatedAt）；
+    // buildAgentDefaultEntry 内部用 JSON 深拷贝，此处对齐前端历史类型签名。
+    activePreset: activePreset.value as unknown as PresetItem | null,
   });
 
   // 读取现有文件，更新当前 Agent，写回
@@ -159,14 +168,12 @@ async function restoreAgentDefaults() {
       // story 走预设子系统：systemPrompt/template 由预设提供，这里只拉预设 + 世界书 + 旋钮
       s.activePresetId = pd.presetId || '';
       if (pd.preset) {
-        const existing = s.presets.find((p) => p.id === pd.preset!.id);
+        const existing = presetList.value.find((p) => p.id === pd.preset!.id);
         if (!existing) {
-          s.presets.push(pd.preset);
           // 🔒 P2-04: await 写 IndexedDB —— 此前 fire-and-forget + 空 catch，
           // 刷新或页面销毁时 Promise 可能未完成，预设丢失且错误被吞。
           try {
-            const { savePreset } = await import('@engine/database');
-            await savePreset(pd.preset as any);
+            await upsertPreset(pd.preset as any);
           } catch (err) {
             console.error('[AgentConfigPanel] 恢复默认预设写 IndexedDB 失败:', err);
           }

--- a/src/ui/components/settings/agent/PresetManager.vue
+++ b/src/ui/components/settings/agent/PresetManager.vue
@@ -26,15 +26,18 @@ import AppCard from '../../shared/AppCard.vue';
 import AppButton from '../../shared/AppButton.vue';
 import AppModal from '../../shared/AppModal.vue';
 import TemplatePreview from '../TemplatePreview.vue';
-import { useSettingsStore, type PresetItem } from '../../../stores/settings-store';
+import { useSettingsStore } from '../../../stores/settings-store';
 import { useUIStore } from '../../../stores/ui-store';
+import { usePresets } from '../../../composables/usePresets';
 import { preprocessPresetForPreview } from '@engine/preset-loader';
+import type { ChatPreset } from '@engine/types';
 
 const props = defineProps<{ agentId: string }>();
 
 const cfg = useSettingsStore();
 const s = cfg.settings;
 const ui = useUIStore();
+const { presets, loadPresets: loadPresetsFromDexie, upsertPreset, removePreset } = usePresets();
 
 const showStoryPreview = ref(false);
 const showStoryResolvedPreview = ref(false);
@@ -77,9 +80,7 @@ function getStoryContextTemplate(): string {
  *    它是对 store 的一行派生（与 `hasApi` 同类），穿 prop 只是为了少一次 store 读取，
  *    却换来一条真正的组件间契约。
  */
-const activePreset = computed(
-  () => s.presets.find((p: PresetItem) => p.id === s.activePresetId) || null,
-);
+const activePreset = computed(() => presets.value.find((p) => p.id === s.activePresetId) || null);
 
 // 条目展开/折叠
 const expandedEntries = ref(new Set<string>());
@@ -91,22 +92,19 @@ function toggleEntry(presetId: string, idx: number) {
 
 // 条目启用/禁用开关 — 自动保存
 async function togglePresetEntryEnabled(presetId: string, idx: number) {
-  const p = s.presets.find((x: PresetItem) => x.id === presetId);
+  const p = presets.value.find((x) => x.id === presetId);
   if (!p?.settings?.prompts) return;
   const prompts = [...p.settings.prompts];
   if (!prompts[idx]) return;
   prompts[idx] = { ...prompts[idx], enabled: !(prompts[idx].enabled !== false) };
-  const raw = JSON.parse(
+  const raw: ChatPreset = JSON.parse(
     JSON.stringify({ ...p, settings: { ...p.settings, prompts }, updatedAt: Date.now() }),
   );
-  // 直接替换 s.presets 中对应的预设（避免闪动后再等 DB 回读）
-  const pi = s.presets.findIndex((x: PresetItem) => x.id === presetId);
-  if (pi >= 0) s.presets[pi] = raw;
   try {
-    const { savePreset } = await import('@engine/database');
-    await savePreset(raw);
+    await upsertPreset(raw);
   } catch {
-    /* DB 写入失败时 UI 已经乐观更新 */
+    /* DB 写入失败时内存 ref 已乐观更新（upsertPreset 内部先写 Dexie 再改 ref，
+       Dexie 失败则 ref 也不变；此处保留 catch 以兼容 IndexedDB 不可用环境） */
   }
 }
 
@@ -117,7 +115,7 @@ const editingEntryPresetId = ref('');
 const entryEditForm = reactive({ name: '', content: '', enabled: true, role: 'system' });
 
 function openEntryEditor(presetId: string, idx: number) {
-  const p = s.presets.find((x: PresetItem) => x.id === presetId);
+  const p = presets.value.find((x) => x.id === presetId);
   if (!p?.settings?.prompts?.[idx]) return;
   const sp = p.settings.prompts[idx];
   editingEntryPresetId.value = presetId;
@@ -130,7 +128,7 @@ function openEntryEditor(presetId: string, idx: number) {
 }
 
 async function saveEntry() {
-  const p = s.presets.find((x: PresetItem) => x.id === editingEntryPresetId.value);
+  const p = presets.value.find((x) => x.id === editingEntryPresetId.value);
   if (!p) return;
   const idx = editingEntryIdx.value;
   const prompts = [...(p.settings.prompts || [])];
@@ -142,12 +140,10 @@ async function saveEntry() {
       enabled: entryEditForm.enabled,
       role: entryEditForm.role,
     };
-    const raw = JSON.parse(
+    const raw: ChatPreset = JSON.parse(
       JSON.stringify({ ...p, settings: { ...p.settings, prompts }, updatedAt: Date.now() }),
     );
-    const { savePreset } = await import('@engine/database');
-    await savePreset(raw);
-    await loadPresets();
+    await upsertPreset(raw);
     s.activePresetId = raw.id;
     showEntryEditor.value = false;
     ui.toast('条目已保存', 'success');
@@ -168,16 +164,11 @@ const editingPresetId = ref<string | null>(null);
 
 async function loadPresets() {
   try {
-    const { getPresets } = await import('@engine/database');
-    const p = await getPresets();
-    if (p) {
-      // IndexedDB 有数据 → 直接用；为空 → 保留内存已有的（来自 agent-config.json seed）
-      if (p.length > 0) s.presets = p as PresetItem[];
-    }
+    await loadPresetsFromDexie();
     // 确保自动选中：如果还没选中且有可用预设，优先项目默认
-    if (!s.activePresetId && s.presets.length > 0) {
+    if (!s.activePresetId && presets.value.length > 0) {
       const pd = cfg.projectAgentDefaults?.agents?.story;
-      if (pd?.presetId && s.presets.find((p) => p.id === pd.presetId)) {
+      if (pd?.presetId && presets.value.find((p) => p.id === pd.presetId)) {
         s.activePresetId = pd.presetId;
       }
     }
@@ -187,7 +178,7 @@ async function loadPresets() {
 }
 function selectPreset(id: string) {
   s.activePresetId = id;
-  const p = s.presets.find((x: PresetItem) => x.id === id);
+  const p = presets.value.find((x) => x.id === id);
   if (p) {
     // 🔴 这里原本还有两行：`agentPromptDraft.value = ...` 与 `s.agentPromptEdited = true`。
     //    经查是**惰性**的：草稿绑的两个 textarea 只在非 story 分支渲染，而本组件只在
@@ -208,13 +199,12 @@ function openNewPreset() {
   showPresetEditor.value = true;
 }
 async function savePreset() {
-  const { savePreset: sp } = await import('@engine/database');
   const now = Date.now();
 
   let settings: Record<string, any>;
   if (editingPresetId.value) {
     // 编辑已有预设：基于原 settings 更新，不丢失原有数据
-    const original = s.presets.find((p: PresetItem) => p.id === editingPresetId.value);
+    const original = presets.value.find((p) => p.id === editingPresetId.value);
     settings = {
       ...(original?.settings || {}), // 保留所有原有 ST 配置
       temp_openai: presetForm.temperature,
@@ -248,26 +238,23 @@ async function savePreset() {
     };
   }
 
-  const item: PresetItem = {
+  const item: ChatPreset = {
     id: editingPresetId.value || crypto.randomUUID(),
     name: presetForm.name,
     description: presetForm.description,
     settings,
     createdAt: editingPresetId.value
-      ? s.presets.find((p: PresetItem) => p.id === editingPresetId.value)?.createdAt || now
+      ? presets.value.find((p) => p.id === editingPresetId.value)?.createdAt || now
       : now,
     updatedAt: now,
   };
-  await sp(item as any);
-  await loadPresets();
+  await upsertPreset(item);
   showPresetEditor.value = false;
   ui.toast(editingPresetId.value ? '预设已更新' : '预设已创建', 'success');
 }
 async function deletePreset(id: string) {
-  const { deletePreset: dp } = await import('@engine/database');
   try {
-    await dp(id);
-    await loadPresets();
+    await removePreset(id);
     if (s.activePresetId === id) s.activePresetId = '';
     ui.toast('预设已删除', 'info');
   } catch {
@@ -275,7 +262,6 @@ async function deletePreset(id: string) {
   }
 }
 async function importStPreset() {
-  const { savePreset: sp } = await import('@engine/database');
   const input = document.createElement('input');
   input.type = 'file';
   input.accept = '.json';
@@ -287,7 +273,7 @@ async function importStPreset() {
       // 用导入的文件名作为预设名
       const presetName = f.name.replace(/\.json$/i, '');
       const now = Date.now();
-      const preset: PresetItem = {
+      const preset: ChatPreset = {
         id: crypto.randomUUID(),
         name: presetName,
         description: raw.description || '',
@@ -295,8 +281,7 @@ async function importStPreset() {
         createdAt: now,
         updatedAt: now,
       };
-      await sp(preset as any);
-      await loadPresets();
+      await upsertPreset(preset);
       ui.toast(`已导入预设「${presetName}」(${raw.prompts?.length || 0} 个子提示词)`, 'success');
     } catch {
       ui.toast('导入失败，请检查文件格式', 'error');
@@ -304,7 +289,7 @@ async function importStPreset() {
   };
   input.click();
 }
-async function exportPresetDynamic(p: PresetItem) {
+async function exportPresetDynamic(p: ChatPreset) {
   const data = { ...p.settings, name: p.name, description: p.description };
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
@@ -341,7 +326,7 @@ void reactive;
         @change="selectPreset(($event.target as HTMLSelectElement).value)"
       >
         <option value="">— 选择预设 —</option>
-        <option v-for="p in s.presets" :key="p.id" :value="p.id">{{ p.name }}</option>
+        <option v-for="p in presets" :key="p.id" :value="p.id">{{ p.name }}</option>
       </select>
       <AppButton variant="ghost" size="sm" @click="importStPreset">导入</AppButton>
       <AppButton variant="primary" size="sm" @click="openNewPreset">+ 新建</AppButton>

--- a/src/ui/composables/usePresets.ts
+++ b/src/ui/composables/usePresets.ts
@@ -1,0 +1,69 @@
+/**
+ * 正文 Agent 预设（ChatPreset）的共享响应式状态 + Dexie 持久化。
+ *
+ * 内容-引擎分离波 1 / D22：预设撤出 localStorage。
+ * 此前预设同时写 Dexie 与 `settings.presets` 镜像，UI 全读镜像 ——
+ * 装包写 Dexie、UI 读镜像 = 装了看不见。本 composable 收口为：
+ *   · Dexie `presets` 表是唯一真源
+ *   · 模块级单例 `ref<ChatPreset[]>` 作跨组件共享响应式视图
+ *   · CRUD 经此处的 `loadPresets / upsertPreset / removePreset`，写 Dexie + 更新 ref
+ *
+ * `activePresetId` 仍在 settings-store（D22：settings 只留它）。
+ *
+ * 🔴 **模块级单例**：`presetsRef` 在文件作用域，所有调用方拿到同一份 ref，
+ *    一处刷新全部响应。不要把它挪进函数体——那会让 PresetManager 与
+ *    AgentConfigPanel 各持一份，saveAsDefault 写入后另一边看不到。
+ */
+import { ref, type Ref } from 'vue';
+import { deletePreset, getPresets, savePreset } from '@engine/database';
+import type { ChatPreset } from '@engine/types';
+
+const presetsRef: Ref<ChatPreset[]> = ref<ChatPreset[]>([]);
+let loaded = false;
+
+/** 从 Dexie 加载全部预设到内存 ref（幂等；首次调用后重复调用会刷新整表）。 */
+export async function loadPresets(): Promise<ChatPreset[]> {
+  const rows = await getPresets();
+  presetsRef.value = rows;
+  loaded = true;
+  return rows;
+}
+
+/** 已加载过则返回 true（避免每次挂载都触发 DB 读）。 */
+export function presetsLoaded(): boolean {
+  return loaded;
+}
+
+/** upsert 一条预设：写 Dexie + 更新内存 ref（命中同 id 则替换，否则追加）。 */
+export async function upsertPreset(preset: ChatPreset): Promise<void> {
+  await savePreset(preset);
+  const idx = presetsRef.value.findIndex((p) => p.id === preset.id);
+  if (idx >= 0) {
+    presetsRef.value[idx] = preset;
+  } else {
+    presetsRef.value.push(preset);
+  }
+}
+
+/** 删除一条预设：写 Dexie + 从内存 ref 移除。 */
+export async function removePreset(id: string): Promise<void> {
+  await deletePreset(id);
+  presetsRef.value = presetsRef.value.filter((p) => p.id !== id);
+}
+
+/** 共享响应式视图（只读语义：消费方不要直接改数组，走 upsert/remove）。 */
+export function usePresets(): {
+  presets: Ref<ChatPreset[]>;
+  loadPresets: typeof loadPresets;
+  upsertPreset: typeof upsertPreset;
+  removePreset: typeof removePreset;
+  presetsLoaded: typeof presetsLoaded;
+} {
+  return {
+    presets: presetsRef,
+    loadPresets,
+    upsertPreset,
+    removePreset,
+    presetsLoaded,
+  };
+}

--- a/src/ui/stores/settings-store.test.ts
+++ b/src/ui/stores/settings-store.test.ts
@@ -162,7 +162,10 @@ describe('settings-store', () => {
     // Q-18: 12 张 per-Agent map 已合并成一张 `agents` 表
     expect(keys).toContain('agents');
     expect(keys).not.toContain('agentModels');
-    expect(keys).toContain('presets');
+    // D22（内容-引擎分离波 1）：presets 镜像已删，真源在 Dexie（usePresets composable）；
+    // settings 只留 activePresetId。与 worldBooks 同口径 —— 不留默认值避免消费端误以为是真相。
+    expect(keys).not.toContain('presets');
+    expect(keys).toContain('activePresetId');
     expect(keys).toContain('plotMode');
     expect(keys).toContain('plotDurationYears');
     expect(keys).toContain('plotDifficultyTier');

--- a/src/ui/stores/settings-store.ts
+++ b/src/ui/stores/settings-store.ts
@@ -121,6 +121,50 @@ export function serializeSettingsForLocalStorage(settings: Record<string, unknow
   return JSON.stringify(copy);
 }
 
+/**
+ * 内容-引擎分离波 1 / D22：把残留的 `settings.presets` localStorage 镜像一次性迁进 Dexie。
+ *
+ * 迁移规则（幂等、跑一次）：
+ *   · 镜像无 presets（新用户 / 已迁完）→ 不动（仍清掉残留空数组键）
+ *   · 镜像有 presets 且 Dexie presets 表为空 → 镜像整份迁入 Dexie，然后从 settings 删除字段
+ *   · 镜像有 presets 但 Dexie 已有数据 → 以 Dexie 为准，直接弃镜像（删字段）
+ *
+ * 🔴 无论命中哪条有数据的分支，**都要从 settings 删除 presets 字段并 persist**：
+ *    `UiSettings` 已不声明该字段，留着会被 deep watch 永久写回 localStorage 成幽灵键。
+ *    迁移成功后下次启动镜像无 presets，本函数空转。
+ */
+async function migratePresetsMirrorToDexie(
+  settingsValue: Record<string, unknown>,
+  persist: () => boolean,
+): Promise<void> {
+  const mirror = settingsValue.presets;
+  if (!Array.isArray(mirror) || mirror.length === 0) {
+    // 即便残留一个空数组也清掉键，避免 deep watch 写回。
+    if ('presets' in settingsValue) {
+      delete settingsValue.presets;
+      persist();
+    }
+    return;
+  }
+  try {
+    const { getPresets, savePreset } = await import('@engine/database');
+    const existing = await getPresets();
+    if (!existing || existing.length === 0) {
+      // Dexie 空 → 迁入镜像里的每一条
+      for (const p of mirror) {
+        if (p && typeof p === 'object' && typeof (p as { id?: unknown }).id === 'string') {
+          await savePreset(p as any);
+        }
+      }
+    }
+    // 无论是否迁入（Dexie 已有则弃镜像），都删字段。
+    delete settingsValue.presets;
+    persist();
+  } catch {
+    // IndexedDB 不可用：保留镜像字段不动，下次启动再试。
+  }
+}
+
 function getDefaults(): UiSettings {
   return {
     // API 池
@@ -153,7 +197,10 @@ function getDefaults(): UiSettings {
     agentPromptEdited: false,
 
     // 预设系统 (ChatPreset)
-    presets: [],
+    // 🔴 `presets` 镜像已删除（内容-引擎分离波 1 / D22）：预设真源是 Dexie `presets` 表，
+    //    唯一响应式视图是 usePresets composable。留个空数组会让消费端以为这里仍是真相来源，
+    //    而 deep watch 又会把它写回 localStorage —— 与 worldBooks/beautifierRules 同口径。
+    //    下面这项是「当前选中哪条预设」的 UI 状态，继续留在设置里。
     activePresetId: '',
 
     // Phase 8: 世界书管理
@@ -289,6 +336,19 @@ export const useSettingsStore = defineStore('settings', () => {
   // 必须在 localStorage→Dexie 迁移**之后**、针对 Dexie 执行，否则会把内置书写回
   // localStorage，源数组在迁移脚下漂移。
   setTimeout(async () => {
+    // 🔴 内容-引擎分离波 1 / D22：一次性迁移 presets 镜像 → Dexie。
+    //    必须在 loadAgentProjectDefaults 之前跑：seed 那步只在 Dexie 空时播种出厂预设，
+    //    迁移先把用户的第三方预设从镜像搬进 Dexie，seed 就不会覆盖它们。
+    //    迁移幂等：完成后从 settings 删除 presets 字段并 persist，下次启动不再触发。
+    await migratePresetsMirrorToDexie(settings.value as Record<string, unknown>, () => {
+      try {
+        localStorage.setItem(STORAGE_KEY, serializeSettingsForLocalStorage(settings.value));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
     // 加载项目默认 Agent 配置
     await loadAgentProjectDefaults();
 
@@ -450,34 +510,27 @@ export const useSettingsStore = defineStore('settings', () => {
       // 就不写键，把「走引擎按类别的默认」那条语义还回去。
       fillMissingAgentSettings(settings.value, agentId, entry);
       // 预设：DB 空 → seed 出厂预设；DB 有同 id → 同步出厂 name（保留用户 prompts 编辑）
+      //
+      // 🔴 内容-引擎分离波 1 / D22：预设只写 Dexie，不再碰 `settings.presets` 镜像。
+      //    （此前这里还同步写镜像 —— 镜像删除后那段是死代码。）响应式视图由
+      //    usePresets composable 提供，本处 seed 之后下次 loadPresets 自然读到。
       if (entry.preset && entry.presetId) {
         try {
           const { getPresets, savePreset } = await import('@engine/database');
           const existing = await getPresets();
-          const embedded: any = JSON.parse(JSON.stringify(entry.preset));
+          const embedded = JSON.parse(JSON.stringify(entry.preset)) as PresetItem;
           if (!existing || existing.length === 0) {
             await savePreset(embedded);
           } else {
             // M5.1: 出厂预设改名同步 —— id 匹配时把 DB 预设 name 更新为出厂版
             // （prompts/settings 保留用户编辑；仅 name 跟随 agent-config.json）
-            const dbMatch = existing.find((p: any) => p.id === embedded.id);
+            const dbMatch = existing.find((p) => p.id === embedded.id);
             if (dbMatch && dbMatch.name !== embedded.name) {
-              const updated = { ...dbMatch, name: embedded.name };
-              await savePreset(updated);
-              const idx = (settings.value.presets as PresetItem[]).findIndex(
-                (p) => p.id === embedded.id,
-              );
-              if (idx >= 0) (settings.value.presets as PresetItem[])[idx] = updated as PresetItem;
+              await savePreset({ ...dbMatch, name: embedded.name });
             }
           }
         } catch {
           /* IndexedDB 不可用时静默跳过 */
-        }
-        const existingPreset = (settings.value.presets as PresetItem[]).find(
-          (p) => p.id === entry.presetId,
-        );
-        if (!existingPreset && entry.preset) {
-          (settings.value.presets as PresetItem[]).push(entry.preset);
         }
         if (!settings.value.activePresetId) {
           settings.value.activePresetId = entry.presetId;

--- a/src/ui/stores/settings-types.ts
+++ b/src/ui/stores/settings-types.ts
@@ -35,7 +35,7 @@
  *
  * 不声明 = 应用代码碰它就是编译错误，迁移模块照常工作。这是想要的效果。
  */
-import type { ApiEntry, PresetItem } from './settings-store';
+import type { ApiEntry } from './settings-store';
 import type { AgentSettingsEntry } from './agent-settings';
 import type { ImageGenMode, ImageRating, NaiBillingTier } from '@engine/types-image';
 
@@ -68,7 +68,8 @@ export type UiSettings = {
   agentPromptEdited: boolean;
 
   // ═══ 预设系统（正文 Agent 专用）═══
-  presets: PresetItem[];
+  // 🔴 内容-引擎分离波 1 / D22：`presets` 镜像已删除。预设真源是 Dexie `presets` 表，
+  //    响应式视图经 `usePresets` composable。这里只剩「当前选中哪条」的 UI 状态。
   activePresetId: string;
 
   // ═══ 世界书（书本体在 Dexie，这里只有 UI 选择/开关）═══


### PR DESCRIPTION
## 内容-引擎分离 · 波 1 · T3

设计真源：\`docs/planning/2026-08-05-content-engine-separation-design.md\` D22

## 问题

此前预设双写（Dexie + \`settings.presets\` 镜像），UI 全读镜像 —— 装包写 Dexie 而 UI 读镜像 = **装了看不见**。D22 从「顺手收益」提级为**前置任务**（D19 装包写 presets 的前提）。

## 交付（1 新文件 + 8 改文件）

- **新建 \`usePresets.ts\`**：模块级单例 \`ref<ChatPreset[]>\` + Dexie CRUD（load/upsert/remove），PresetManager 与 AgentConfigPanel 共享同一份响应式视图
- **PresetManager.vue**：10 处 \`s.presets\` 镜像 + 5 处动态 import(database) 全改 usePresets
- **AgentConfigPanel.vue:58**：activePreset computed + restoreAgentDefaults 走 usePresets
- **settings-store.ts**：getDefaults 删 presets 默认值；播种路径改纯 Dexie；新增 \`migratePresetsMirrorToDexie\`（boot 一次性迁移：Dexie 空迁入后删字段 / Dexie 有则弃字段；幂等；IndexedDB 不可用保留镜像下次再试）
- **settings-types.ts**：UiSettings 删 \`presets\` 字段（保留 \`activePresetId\`）
- **database.ts**：presets 从 lorebooks/settings 事务拆出，改三态护栏（字段缺失跳过 / [] 清空 / rows 替换）—— 🔴 护栏作用域只保护手编备份，不阻断 D18 reconcilePackState（T5）
- **database.test.ts**：加 D22 presets 三态 4 条断言
- settings-store.test.ts / SettingsPage.engine-imports.test.ts：断言修正

## 验证

- prettier --write 所有改过文件 ✅
- typecheck ×2 ✅ / lint ✅ / knip（144 无新增）✅
- 全量 test:run ✅（264 文件 / 6805 tests，含 encoding-invariants 编码门）
- 改过文件编码全干净

## 主会话审查

子 agent 产出干净，本喵无需修正（usePresets 模块级单例设计正确、迁移幂等逻辑正确、三态护栏作用域正确）。主会话独立重跑全部六道门全绿。

## 后续

合并后派 T6（planner 四态逻辑，新文件零撞面）→ T5（Dexie v20）→ T4（agents 分层）→ T7（执行器）。