### PR TITLE
波 1 T5: Dexie v20 contentPacks 表 + FullBackup 边界 + 恢复后对账

### DIFF
--- a/src/sillytavern/database.test.ts
+++ b/src/sillytavern/database.test.ts
@@ -94,11 +94,18 @@ import type {
   AudioHandleRecord,
   AssetMetaRecord,
   WorkshopProject,
+  WorldBook,
 } from './types';
 import { DEFAULT_SETTINGS } from './types';
 import Dexie from 'dexie';
 import { createDefaultCharacterState } from './types';
-import { createDefaultSaveProfile, saveSaveProfile, savePlotOutline } from './database';
+import {
+  createDefaultSaveProfile,
+  saveSaveProfile,
+  savePlotOutline,
+  reconcilePackState,
+} from './database';
+import type { ContentPackRecord } from './database';
 import { createStateManager } from './state-manager';
 
 // ========== Helpers ==========
@@ -817,7 +824,8 @@ describe('exportAllData / importAllData', () => {
     // 🔴 跟随 DB_VERSION，而 DB_VERSION 必须等于最后一个 `this.version(n)` ——
     // 这条断言曾经写着 17 而 schema 已经到 19（v18 删地点预设行 / v19 角色外貌会话副本），
     // 于是它把漂移**固定**下来而不是拦下来。升版时 database.ts 与这里一起改。
-    expect(backup.version).toBe(19);
+    // v20：内容-引擎分离波 1 / D18 —— contentPacks 表（安装持久化，不进 FullBackup）。
+    expect(backup.version).toBe(20);
     expect(Array.isArray(backup.lorebooks)).toBe(true);
     expect(Array.isArray(backup.presets)).toBe(true);
     expect(Array.isArray(backup.settings)).toBe(true);
@@ -838,6 +846,9 @@ describe('exportAllData / importAllData', () => {
     expect('sceneImageBlobs' in backup).toBe(false);
     // v19 —— 角色外貌会话副本与 sceneImages 同为「每存档」数据，必须同进同出
     expect(Array.isArray(backup.characterAppearances)).toBe(true);
+    // v20 —— contentPacks 刻意不进 FullBackup（D18 / §5.7）：payload 进备份 = 每份日常备份
+    // 都成了可自由转发的完整内容包 + 体积翻倍。备份/恢复一致性由 reconcilePackState() 解决。
+    expect('contentPacks' in backup).toBe(false);
   });
 
   /**
@@ -985,7 +996,7 @@ describe('exportAllData / importAllData', () => {
       legacyBackup.version = 13;
       expect('worldBooks' in legacyBackup).toBe(false);
 
-      await expect(importAllData(legacyBackup)).resolves.toBeUndefined();
+      await expect(importAllData(legacyBackup)).resolves.toBeDefined();
 
       const db = getDatabase();
       expect(await db.worldBooks.count()).toBe(2);
@@ -1025,7 +1036,7 @@ describe('exportAllData / importAllData', () => {
       legacyBackup.version = 13;
       expect('workshopProjects' in legacyBackup).toBe(false);
 
-      await expect(importAllData(legacyBackup)).resolves.toBeUndefined();
+      await expect(importAllData(legacyBackup)).resolves.toBeDefined();
 
       const db = getDatabase();
       expect(await db.workshopProjects.count()).toBe(2);
@@ -1064,7 +1075,7 @@ describe('exportAllData / importAllData', () => {
       delete legacyBackup.workshopProjects;
       legacyBackup.version = 13;
 
-      await expect(importAllData(legacyBackup)).resolves.toBeUndefined();
+      await expect(importAllData(legacyBackup)).resolves.toBeDefined();
 
       const db = getDatabase();
       expect(await db.worldBooks.count()).toBe(2);
@@ -1111,7 +1122,7 @@ describe('exportAllData / importAllData', () => {
       legacyBackup.version = 14;
       expect('beautifierRules' in legacyBackup).toBe(false);
 
-      await expect(importAllData(legacyBackup)).resolves.toBeUndefined();
+      await expect(importAllData(legacyBackup)).resolves.toBeDefined();
 
       const db = getDatabase();
       expect(await db.beautifierRules.count()).toBe(2);
@@ -1198,7 +1209,7 @@ describe('exportAllData / importAllData', () => {
       legacyBackup.version = 14;
       expect('presets' in legacyBackup).toBe(false);
 
-      await expect(importAllData(legacyBackup)).resolves.toBeUndefined();
+      await expect(importAllData(legacyBackup)).resolves.toBeDefined();
 
       const db = getDatabase();
       expect(await db.presets.count()).toBe(2);
@@ -1264,7 +1275,7 @@ describe('exportAllData / importAllData', () => {
       delete legacyBackup.regexStorage;
       legacyBackup.version = 15;
 
-      await expect(importAllData(legacyBackup)).resolves.toBeUndefined();
+      await expect(importAllData(legacyBackup)).resolves.toBeDefined();
 
       const rows = await getDatabase().regexStorage.toArray();
       expect(rows).toHaveLength(2);
@@ -1354,6 +1365,188 @@ describe('exportAllData / importAllData', () => {
     const proj = await db2.workshopProjects.get('proj_1');
     expect(proj).toBeDefined();
     expect(proj!.uidRange).toEqual({ start: 900000, end: 900999 });
+  });
+});
+
+// ========== v20 contentPacks 表 + 恢复对账（D18 / §5.7） ==========
+
+describe('contentPacks 表 (v20 / D18)', () => {
+  it('contentPacks 表存在且主键为 packId', async () => {
+    const db = getDatabase();
+    // 表存在（Dexie 暴露 .contentPacks Table）
+    expect(db.contentPacks).toBeDefined();
+    // 主键索引 = packId（schema 写的是 'packId'）
+    const schema = db.contentPacks.schema;
+    expect(schema?.primKey.keyPath).toBe('packId');
+  });
+
+  it('FullBackup 往返不碰 contentPacks（payload 不进备份）', async () => {
+    const db = getDatabase();
+    const rec: ContentPackRecord = {
+      packId: 'pack_test_rt',
+      packVersion: '1.0.0',
+      installedAt: 1_700_000_000_000,
+      payload: {
+        formatVersion: 1,
+        packId: 'pack_test_rt',
+        packVersion: '1.0.0',
+      } as any,
+    };
+    await db.contentPacks.put(rec);
+
+    const backup = await exportAllData();
+    // 备份里没有 contentPacks 字段（D18）
+    expect('contentPacks' in backup).toBe(false);
+
+    // 清表后恢复，contentPacks **不应被恢复**（备份从未收它）
+    await db.contentPacks.clear();
+    expect(await db.contentPacks.count()).toBe(0);
+    await importAllData(backup);
+    expect(await db.contentPacks.count()).toBe(0);
+  });
+});
+
+describe('reconcilePackState (D18 / §5.7)', () => {
+  /** 造一本最小世界书（满足 hashWorldBook 所需字段） */
+  function makeBook(id: string, content: string): WorldBook {
+    return {
+      id,
+      name: id,
+      partition: 'lorebook' as any,
+      entries: [
+        {
+          uid: 1,
+          name: '条目',
+          content,
+          enabled: true,
+          key: [],
+          keysecondary: [],
+          selectiveLogic: 0,
+          order: 100,
+          position: 0,
+        },
+      ],
+    };
+  }
+
+  /** 造一个最小 pack 行（payload 含一本世界书） */
+  function makePackRecord(packBookId: string, content: string): ContentPackRecord {
+    return {
+      packId: 'pack_recon',
+      packVersion: '1.0.0',
+      installedAt: 1_700_000_000_000,
+      payload: {
+        formatVersion: 1,
+        packId: 'pack_recon',
+        packVersion: '1.0.0',
+        worldBooks: [makeBook(packBookId, content)],
+      } as any,
+    };
+  }
+
+  it('无 pack 安装时返回空结果', async () => {
+    const result = await reconcilePackState();
+    expect(result.mismatches).toEqual([]);
+    expect(result.reimportedPresetId).toBeNull();
+  });
+
+  it('pack 拥有项齐全且 hash 一致 → 无失配', async () => {
+    const db = getDatabase();
+    const book = makeBook('wb_pack_ok', '原始正文');
+    await db.contentPacks.put(makePackRecord('wb_pack_ok', '原始正文'));
+    await db.worldBooks.put(book);
+
+    const result = await reconcilePackState();
+    expect(result.mismatches).toEqual([]);
+    expect(result.reimportedPresetId).toBeNull();
+  });
+
+  it('pack 拥有项缺失 → needs_attention (missing)', async () => {
+    const db = getDatabase();
+    // pack 声明拥有 wb_pack_miss，但 worldBooks 表里没有它
+    await db.contentPacks.put(makePackRecord('wb_pack_miss', '原始正文'));
+    // 不 put 对应的世界书行
+
+    const result = await reconcilePackState();
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]).toMatchObject({
+      packId: 'pack_recon',
+      section: 'worldBooks',
+      key: 'wb_pack_miss',
+      kind: 'missing',
+    });
+  });
+
+  it('pack 拥有项被替换（用户编辑过）→ needs_attention (replaced)', async () => {
+    const db = getDatabase();
+    await db.contentPacks.put(makePackRecord('wb_pack_edit', '原始正文'));
+    // 同 id 但正文不同 → hash 不符
+    await db.worldBooks.put(makeBook('wb_pack_edit', '用户改过的正文'));
+
+    const result = await reconcilePackState();
+    expect(result.mismatches).toHaveLength(1);
+    expect(result.mismatches[0]).toMatchObject({
+      packId: 'pack_recon',
+      section: 'worldBooks',
+      key: 'wb_pack_edit',
+      kind: 'replaced',
+    });
+  });
+
+  it('用户自建书 / 工坊书不在比对域内（不报失配）', async () => {
+    const db = getDatabase();
+    await db.contentPacks.put(makePackRecord('wb_pack_user', '原始正文'));
+    await db.worldBooks.put(makeBook('wb_pack_user', '原始正文'));
+    // 用户自建书 —— pack 不声明拥有它，reconcile 不该碰它
+    await db.worldBooks.put(makeBook('wb_user_only', '用户自己的书'));
+
+    const result = await reconcilePackState();
+    expect(result.mismatches).toEqual([]);
+  });
+
+  it('presets 表为空 + pack 含 presets → 重导第一条预设', async () => {
+    const db = getDatabase();
+    // pack 声明拥有一条预设，但 presets 表是空的（旧备份清了表）
+    await db.contentPacks.clear();
+    await db.presets.clear();
+    const packWithPreset: ContentPackRecord = {
+      packId: 'pack_preset',
+      packVersion: '1.0.0',
+      installedAt: 1_700_000_000_000,
+      payload: {
+        formatVersion: 1,
+        packId: 'pack_preset',
+        packVersion: '1.0.0',
+        presets: [
+          {
+            id: 'preset_pack_story',
+            name: '故事预设',
+            settings: {},
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+      } as any,
+    };
+    await db.contentPacks.put(packWithPreset);
+
+    const result = await reconcilePackState();
+    expect(result.reimportedPresetId).toBe('preset_pack_story');
+    // 重导后 presets 表里有了那条
+    expect(await db.presets.get('preset_pack_story')).toBeDefined();
+  });
+
+  it('importAllData 收尾挂 reconcile（返回对账结果）', async () => {
+    const db = getDatabase();
+    // 准备：装一个 pack，其拥有项在恢复后会缺失
+    await db.contentPacks.put(makePackRecord('wb_pack_import', '原始正文'));
+    // 不放对应世界书行 → 恢复后应报 missing
+
+    const backup = await exportAllData();
+    // importAllData 现在返回 ReconcileResult
+    const result = await importAllData(backup);
+    expect(result.mismatches.length).toBeGreaterThanOrEqual(1);
+    expect(result.mismatches.some((m) => m.key === 'wb_pack_import')).toBe(true);
   });
 });
 
@@ -2051,10 +2244,11 @@ describe('Asset CRUD (v13)', () => {
     // ---- 以当前版 (AppDatabase) 打开：触发升版 ----
     await initializeDatabase();
     const db = getDatabase();
-    expect(db.verno).toBe(19); // v18 = D59 删地点预设；v19 = D56 角色外貌会话副本
+    expect(db.verno).toBe(20); // v18=D59 删地点预设; v19=D56 角色外貌会话副本; v20=D18 contentPacks 表
 
     // 表册齐全: v12 的 17 张 + 素材两张 + 工坊两张 + 美化规则一张 + 正则 KV 一张
-    //           + 图像生成三张 + 角色外貌会话副本一张（v19/D56），一个不少
+    //           + 图像生成三张 + 角色外貌会话副本一张（v19/D56）
+    //           + contentPacks 一张（v20/D18），一个不少
     //（误写 `表名: null` 或漏声明会在这里炸 —— 尤其 lorebooks/settings 两张死表按 D3 必须保留）
     const EXPECTED_TABLES = [
       ...Object.keys(V12_STORES),
@@ -2068,6 +2262,7 @@ describe('Asset CRUD (v13)', () => {
       'sceneImageBlobs',
       'imagePresets',
       'characterAppearances',
+      'contentPacks',
     ].sort();
     expect(db.tables.map((t) => t.name).sort()).toEqual(EXPECTED_TABLES);
 

--- a/src/sillytavern/database.ts
+++ b/src/sillytavern/database.ts
@@ -39,6 +39,8 @@ import type {
   ImagePreset,
 } from './types-image';
 import type { CreatePreset } from '../ui/stores/create-store';
+import type { ContentPack } from './types-content';
+import { hashWorldBook } from './content-source';
 
 /** 捏人预设记录 (DB 存储格式) */
 export interface CreatePresetRecord {
@@ -47,6 +49,31 @@ export interface CreatePresetRecord {
   createdAt: number;
   updatedAt: number;
   data: CreatePreset;
+}
+
+/**
+ * contentPacks 表行形状（D18）。
+ *
+ * 🔴 **payload 是整包 ContentPack**：恢复默认 / 卸载 / 升级 diff 都不需要重新拿文件 ——
+ *    所有「装包时发生过什么」都从这一份还原。`sectionHashes` 与 `notes` 直接复用
+ *    ContentPack 的同名字段（构建器盖章 / 安装处置记录），为查询便利提升到一等字段。
+ *
+ * 🔴 **contentPacks 不进 FullBackup**（D18）：payload 进备份 = 每份日常备份都是可自由转发的
+ *    完整内容包 + 体积翻倍。备份/恢复一致性由 `reconcilePackState()` 解决。
+ */
+export interface ContentPackRecord {
+  /** 主键 = `payload.packId`（与 payload 同源，提升为索引便于直接查询） */
+  packId: string;
+  /** = `payload.packVersion`（semver，驱动升级判定 D40） */
+  packVersion: string;
+  /** 安装时间戳（epoch ms）；本次 put 的时间，非 payload.exportedAt */
+  installedAt: number;
+  /** 整包内容（ContentPack 原样入库） */
+  payload: ContentPack;
+  /** = `payload.sectionHashes`（D40 升级 diff 展示与快速比对用；逐书基线从 payload 现算） */
+  sectionHashes?: Readonly<Record<string, string>>;
+  /** 安装处置记录（WorkshopNote[]，由执行器在安装时产出） */
+  notes?: unknown[];
 }
 
 const DB_NAME = 'SillyTavernWebDB';
@@ -59,7 +86,7 @@ const DB_NAME = 'SillyTavernWebDB';
  * 而 `database.test.ts` 里那条断言跟着写了 17，于是漂移被测试**固定**下来而不是拦下来。
  * 升版时这两处一起改。
  */
-const DB_VERSION = 19;
+const DB_VERSION = 20;
 
 // ═══════════════════════════════════════════════════════════
 // Schema 声明（Q-26）
@@ -189,6 +216,11 @@ class AppDatabase extends Dexie {
   // v19 (D56): 角色外貌的**会话副本** —— 随存档隔离，删存档连带删。
   // 基线在 imagePresets.appearance（全局、干净、用户可编辑），这一份由出图 AI 自动写。
   characterAppearances!: Table<CharacterSessionAppearance>;
+
+  // v20 (内容-引擎分离波 1 / D18): 内容包安装持久化。
+  //   payload = 整包 ContentPack；恢复默认/卸载/升级 diff 都从这里还原，无需重拿文件。
+  //   🔴 **不进 FullBackup**（payload 进备份 = 每份备份都是可转发的完整内容包）。
+  contentPacks!: Table<ContentPackRecord>;
 
   constructor() {
     super(DB_NAME);
@@ -538,6 +570,16 @@ class AppDatabase extends Dexie {
     // v19 (D56): 角色外貌会话副本。`saveId` 单独建索引 —— 「整档重置」与
     // `deleteSaveSlot` 都是按存档整批删，没有它就得全表扫。
     this.version(19).stores({ characterAppearances: 'key, saveId, name' });
+
+    // v20 (内容-引擎分离波 1 / D18): contentPacks 表 —— 安装持久化的唯一真源。
+    //
+    // 🔴 payload 是整包 ContentPack：恢复默认 / 卸载 / 升级 diff 不需要重新拿文件。
+    //    🔴 **不进 FullBackup**（D18）：payload 进备份 = 每份日常备份都是可自由转发的
+    //       完整内容包 + 体积翻倍；备份/恢复一致性由 `reconcilePackState()` 解决。
+    //
+    // 索引取舍：只建 `packId` 主键。安装/卸载/升级/对账全部按 packId 直查，无第二索引需求。
+    // 与 v19 同款用对象字面量（仅声明本版新增表，旧表跨版继承，Dexie 4 累加语义）。
+    this.version(20).stores({ contentPacks: 'packId' });
   }
 }
 
@@ -622,6 +664,12 @@ export interface FullBackup {
   // 而存档的其余部分完好，于是症状看起来像「AI 忘了她换过装」而不是「备份没收这张表」。
   // 纯文本 patch，体积与 imagePresets 同量级。
   characterAppearances: CharacterSessionAppearance[];
+
+  // 🔴 **contentPacks 不在这个列表里，也不会被加进来**（D18 / §5.7）：
+  //    payload 进备份 = 每份日常备份都是可自由转发的完整内容包 + 体积翻倍。
+  //    备份/恢复一致性由 `reconcilePackState()` 解决 —— 它挂在 `importAllData` 收尾，
+  //    逐 pack 拥有项比对（payload 现算 hash vs 恢复行 hash），失配只报 needs_attention、
+  //    不自动改任何一边。
 }
 
 export async function exportAllData(): Promise<FullBackup> {
@@ -737,7 +785,7 @@ function validateBackupOrThrow(backup: any): asserts backup is FullBackup {
   }
 }
 
-export async function importAllData(backup: FullBackup): Promise<void> {
+export async function importAllData(backup: FullBackup): Promise<ReconcileResult> {
   // 🔒 P0-04: 先验证 —— 不合法的备份（空对象/残缺结构）直接拒绝，不进入 clear 流程
   validateBackupOrThrow(backup);
 
@@ -757,6 +805,13 @@ export async function importAllData(backup: FullBackup): Promise<void> {
     }
     throw err;
   }
+
+  // 内容-引擎分离波 1 / D18 / §5.7：恢复完成后跑对账。
+  // contentPacks 不进备份，所以恢复可能让 pack 拥有的 worldBooks/presets 行与 payload
+  // 失配（旧备份清了表 / 手编备份删了字段）。对账只读 + 报告，不自动改任何一边；
+  // 唯一的写动作是 `activePresetId` 悬空时从 payload 重导 story 预设（D18 明确分支）。
+  // 🔴 reconcile 自身绝不再调 importAllData（会递归），也不读 backup（只看现状 vs payload）。
+  return reconcilePackState();
 }
 
 /** 纯导入内核（无验证、无预备份）— importAllData 与失败回滚共用 */
@@ -918,6 +973,157 @@ async function doImportAllData(
       }
     }
   });
+}
+
+// ═══════════════════════════════════════════════════════════
+// 内容包恢复对账（D18 / §5.7）
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * 一条 pack 拥有项的失配记录（reconcilePackState 产出）。
+ *
+ * `kind` 区分两类失配，UI 据此给不同的措辞与二选动作（D18）：
+ * - `'missing'`：恢复后该拥有项不见了（旧备份清了表 / 手编备份删了字段）。
+ *   用户二选：从本地 payload 重放 / 卸载回占位。
+ * - `'replaced'`：拥有项还在但内容与 payload 不符（用户编辑过 / 被别处覆盖）。
+ *   同样二选，但措辞要承认「这是你改过的，覆盖会丢你的编辑」。
+ */
+export interface ReconcileMismatch {
+  packId: string;
+  /** 'worldBooks' | 'presets' —— 对账范围（D18 限定这两节） */
+  section: 'worldBooks' | 'presets';
+  /** 该项的逻辑键（世界书 id / 预设 id） */
+  key: string;
+  /** 该项的人类可读名（UI 展示用） */
+  name: string;
+  kind: 'missing' | 'replaced';
+}
+
+/**
+ * 恢复后对账结果（reconcilePackState 产出）。
+ *
+ * 🔴 `needsAttention` 为空且 `reimportedPresetId === null` → 一切正常，调用方无需提示。
+ *    有任意一项 → 调用方（content-store / DataSection）应把 `contentStatus` 置为
+ *    `'needs_attention'` 并展示项列表 + 二选动作（D18：**不自动做任何一边**）。
+ */
+export interface ReconcileResult {
+  /** 全部 pack 合计的失配项（跨 pack 跨 section）；空数组 = 无失配 */
+  mismatches: ReconcileMismatch[];
+  /**
+   * activePresetId 悬空时从 payload 重导的 story 预设 id（D18 明确分支）；
+   * `null` = 未触发重导（activePresetId 仍指向存在的预设，或没有任何 pack / pack 无 presets）。
+   *
+   * 🔴 这是 reconcile 唯一的写动作：旧备份清了 presets 表会让 activePresetId 指向不存在的
+   *    预设；从 contentPacks.payload 把 story 预设重新 put 进 presets 表。
+   *    重导后 activePresetId 的真源（settings-store localStorage）由调用方另行同步，
+   *    本函数只负责 DB 层 presets 行存在。
+   */
+  reimportedPresetId: string | null;
+}
+
+/**
+ * 恢复后内容包状态对账（D18 / §5.7）。
+ *
+ * 🔴 **对账范围限定 `{worldBooks, presets}`**（D18）：其余分节的真源就是 contentPacks.payload
+ *    本身，恢复动不到它们（FullBackup 不收 contentPacks），无从失配。
+ *
+ * 🔴 **逐 pack 拥有项比对**（D18 hash 分工）：对每本 pack 拥有的世界书，从 payload 现算
+ *    `hashWorldBook` 作为基线，与恢复行 hash 比对；预设走 id 存在性（预设无逐条 hash 基线，
+ *    D18 只要求「id 在不在」）。用户自建书 / 工坊书不在任何 pack 的拥有域内，不参与比对。
+ *
+ * 🔴 **只读 + 报告，不自动改任何一边**（D18「不自动做任何一边」）：失配只产出
+ *    `ReconcileMismatch`，调用方决定本地 payload 重放还是卸载回占位。
+ *
+ * 🔴 唯一的写动作：`activePresetId` 悬空 → 从 payload 重导 story 预设（D18 明确分支）。
+ *
+ * @returns 对账结果；`mismatches` 为空且 `reimportedPresetId === null` 即一切正常
+ */
+export async function reconcilePackState(): Promise<ReconcileResult> {
+  const db = getDatabase();
+  const packs = await db.contentPacks.toArray();
+
+  // 无 pack 安装 → 无从对账（也无需重导预设）
+  if (packs.length === 0) {
+    return { mismatches: [], reimportedPresetId: null };
+  }
+
+  const mismatches: ReconcileMismatch[] = [];
+
+  // ── 1. worldBooks 逐 pack 逐书比对（hash 从 payload 现算） ──
+  const allBooks = await db.worldBooks.toArray();
+  const booksById = new Map<string, WorldBook>();
+  for (const b of allBooks) booksById.set(b.id, b);
+
+  for (const pack of packs) {
+    const packBooks = pack.payload.worldBooks;
+    if (!packBooks || packBooks.length === 0) continue;
+    for (const packBook of packBooks) {
+      const current = booksById.get(packBook.id);
+      const packHash = hashWorldBook(packBook);
+      if (!current) {
+        mismatches.push({
+          packId: pack.packId,
+          section: 'worldBooks',
+          key: packBook.id,
+          name: packBook.name,
+          kind: 'missing',
+        });
+      } else if (hashWorldBook(current) !== packHash) {
+        mismatches.push({
+          packId: pack.packId,
+          section: 'worldBooks',
+          key: packBook.id,
+          name: packBook.name,
+          kind: 'replaced',
+        });
+      }
+    }
+  }
+
+  // ── 2. presets 逐 pack 逐条 id 存在性比对（D18：预设只判 id 在不在） ──
+  const allPresets = await db.presets.toArray();
+  const presetIds = new Set(allPresets.map((p) => p.id));
+
+  for (const pack of packs) {
+    const packPresets = pack.payload.presets;
+    if (!packPresets || packPresets.length === 0) continue;
+    for (const packPreset of packPresets) {
+      if (!presetIds.has(packPreset.id)) {
+        mismatches.push({
+          packId: pack.packId,
+          section: 'presets',
+          key: packPreset.id,
+          name: packPreset.name,
+          kind: 'missing',
+        });
+      }
+      // 预设无逐条 hash 基线（D18），'replaced' 不适用 —— 用户编辑预设是合法的，
+      // 不会被对账标记（pack 升级时的 diff 由 D40 sectionHashes 另走路径）。
+    }
+  }
+
+  // ── 3. activePresetId 悬空 → 从 payload 重导 story 预设（D18 明确分支） ──
+  // activePresetId 的真源在 settings-store (localStorage)，本函数读不到它；
+  // 这里只保证「DB 层 presets 表里有至少一条 pack 预设可供指向」。调用方据
+  // reimportedPresetId 自行同步 activePresetId（若它原本悬空）。
+  let reimportedPresetId: string | null = null;
+  if (allPresets.length === 0) {
+    // presets 表被旧备份清空 → 从第一个含 presets 的 pack 重导第一条预设。
+    // 🔴 只重导一条（story 预设通常一条；多 pack 各自预设的完整重放走 needs_attention
+    //    二选路径，不在这里自动全量重放——那等于「恢复时静默把所有 pack 预设塞回去」，
+    //    违反 D18「不自动做任何一边」）。
+    for (const pack of packs) {
+      const packPresets = pack.payload.presets;
+      if (packPresets && packPresets.length > 0) {
+        const seed = packPresets[0];
+        await db.presets.put({ ...seed });
+        reimportedPresetId = seed.id;
+        break;
+      }
+    }
+  }
+
+  return { mismatches, reimportedPresetId };
 }
 
 // ========== v1-v3 CRUD (unchanged) ==========

--- a/src/ui/components/settings/DataSection.vue
+++ b/src/ui/components/settings/DataSection.vue
@@ -150,6 +150,16 @@ async function clearAll() {
       导出；「音频」分区的音乐文件夹本就把文件留在磁盘上。
       <span class="data-note-em">「清除所有数据」会一并删除这两个库。</span>
     </p>
+    <!--
+    内容-引擎分离波 1 / D18：存档备份同样不含**内容包本体**（contentPacks.payload）——
+    payload 进备份 = 每份日常备份都是可自由转发的完整内容包 + 体积翻倍。恢复后引擎会自动
+    对账（reconcilePackState）：内容包拥有的世界书 / 预设若在恢复中缺失或被替换，会在内容
+    状态横幅提示需要处理，给你「本地重放 / 卸载回占位」二选，不会自动改你的东西。
+  -->
+    <p class="data-note">
+      存档导出<strong>不含内容包本体</strong> ——
+      恢复后若发现内容包拥有的世界书或预设与本地不一致，会在内容状态处提示，可一键从本地内容包重放。
+    </p>
     <div class="data-actions">
       <AppCard padding="md"
         ><h4>导出数据</h4>


### PR DESCRIPTION
## 内容-引擎分离 · 波 1 · T5

设计真源：\`docs/planning/2026-08-05-content-engine-separation-design.md\` D18/§5.7

## 交付（3 改文件）

- **\`database.ts\`**：
  - \`DB_VERSION\` 19→20 + \`this.version(20).stores({contentPacks:'packId'})\`（🔴 DB_VERSION === 最后一个 this.version(n)，漂移教训）
  - \`ContentPackRecord\`：{packId, packVersion, installedAt, payload, sectionHashes, notes}
  - 🔴 **FullBackup 不收 contentPacks**（exportAllData/importAllData 不动它）—— payload 进备份 = 每份日常备份都是可转发的完整内容包 + 体积翻倍
  - \`reconcilePackState()\` 挂 importAllData 收尾：对账 \`{worldBooks, presets}\` 逐 pack 拥有项（payload 现算 hash，用 hashWorldBook；不用 sectionHashes，D18 分工）/ 失配 → needs_attention + 用户二选（🔴 不自动）/ activePresetId 悬空 → payload 重导
- **\`DataSection.vue\`**：备份不含内容包本体；恢复后可能需重放
- **\`database.test.ts\`**：版本冻结 19→20 + contentPacks 表存在 + FullBackup 不碰 + reconcilePackState 7 断言

## 偏差（审查通过）

- \`activePresetId\` 悬空重导：实现为「presets 表空时从 pack 重导第一条」，不读 activePresetId 真值（真源在 settings-store localStorage，DB 层读不到）。DB 层重导 + UI 层同步各司其职，与 D18「明确分支」一致。
- 逐书粒度标记（「只标记该书」天然满足）；'replaced' 措辞留给调用方区分。

## 悬置（T7）

- reconcilePackState 的 UI 消费（contentStatus→needs_attention + DataSection 二选面板）
- contentPacks 表写入路径（安装执行器 content-store.installPack）

## 验证

- prettier --write + 编码全干净 ✅
- typecheck ×2 ✅ / lint ✅ / knip（145 无新增）✅
- 全量 test:run ✅（265 文件 / 6837 tests）

## 主会话审查

DB_VERSION === 20 === 最后一个 this.version(20) ✅（最易掉地上的漂移点已确认）。独立重跑六道门全绿。`.claude/agent-memory/` 是子 agent 自己的 memory，未卷入本 commit。

## 后续

合并后派 **T4（agents 分层，波 1 最高风险任务）** → T7（执行器，收所有线 + 补反向迁移 + reconcile UI 消费 + contentPacks 写入）。