### PR TITLE
feat(content): T7 内容包执行器 + 导入 UI + 恢复默认矩阵 + D42 接口

### DIFF
--- a/src/sillytavern/content-pack-plan.ts
+++ b/src/sillytavern/content-pack-plan.ts
@@ -527,6 +527,41 @@ function handleUnmatchedPartition(
 }
 
 // ═══════════════════════════════════════════════════════════
+// 逐项基线（D18 hash 分工：冲突判定/对账的逐书基线一律从 payload 现算）
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * 从一份已装的 `ContentPack.payload` 现算 `PackBaseline`（D18）。
+ *
+ * 🔴 **hash 分工**：升级 diff 展示用 `payload.sectionHashes`（构建器盖章）；冲突判定 /
+ *   卸载确认 / 对账用的**逐项基线**从这里现算（同一份 payload 现算，不信任 sectionHashes）。
+ *   安装时执行器把上一次装包的 baseline 喂给 `planPackInstall`；卸载时喂给
+ *   `planPackUninstall` 判「N 本已被你编辑过」。
+ *
+ * 输出覆盖三键（`byBook` / `byPreset` / `byBeautifierRule`），与 planner 四态规则的
+ * 消费键一一对应。hash 算法与四态判定侧共用（worldBooks → `hashWorldBook` 同步确定性；
+ * rows 用 `hashContentDeterministic` 接 `stableSerialize`）。
+ *
+ * @param payload 已装内容包的 payload
+ */
+export function buildPackBaseline(payload: ContentPack): PackBaseline {
+  const byBook: Record<string, string> = {};
+  for (const b of payload.worldBooks ?? []) byBook[b.id] = hashWorldBook(b);
+
+  const byPreset: Record<string, string> = {};
+  for (const p of payload.presets ?? [])
+    byPreset[p.id] = hashContentDeterministic(
+      JSON.stringify(stableSerialize({ id: p.id, name: p.name, settings: p.settings })),
+    );
+
+  const byBeautifierRule: Record<string, string> = {};
+  for (const r of payload.beautifierRules?.rules ?? [])
+    byBeautifierRule[r.id] = hashContentDeterministic(JSON.stringify(stableSerialize(r)));
+
+  return { byBook, byPreset, byBeautifierRule };
+}
+
+// ═══════════════════════════════════════════════════════════
 // 卸载计划（§5.2）
 // ═══════════════════════════════════════════════════════════
 

--- a/src/sillytavern/content-source.ts
+++ b/src/sillytavern/content-source.ts
@@ -35,7 +35,7 @@ import type {
 } from './types-content';
 import { planPackInstall as planPackInstallImpl } from './content-pack-plan';
 import type { CurrentLibrary } from './content-pack-plan';
-import type { WorldBook } from './types';
+import type { WorldBook, BeautifierRule } from './types';
 
 // ═══════════════════════════════════════════════════════════
 // 常量
@@ -101,6 +101,45 @@ export function reportContentFetch(report: ContentFetchReport): void {
     contentFetchReporter?.(report);
   } catch {
     /* 上报自身永不抛 */
+  }
+}
+
+// ═══════════════════════════════════════════════════════════
+// pack 美化规则注入缝（D20：pack 规则走 provider 内存层，不写用户表）
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * 读取已解析出的 pack 美化规则集（美化规则 provider 内存层的读取入口）。
+ *
+ * 🔴 D20：pack 规则走 **provider 内存层**（`presetRules` 语义，`isBuiltin: true`，
+ * 参与 `builtinDisabled` 门控），**不写用户表** —— 卸载天然免费。消费方
+ * （beautifier-store 的 `refreshPresetRules`，§5.6 恢复默认矩阵）经此取当前生效的
+ * pack 规则；装包时由 content-store 的 `setPackRulesProvider` 注册，卸载时注册回
+ * 无 pack 版本（返回 undefined → 消费方回落占位文件）。
+ *
+ * 与 `setContentFetchReporter` 同一个注入缝先例。
+ */
+export type PackRulesProvider = () => readonly BeautifierRule[] | undefined;
+
+/** 当前生效的 pack 美化规则读取器（content-store 装包/卸载时注册） */
+let packRulesProvider: PackRulesProvider | null = null;
+
+/**
+ * 注册 pack 美化规则读取器（唯一生产注册点 = content-store 的装包/卸载执行器）。
+ * 传 `null` = 无 pack（占位态），消费方回落占位文件。
+ */
+export function setPackRulesProvider(fn: PackRulesProvider | null): void {
+  packRulesProvider = fn;
+}
+
+/**
+ * 取当前生效的 pack 美化规则；无 pack / 未注册返回 `undefined`（消费方回落占位文件）。
+ */
+export function getPackRules(): readonly BeautifierRule[] | undefined {
+  try {
+    return packRulesProvider?.();
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/ui/components/settings/DataSection.vue
+++ b/src/ui/components/settings/DataSection.vue
@@ -11,18 +11,218 @@ import type { SceneImageUsage } from '@engine/types-image';
 import AppCard from '../shared/AppCard.vue';
 import AppButton from '../shared/AppButton.vue';
 import AppModal from '../shared/AppModal.vue';
+import PackInstallConfirmModal from './PackInstallConfirmModal.vue';
 import { useSettingsStore } from '../../stores/settings-store';
 import { useUIStore } from '../../stores/ui-store';
+import type { PackInstallPlan } from '@engine/types-content';
+import type { PackUpgradeDiff } from '@engine/content-pack-plan';
 
 const cfg = useSettingsStore();
 const ui = useUIStore();
+
+/** 内容态（内容包是否已装） */
+const activeContent = ref<{ packId: string | null; packVersion: string | null }>({
+  packId: null,
+  packVersion: null,
+});
+const hasActivePack = computed(() => activeContent.value.packId !== null);
+const activePackVersion = computed(() => activeContent.value.packVersion);
+
+/** 挂载时读一次内容态（content-store 的 store 状态） */
+onMounted(async () => {
+  loadStorageUsage();
+  const { useContentStore } = await import('../../stores/content-store');
+  const c = useContentStore();
+  await c.hydratePackState();
+  activeContent.value = { packId: c.activePackId, packVersion: c.activePackVersion };
+});
+
+// ═══════════ 内容包导入（波 1 T7 / D19 / §5.2）═══════════
+
+/**
+ * 内容包导入入口：文件 picker（.json）→ installPack → 有 conflicted 弹两阶段确认；
+ * 无冲突直接装。
+ *
+ * 🔴 两阶段提交（D19）：installPack 在无 `confirmConflicts` 时遇 conflicted 返回
+ * `needs_confirmation`（带完整 plan），这里把 plan 塞给
+ * `PackInstallConfirmModal`，用户确认后以 `{ confirmConflicts: true }` 重入。
+ */
+const packPlan = ref<PackInstallPlan | null>(null);
+const packPending = ref<unknown | null>(null); // 待确认的原始 pack JSON
+const packDiff = ref<PackUpgradeDiff | null>(null);
+const packError = ref<string | null>(null);
+const packInstalling = ref(false);
+
+async function pickPackFile() {
+  const i = document.createElement('input');
+  i.type = 'file';
+  i.accept = '.json';
+  i.onchange = async (e) => {
+    const f = (e.target as HTMLInputElement).files?.[0];
+    if (!f) return;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(await f.text());
+    } catch {
+      ui.toast('内容包格式无效：JSON 解析失败', 'error');
+      return;
+    }
+    await runInstall(raw);
+  };
+  i.click();
+}
+
+/** 执行安装（第一段：无冲突直接装；有冲突弹确认）。已装同 packId → 走升级路径（显示 diff） */
+async function runInstall(raw: unknown) {
+  packError.value = null;
+  packDiff.value = null;
+  packInstalling.value = true;
+  try {
+    const { useContentStore } = await import('../../stores/content-store');
+    const c = useContentStore();
+    const packId = (raw as { packId?: string } | null)?.packId ?? '';
+    // 已是同 packId → 升级路径（diff 展示）；否则首次安装
+    if (activeContent.value.packId === packId) {
+      await runUpgradeRaw(c, raw);
+      return;
+    }
+    const outcome = await c.installPack(raw);
+    if (!outcome.ok) {
+      if (outcome.status === 'needs_confirmation') {
+        packPlan.value = outcome.plan ?? null;
+        packPending.value = raw;
+        packDiff.value = outcome.upgradeDiff ?? null;
+      } else if (outcome.status === 'invalid') {
+        packError.value =
+          (outcome.validationErrors ?? []).map((e: any) => e.text ?? String(e)).join('\n') ||
+          '内容包校验未通过';
+        ui.toast('内容包校验未通过', 'error');
+      }
+      return;
+    }
+    await afterPackApplied(outcome.notes ?? []);
+    ui.toast('内容包已安装', 'success');
+  } catch {
+    ui.toast('内容包安装失败', 'error');
+  } finally {
+    packInstalling.value = false;
+  }
+}
+
+/** 升级路径：查 diff → 展示 → 有冲突/变化则弹确认；无冲突直接装 */
+async function runUpgradeRaw(
+  store: {
+    upgradePack: (
+      raw: unknown,
+      opts?: { confirmConflicts?: boolean },
+    ) => Promise<{
+      ok: boolean;
+      status: string;
+      plan?: unknown;
+      upgradeDiff?: unknown;
+      notes?: unknown[];
+    }>;
+  },
+  raw: unknown,
+): Promise<void> {
+  const outcome = await store.upgradePack(raw);
+  if (!outcome.ok && outcome.status === 'needs_confirmation') {
+    packPlan.value = (outcome.plan as PackInstallPlan | null) ?? null;
+    packPending.value = raw;
+    packDiff.value = (outcome.upgradeDiff as PackUpgradeDiff | null) ?? null;
+    return;
+  }
+  if (outcome.ok) {
+    await afterPackApplied(outcome.notes ?? []);
+    ui.toast('内容包已升级', 'success');
+  } else if (outcome.status === 'invalid') {
+    ui.toast('内容包校验未通过', 'error');
+  }
+}
+
+/** 用户在确认 Modal 点「确认」→ 以 confirmConflicts 重入 */
+async function confirmPackInstall() {
+  if (!packPending.value) return;
+  const raw = packPending.value;
+  const wasUpgrade = activeContent.value.packId === ((raw as { packId?: string })?.packId ?? '');
+  packPending.value = null;
+  packPlan.value = null;
+  packDiff.value = null;
+  packInstalling.value = true;
+  try {
+    const { useContentStore } = await import('../../stores/content-store');
+    const c = useContentStore();
+    const outcome = await (wasUpgrade
+      ? c.upgradePack(raw, { confirmConflicts: true })
+      : c.installPack(raw, { confirmConflicts: true }));
+    if (!outcome.ok) {
+      ui.toast('内容包安装失败', 'error');
+      return;
+    }
+    await afterPackApplied(outcome.notes ?? []);
+    ui.toast(wasUpgrade ? '内容包已升级' : '内容包已安装', 'success');
+  } catch {
+    ui.toast('内容包安装失败', 'error');
+  } finally {
+    packInstalling.value = false;
+  }
+}
+
+/** 装/卸/升后统一收尾：重载 Agent 默认 + 刷新内容态 */
+async function afterPackApplied(notes: unknown[]): Promise<void> {
+  showSuccessNotes(notes, null);
+  await cfg.loadAgentProjectDefaults();
+  const { useContentStore } = await import('../../stores/content-store');
+  const c = useContentStore();
+  await c.hydratePackState();
+  activeContent.value = { packId: c.activePackId, packVersion: c.activePackVersion };
+}
+
+/** 卸载（带确认；编辑过的书需二次确认） */
+async function requestUninstall() {
+  const { useContentStore } = await import('../../stores/content-store');
+  const c = useContentStore();
+  const outcome = await c.uninstallPack();
+  if (!outcome.ok && outcome.status === 'needs_confirmation') {
+    // 有编辑过的书，弹 confirm
+    if (
+      window.confirm(
+        `有 ${outcome.plan?.confirmations.length ?? 0} 本内容包世界书被编辑过，卸载会丢弃这些修改。确定卸载吗？`,
+      )
+    ) {
+      const done = await c.uninstallPack({ confirmEdits: true });
+      if (done.ok) {
+        ui.toast('内容包已卸载', 'success');
+        await cfg.loadAgentProjectDefaults();
+      } else ui.toast('卸载失败', 'error');
+    }
+    return;
+  }
+  if (outcome.ok) {
+    ui.toast('内容包已卸载', 'success');
+    await cfg.loadAgentProjectDefaults();
+  } else ui.toast('卸载失败', 'error');
+}
+
+/** 安装结果的三类处置记录 toast（dropped/degraded/sideEffect） */
+function showSuccessNotes(notes: unknown[], _outcome: unknown): void {
+  const dropped = notes.filter((n: any) => n?.kind === 'dropped');
+  const degraded = notes.filter((n: any) => n?.kind === 'degraded');
+  const side = notes.filter((n: any) => n?.kind === 'sideEffect');
+  if (dropped.length || degraded.length || side.length) {
+    const parts: string[] = [];
+    if (dropped.length) parts.push(`${dropped.length} 项丢弃`);
+    if (degraded.length) parts.push(`${degraded.length} 项降级`);
+    if (side.length) parts.push(`${side.length} 项附带影响`);
+    ui.toast(`内容包已处理，注意：${parts.join('、')}`, 'warning');
+  }
+}
 
 const showClearConfirm = ref(false);
 const storageInfo = ref<{ used: number; quota: number; pct: number } | null>(null);
 async function loadStorageUsage() {
   storageInfo.value = await cfg.getStorageUsage();
 }
-onMounted(loadStorageUsage);
 function fmtBytes(b: number) {
   if (b < 1024) return `${b} B`;
   if (b < 1048576) return `${(b / 1024).toFixed(1)} KB`;
@@ -229,7 +429,34 @@ async function clearAll() {
         <AppButton variant="danger" size="sm" class="card-action" @click="showClearConfirm = true"
           >清除所有数据</AppButton
         ></AppCard
-      >
+      ><AppCard padding="md" class="pack-card"
+        ><h4>内容包</h4>
+        <p class="text-muted text-sm">
+          导入《命定之诗》内容包以加载完整的世界书、Agent 提示词、预设与目录数据。<template
+            v-if="activePackVersion"
+            >当前：{{ activePackVersion }}。</template
+          >未装包时运行在演示级占位内容上。
+        </p>
+        <div class="pack-actions">
+          <AppButton
+            variant="secondary"
+            size="sm"
+            class="card-action"
+            :loading="packInstalling"
+            @click="pickPackFile"
+            >导入 / 升级内容包</AppButton
+          >
+          <AppButton
+            v-if="hasActivePack"
+            variant="ghost"
+            size="sm"
+            class="card-action"
+            :disabled="packInstalling"
+            @click="requestUninstall"
+            >卸载内容包</AppButton
+          >
+        </div>
+      </AppCard>
     </div>
     <AppModal
       :open="showClearConfirm"
@@ -282,6 +509,31 @@ async function clearAll() {
         ></template
       ></AppModal
     >
+    <!--
+      内容包安装/升级的两阶段确认（波 1 T7 / D19 / §5.2）：
+      plan 非空时展示，确认后 confirmPackInstall 以 confirmConflicts:true 重入 installPack。
+    -->
+    <PackInstallConfirmModal
+      :open="!!(packPlan || packError)"
+      :plan="packPlan"
+      :upgrade-diff="packDiff"
+      :error-message="packError"
+      @update:open="
+        (v: boolean) => {
+          if (!v) {
+            packPlan = null;
+            packError = null;
+            packPending = null;
+          }
+        }
+      "
+      @confirm="confirmPackInstall"
+      @cancel="
+        packPlan = null;
+        packError = null;
+        packPending = null;
+      "
+    />
   </section>
 </template>
 
@@ -320,6 +572,17 @@ async function clearAll() {
 }
 .data-danger:hover {
   border-color: color-mix(in srgb, var(--theme-error) 45%, transparent) !important;
+}
+/* 内容包卡片的按钮行（导入 + 卸载并排） */
+.pack-card {
+  border-color: color-mix(in srgb, var(--theme-quality-rare) 25%, transparent) !important;
+}
+.pack-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  flex-wrap: wrap;
 }
 .storage-bar-track {
   height: 8px;

--- a/src/ui/components/settings/PackInstallConfirmModal.vue
+++ b/src/ui/components/settings/PackInstallConfirmModal.vue
@@ -193,9 +193,7 @@ function noteTitle(kind: 'dropped' | 'degraded' | 'sideEffect'): string {
 
     <p v-if="hasConflicts" class="pk-warn">
       检测到
-      {{
-        plan?.sections ? countConflicted(plan) : 0
-      }}
+      {{ plan?.sections ? countConflicted(plan) : 0 }}
       项内容与本地现有数据不一致。覆盖这些项会<b>丢弃本地对这些内容的修改</b>。
     </p>
 

--- a/src/ui/components/settings/PackInstallConfirmModal.vue
+++ b/src/ui/components/settings/PackInstallConfirmModal.vue
@@ -1,0 +1,290 @@
+<!--
+  PackInstallConfirmModal.vue — 内容包安装/升级的两阶段确认（波 1 T7 / D19 / §5.2）
+
+  展示 planPackInstall 产出的安装计划，让用户在「覆盖前」看到逐节 added/updated/removed/
+  conflicted + 存档 uid 迁移说明 + 三类处置记录。确认后由 DataSection 以
+  `{ confirmConflicts: true }` 重入 installPack。
+
+  纯展示组件：不碰 store，不判该显示什么（那由宿主 DataSection 决定传什么 plan），
+  只把传进来的 PackInstallPlan 画出来。
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { PackInstallPlan } from '@engine/types-content';
+import type { PackUpgradeDiff } from '@engine/content-pack-plan';
+import type { WorldBook, ChatPreset } from '@engine/types';
+import AppModal from '../shared/AppModal.vue';
+import AppButton from '../shared/AppButton.vue';
+
+const props = defineProps<{
+  open: boolean;
+  plan?: PackInstallPlan | null;
+  /** 升级 diff（升级路径时展示「这一版会改什么」） */
+  upgradeDiff?: PackUpgradeDiff | null;
+  /** 安装失败（校验/执行 throw）时展示的消息 */
+  errorMessage?: string | null;
+}>();
+
+const emit = defineEmits<{
+  'update:open': [value: boolean];
+  confirm: [];
+  cancel: [];
+}>();
+
+/** 是否有需要确认的冲突（决定确认按钮语气） */
+const hasConflicts = computed(() => {
+  const p = props.plan;
+  if (!p) return false;
+  return Object.values(p.sections).some((s) => s && s.conflicted && s.conflicted.length > 0);
+});
+
+interface Row {
+  key: string;
+  name: string;
+  kind: 'added' | 'updated' | 'removed' | 'conflicted';
+}
+
+/** 把单个分节计划抽成四态行 */
+function sectionRows<T>(
+  sec: NonNullable<PackInstallPlan['sections']['worldBooks']>,
+  getKey: (row: T) => string,
+  getName: (row: T) => string,
+): Row[] {
+  return [
+    ...sec.added.map((r) => ({
+      key: getKey(r as T),
+      name: getName(r as T),
+      kind: 'added' as const,
+    })),
+    ...sec.updated.map((r) => ({
+      key: getKey(r as T),
+      name: getName(r as T),
+      kind: 'updated' as const,
+    })),
+    ...sec.removed.map((r) => ({
+      key: getKey(r as T),
+      name: getName(r as T),
+      kind: 'removed' as const,
+    })),
+    ...sec.conflicted.map((c) => ({ key: c.key, name: c.name, kind: 'conflicted' as const })),
+  ];
+}
+
+const KIND_LABEL: Record<Row['kind'], string> = {
+  added: '新增',
+  updated: '更新',
+  removed: '移除',
+  conflicted: '需确认覆盖',
+};
+
+const KIND_CLASS: Record<Row['kind'], string> = {
+  added: 'pk-added',
+  updated: 'pk-updated',
+  removed: 'pk-removed',
+  conflicted: 'pk-conflicted',
+};
+
+/** 汇总 diff 用到世界书/预设的 key/name 抽取 */
+const wbSection = computed(() => props.plan?.sections.worldBooks);
+const preSection = computed(() => props.plan?.sections.presets);
+
+const wbRows = computed<Row[]>(() =>
+  wbSection.value
+    ? sectionRows<WorldBook>(
+        wbSection.value,
+        (b) => b.id,
+        (b) => b.name,
+      )
+    : [],
+);
+const presetRows = computed<Row[]>(() =>
+  preSection.value
+    ? sectionRows<ChatPreset>(
+        preSection.value as unknown as NonNullable<PackInstallPlan['sections']['worldBooks']>,
+        (p) => p.id,
+        (p) => p.name,
+      )
+    : [],
+);
+
+/** 存档 uid 迁移说明字符串（D43） */
+const saveMigText = computed(() => {
+  const mig = props.plan?.saveUidMigration;
+  if (!mig) return '';
+  const n = Object.keys(mig.rewrite ?? {}).length;
+  const needsSel = mig.needsSelectionPartitions?.length ?? 0;
+  const parts: string[] = [];
+  if (n > 0) parts.push(`将把 ${n} 条已建档案的世界书条目按名配对到新内容`);
+  if (needsSel > 0)
+    parts.push(`有 ${needsSel} 个分区需要你在对应存档里重新选择（键已保留，不会自动删）`);
+  return parts.join('；');
+});
+
+/** 三类处置记录分组标题 */
+function noteTitle(kind: 'dropped' | 'degraded' | 'sideEffect'): string {
+  return { dropped: '已丢弃的项', degraded: '受限制退化的项', sideEffect: '附带影响' }[kind] ?? '';
+}
+</script>
+
+<template>
+  <AppModal
+    :open="open"
+    title="内容包安装预览"
+    size="lg"
+    @update:open="emit('update:open', $event)"
+    @close="emit('cancel')"
+  >
+    <!-- 升级 diff -->
+    <template v-if="upgradeDiff && (upgradeDiff.worldBooks.length || upgradeDiff.presets.length)">
+      <h4 class="pk-sec-title">这一版会改什么（升级 diff）</h4>
+      <ul class="pk-diff-list">
+        <li
+          v-for="item in [...upgradeDiff.worldBooks, ...upgradeDiff.presets]"
+          :key="item.kind + item.key"
+        >
+          <span class="pk-badge" :class="KIND_CLASS[item.kind]">{{ KIND_LABEL[item.kind] }}</span>
+          <span class="pk-name">{{ item.name }}</span>
+        </li>
+      </ul>
+    </template>
+
+    <!-- 校验失败 -->
+    <div v-if="errorMessage" class="pk-error">
+      {{ errorMessage }}
+    </div>
+
+    <!-- 世界书变化 -->
+    <div v-if="wbRows.length">
+      <h4 class="pk-sec-title">世界书（{{ wbRows.length }} 项变化）</h4>
+      <ul class="pk-change-list">
+        <li v-for="row in wbRows" :key="row.kind + row.key">
+          <span class="pk-badge" :class="KIND_CLASS[row.kind]">{{ KIND_LABEL[row.kind] }}</span>
+          <span class="pk-name">{{ row.name }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <!-- 预设变化 -->
+    <div v-if="presetRows.length">
+      <h4 class="pk-sec-title">预设（{{ presetRows.length }} 项变化）</h4>
+      <ul class="pk-change-list">
+        <li v-for="row in presetRows" :key="row.kind + row.key">
+          <span class="pk-badge" :class="KIND_CLASS[row.kind]">{{ KIND_LABEL[row.kind] }}</span>
+          <span class="pk-name">{{ row.name }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <!-- 存档迁移 -->
+    <p v-if="saveMigText" class="pk-note"><strong>存档迁移：</strong>{{ saveMigText }}</p>
+
+    <!-- 处置记录 -->
+    <template v-if="plan && plan.notes.length">
+      <h4 class="pk-sec-title">处置记录</h4>
+      <div v-for="kind in ['dropped', 'degraded', 'sideEffect'] as const" :key="kind">
+        <p v-if="plan.notes.some((n: any) => n.kind === kind)" class="pk-note">
+          <strong>{{ noteTitle(kind) }}：</strong>
+          <span v-for="(n, i) in plan.notes.filter((x: any) => x.kind === kind)" :key="i">
+            {{ n.text }}；</span
+          >
+        </p>
+      </div>
+    </template>
+
+    <p v-if="hasConflicts" class="pk-warn">
+      检测到
+      {{
+        plan?.sections ? countConflicted(plan) : 0
+      }}
+      项内容与本地现有数据不一致。覆盖这些项会<b>丢弃本地对这些内容的修改</b>。
+    </p>
+
+    <template #footer>
+      <AppButton variant="ghost" size="sm" @click="emit('cancel')">取消</AppButton>
+      <AppButton variant="primary" size="sm" @click="emit('confirm')"
+        >确认{{ hasConflicts ? '覆盖' : '安装' }}</AppButton
+      >
+    </template>
+  </AppModal>
+</template>
+
+<script lang="ts">
+/** 数一下所有分节的 conflicted 总数（模板里不好写循环） */
+function countConflicted(plan: PackInstallPlan): number {
+  let n = 0;
+  for (const s of Object.values(plan.sections)) {
+    if (s && s.conflicted) n += s.conflicted.length;
+  }
+  return n;
+}
+</script>
+
+<style scoped>
+.pk-sec-title {
+  margin: 14px 0 6px;
+  font-size: 0.9rem;
+  color: var(--theme-text-secondary);
+}
+.pk-change-list,
+.pk-diff-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.pk-change-list li,
+.pk-diff-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+  font-size: 0.85rem;
+}
+.pk-badge {
+  flex-shrink: 0;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+}
+.pk-added {
+  background: rgba(80, 180, 80, 0.15);
+  color: var(--theme-quality-epic, #58c);
+}
+.pk-updated {
+  background: rgba(80, 140, 200, 0.15);
+  color: var(--theme-quality-rare, #48c);
+}
+.pk-removed {
+  background: rgba(180, 60, 60, 0.15);
+  color: var(--theme-error, #c44);
+}
+.pk-conflicted {
+  background: rgba(230, 170, 40, 0.18);
+  color: #caa030;
+}
+.pk-name {
+  flex: 1;
+}
+.pk-note {
+  margin: 8px 0;
+  font-size: 0.82rem;
+  color: var(--theme-text-muted);
+}
+.pk-warn {
+  margin: 12px 0 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(230, 170, 40, 0.1);
+  border: 1px solid rgba(230, 170, 40, 0.3);
+  font-size: 0.82rem;
+  color: var(--theme-text, inherit);
+}
+.pk-error {
+  margin: 10px 0;
+  padding: 10px;
+  border-radius: 6px;
+  background: rgba(220, 60, 60, 0.1);
+  border: 1px solid rgba(220, 60, 60, 0.3);
+  color: var(--theme-error, #c44);
+  font-size: 0.85rem;
+}
+</style>

--- a/src/ui/components/settings/WorldBookSection.vue
+++ b/src/ui/components/settings/WorldBookSection.vue
@@ -14,7 +14,6 @@ import WorldBookEditor from './WorldBookEditor.vue';
 import { useSettingsStore } from '../../stores/settings-store';
 import { useUIStore } from '../../stores/ui-store';
 import { useWorldBookStore } from '../../stores/worldbook-store';
-import { loadBuiltInWorldBooks } from '@engine/builtin-worldbooks';
 import type { WorldBook } from '@engine/types';
 
 const cfg = useSettingsStore();
@@ -48,20 +47,21 @@ async function saveWorldBookAsDefault(book: WorldBook) {
   }
 }
 
-/** 重置单本内置世界书 → 删除用户副本，重新从本地 JSON 加载 */
+/** 重置单本内置世界书 → 删除用户副本，从默认真源重新加载（§5.6：pack payload > 占位文件） */
 async function resetSingleWorldBook(id: string) {
   const book = wb.getBook(id);
   if (!book?.builtIn) return;
   if (!confirm(`确定将"${book.name}"恢复为默认吗？\n\n您对该书的所有修改将被清除。`)) return;
   try {
-    // 先取到干净版本再落库：加载不到就什么都不动，绝不先删了再发现拿不回来
-    const builtIn = await loadBuiltInWorldBooks();
-    const fresh = builtIn.find((b) => b.id === id);
+    // 内容-引擎分离波 1 / §5.6：默认真源 = 已装 content pack 的 payload > 占位文件。
+    // 导入真实包后 restore 不再把提示词打回占位。
+    const { loadDefaultBook } = await import('../../stores/content-store');
+    const fresh = await loadDefaultBook(id);
     if (!fresh) {
       ui.toast('恢复失败：未找到内置版本', 'error');
       return;
     }
-    await wb.upsertBook(fresh);
+    await wb.upsertBook({ ...fresh, builtIn: true });
     if (activeWorldBook.value?.id === id) activeWorldBook.value = wb.getBook(id) ?? null;
     ui.toast(`"${book.name}"已恢复为默认`, 'success');
   } catch {

--- a/src/ui/components/shared/ContentStatusBanner.vue
+++ b/src/ui/components/shared/ContentStatusBanner.vue
@@ -16,8 +16,11 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { useContentStore } from '../../stores/content-store';
+import { useUIStore } from '../../stores/ui-store';
+import AppButton from './AppButton.vue';
 
 const content = useContentStore();
+const ui = useUIStore();
 
 /** 占位世界书条目规模阈值（§5.8）：超过则判定为「本地有真实内容」 */
 const PLACEHOLDER_ENTRY_THRESHOLD = 150;
@@ -50,7 +53,6 @@ const detectedLegacyContent = computed(() => localEntryScale.value > PLACEHOLDER
 const visible = computed(() => {
   const st = content.contentStatus;
   if (st === 'pack' || st === 'needs_attention') {
-    // T7 装包落地前 activePackId 恒为 null → 不渲染（避免空横幅）
     return content.activePackId !== null;
   }
   return true; // placeholder / error 始终显示
@@ -78,6 +80,80 @@ const level = computed<'info' | 'warn' | 'error'>(() => {
   if (detectedLegacyContent.value) return 'warn';
   return 'info';
 });
+
+// ── 波 1 T7：横幅动作（placeholder → 导入；pack → 卸载） ──
+const busy = ref(false);
+
+/** placeholder 态：导入内容包（文件 picker → installPack；冲突弹系统确认窗口） */
+function importPack() {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json';
+  input.onchange = async (e) => {
+    const f = (e.target as HTMLInputElement).files?.[0];
+    if (!f) return;
+    let raw: unknown;
+    try {
+      raw = JSON.parse(await f.text());
+    } catch {
+      ui.toast('内容包格式无效', 'error');
+      return;
+    }
+    busy.value = true;
+    try {
+      const outcome = await content.installPack(raw);
+      if (!outcome.ok) {
+        if (outcome.status === 'needs_confirmation') {
+          // 横幅不内嵌复杂 Modal，引导去设置页数据分区完成两阶段确认
+          if (
+            window.confirm(
+              '检测到与本地既有内容冲突的项，覆盖将丢弃这些修改。前往「设置 → 存档数据 → 导入内容包」完成确认。',
+            )
+          ) {
+            ui.navigate('settings');
+          }
+        } else if (outcome.status === 'invalid') {
+          ui.toast('内容包校验未通过', 'error');
+        }
+        return;
+      }
+      ui.toast('内容包已安装', 'success');
+    } catch {
+      ui.toast('内容包安装失败', 'error');
+    } finally {
+      busy.value = false;
+    }
+  };
+  input.click();
+}
+
+/** pack 态：卸载内容包（确认后执行） */
+async function uninstallPack() {
+  if (!window.confirm('确定卸载内容包吗？将恢复到演示级占位内容。')) return;
+  busy.value = true;
+  try {
+    const outcome = await content.uninstallPack();
+    if (!outcome.ok && outcome.status === 'needs_confirmation') {
+      if (
+        !window.confirm(
+          `有 ${(outcome.plan?.confirmations?.length ?? 0) as number} 本内容包世界书被编辑过，卸载会丢弃这些修改。确定卸载吗？`,
+        )
+      ) {
+        return;
+      }
+      const done = await content.uninstallPack({ confirmEdits: true });
+      if (done.ok) ui.toast('内容包已卸载', 'success');
+      else ui.toast('卸载失败', 'error');
+      return;
+    }
+    if (outcome.ok) ui.toast('内容包已卸载', 'success');
+    else ui.toast('卸载失败', 'error');
+  } catch {
+    ui.toast('卸载失败', 'error');
+  } finally {
+    busy.value = false;
+  }
+}
 </script>
 
 <template>
@@ -94,6 +170,24 @@ const level = computed<'info' | 'warn' | 'error'>(() => {
       aria-hidden="true"
     />
     <span class="content-banner-text">{{ message }}</span>
+    <span class="content-banner-actions">
+      <AppButton
+        v-if="content.contentStatus === 'placeholder'"
+        variant="secondary"
+        size="sm"
+        :loading="busy"
+        @click="importPack"
+        >导入内容包</AppButton
+      >
+      <AppButton
+        v-else-if="content.contentStatus === 'pack'"
+        variant="ghost"
+        size="sm"
+        :disabled="busy"
+        @click="uninstallPack"
+        >卸载内容包</AppButton
+      >
+    </span>
   </div>
 </template>
 
@@ -113,6 +207,14 @@ const level = computed<'info' | 'warn' | 'error'>(() => {
 }
 .content-banner-text {
   flex: 1;
+}
+.content-banner-actions {
+  flex-shrink: 0;
+}
+@media (max-width: 520px) {
+  .content-banner-actions {
+    margin-top: 6px;
+  }
 }
 .content-banner-info {
   background: var(--theme-bg-elevated, rgba(100, 149, 237, 0.08));

--- a/src/ui/stores/beautifier-store.ts
+++ b/src/ui/stores/beautifier-store.ts
@@ -19,6 +19,7 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { getDatabase } from '@engine/database';
 import { loadPresetRules, mergeRules } from '@engine/beautifier';
+import { getPackRules } from '@engine/content-source';
 import type { BeautifierRule } from '@engine/types';
 import {
   migrateBeautifierRulesToDexie,
@@ -88,6 +89,14 @@ export const useBeautifierStore = defineStore('beautifier', () => {
   /**
    * 重算预设规则（含 autoEnable 解析）。
    *
+   * 内容-引擎分离波 1 / D20 + §5.6：预设规则真源 = **已装 pack 的美化规则 > 占位文件**
+   * （provider 内存层）。装包 / 卸载 / 恢复默认时经 content-source 的
+   * `setPackRulesProvider` 把当前生效的 pack 规则注册进去，由 `getPackRules()` 读取；
+   * 无 pack（占位态）时回落 `loadPresetRules()`（占位文件）。
+   *
+   * 🔴 pack 规则只进内存 `presetRules` ref（`isBuiltin`），**永不写用户表**
+   * （beautifierRules）—— 卸载天然免费（D20）。
+   *
    * 启动时无存档上下文 → 传空信号；locked 由游戏页/设置页按存档
    * `enabledWorldBookEntries` 各自重算（`useBeautify` / `BeautifierSection`）。
    *
@@ -97,9 +106,18 @@ export const useBeautifierStore = defineStore('beautifier', () => {
     activeWorldBookIds: Set<string> = new Set(),
     activeEntryUids: Set<number> = new Set(),
     activeCharacterNames: Set<string> = new Set(),
+    // 🔴 供测试/装包流程显式注入 pack 规则；生产路径不传，由 provider 惰性读（§5.6 恢复默认）
+    packRulesOverride?: readonly BeautifierRule[],
   ): Promise<void> {
     try {
-      const preset = await loadPresetRules();
+      // provider 内存层优先（D20）：pack 规则 > 占位文件。packRulesOverride 显式传入时
+      // 优先用它（装包瞬间 provider 注册与重算谁先谁都互斥，显式传最稳）。
+      const packRules = packRulesOverride ?? getPackRules();
+      // 兼容下游 mergeRules / pruneLegacyBuiltinOverrides 的 mutable 参数，展开为可变数组
+      const preset: BeautifierRule[] =
+        packRules !== undefined && packRules.length >= 0
+          ? [...packRules]
+          : ((await loadPresetRules()) as BeautifierRule[]);
       // 覆盖列表语义迁移：认得出出厂默认值才能做，所以挂在预设加载之后。
       // 内部有标志位，重复调用是空转。
       const settingsStore = useSettingsStore();

--- a/src/ui/stores/content-store-executor.test.ts
+++ b/src/ui/stores/content-store-executor.test.ts
@@ -1,0 +1,500 @@
+/**
+ * content-store.ts 装包执行器端到端测试（波 1 T7 / D19 / §5.2 / D43 / D42）
+ *
+ * 🔴 六类验收（订单 §7.1「新增公开仓」）：
+ *   1. 装（含冲突确认路径）—— 空库 + pack → 全部 added；编辑过 → conflicted → 确认后覆盖
+ *   2. 升 —— upgradePack 产 added/updated/removed diff
+ *   3. 卸（快照回滚路径）—— 卸载后 pack 书被占位书替换；编辑过的书需确认
+ *   4. 占位建档 → 装包 → 存档存活（D43 回归，验收 #14c）—— 占位 uid(900001+) → 装包 → enabledWorldBookEntries 按名配对重写
+ *   5. 装包后 boot 时序断言 —— loadProjectDefaults 返回 pack agentDefaults（D44 默认层）
+ *   6. D42 重播种 —— 动过的书不被覆盖
+ *
+ * fake-indexeddb 由 test-setup.ts 注入；store 需 active pinia。
+ * 模块级 activePack 缓存跨用例残留 → afterEach 用 setActivePackRecord(null) 复位。
+ */
+import 'fake-indexeddb/auto';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useContentStore, setActivePackRecord, resetPlaceholderHashesCache } from './content-store';
+import { getDatabase } from '@engine/database';
+import { hashWorldBook } from '@engine/content-source';
+import type { WorldBook, WorldBookEntry } from '@engine/types';
+import type { ContentPack } from '@engine/types-content';
+
+// ── 夹具 ──
+
+/** 造一条世界书条目 */
+function entry(uid: number, name: string, content = `content-${name}`): WorldBookEntry {
+  return {
+    uid,
+    name,
+    content,
+    enabled: true,
+    key: [],
+    keysecondary: [],
+    selectiveLogic: 0,
+    order: 100,
+    position: 0,
+  };
+}
+
+/** 造一本书（default state：占位 = 保留段 uid，分隔由调用方控制） */
+function book(
+  id: string,
+  partition: WorldBookPartition,
+  entries: WorldBookEntry[],
+  opts: { name?: string; builtIn?: boolean } = {},
+): WorldBook {
+  return {
+    id,
+    name: opts.name ?? id,
+    partition,
+    entries,
+    builtIn: opts.builtIn ?? true,
+  };
+}
+
+/** 占位书的保留段条目（D43：uid ∈ [900001, …)） */
+const PLACEHOLDER_SYSTEM_CORE: WorldBook = book('system_core', 'system_core', [
+  entry(900001, '核心A', '占位A'),
+  entry(900002, '核心B', '占位B'),
+]);
+
+/** 占位 world_setting 书（多选分区，装包/卸载都会涉及） */
+const PLACEHOLDER_WORLD: WorldBook = book('world_setting', 'world_setting', [
+  entry(900003, '背景常识', '占位背景'),
+]);
+
+/** 装包用的真实内容包（与占位书共用 id，真实 uid 空间 < 900001） */
+function makePack(version = '1.0.0'): ContentPack {
+  return {
+    formatVersion: 1,
+    packId: 'fated-poem-official',
+    packVersion: version,
+    name: '测试内容包',
+    worldBooks: [
+      book('system_core', 'system_core', [entry(1, '核心A', '真实A'), entry(2, '核心B', '真实B')]),
+      book('world_setting', 'world_setting', [entry(3, '背景常识', '真实背景')]),
+    ],
+    agentDefaults: {
+      version: 1,
+      agents: {
+        story: {
+          model: 'story-model',
+          worldBookEnabled: true,
+          worldBookIds: ['system_core'],
+          systemPrompt: 'pack-story-prompt',
+          template: '',
+          temperature: 0.7,
+          topP: 1.0,
+          freqPen: 0,
+          presPen: 0,
+          maxTokens: 4096,
+        },
+        narrator: {
+          model: 'narrator-model',
+          worldBookEnabled: true,
+          worldBookIds: ['world_setting'],
+          systemPrompt: 'pack-narrator-prompt',
+          template: '',
+          temperature: 0.7,
+          topP: 1.0,
+          freqPen: 0,
+          presPen: 0,
+          maxTokens: 4096,
+        },
+      },
+    },
+    presets: [
+      { id: 'pack-story-preset', name: 'Pack Story', settings: {}, createdAt: 1, updatedAt: 2 },
+    ],
+    beautifierRules: {
+      version: 1,
+      rules: [
+        {
+          id: 'pack-rule-1',
+          name: 'Rules',
+          scope: 'maintext',
+          pattern: 'x',
+          flags: '',
+          replacement: 'y',
+          enabled: true,
+          order: 100,
+          isBuiltin: true,
+        },
+      ],
+    },
+  };
+}
+
+type WorldBookPartition = WorldBook['partition'];
+
+/** 基于当前占位书集构造占位基线清单（byBook hash 现算），返回可复用的 fetch mock。 */
+function installContentFetchMock(opts: { version?: string; extraBooks?: WorldBook[] } = {}): {
+  manifest: { version: string; byBook: Record<string, string> };
+  restore: () => void;
+} {
+  const placeholderBooks = [PLACEHOLDER_SYSTEM_CORE, PLACEHOLDER_WORLD, ...(opts.extraBooks ?? [])];
+  const byBook: Record<string, string> = {};
+  for (const b of placeholderBooks) byBook[b.id] = hashWorldBook(b);
+  const manifest = { version: opts.version ?? '1', byBook };
+  const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.includes('placeholder-hashes.json')) {
+      return new Response(JSON.stringify(manifest), { status: 200 });
+    }
+    // 占位世界书 /data/worldbooks/<id>.json
+    const m = /\/data\/worldbooks\/(.+)\.json$/.exec(url);
+    if (m) {
+      const book = placeholderBooks.find((b) => b.id === m[1]);
+      if (book) return new Response(JSON.stringify(book), { status: 200 });
+      return new Response('', { status: 404 });
+    }
+    return new Response('', { status: 404 });
+  });
+  return { manifest, restore: () => spy.mockRestore() };
+}
+
+/** 预置占位库（占位期的初始状态：同 id 同分区同 builtIn，uid 保留段） */
+async function seedPlaceholderLibrary(): Promise<void> {
+  const db = getDatabase();
+  await db.worldBooks.bulkPut([PLACEHOLDER_SYSTEM_CORE, PLACEHOLDER_WORLD]);
+  // 占位默认层（含 story 的占位预设 id）
+  await db.contentPacks.clear();
+  await db.presets.clear();
+}
+
+/** 清理所有用到的表 + 模块缓存 */
+async function cleanDb(): Promise<void> {
+  const db = getDatabase();
+  await db.contentPacks.clear();
+  await db.worldBooks.clear();
+  await db.presets.clear();
+  await db.saves.clear();
+  await db.beautifierRules.clear();
+  setActivePackRecord(null);
+}
+
+describe('content-store 执行器 —— 1. 安装（含冲突确认路径）', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    await cleanDb();
+    installContentFetchMock();
+  });
+  afterEach(() => {
+    setActivePackRecord(null);
+    resetPlaceholderHashesCache();
+    vi.restoreAllMocks();
+  });
+
+  it('空库（无占位书）装 pack → 全部 added，装后内容态 pack + activePackId/Version 设定', async () => {
+    const c = useContentStore();
+    const outcome = await c.installPack(makePack());
+    expect(outcome.ok).toBe(true);
+    expect(outcome.status).toBe('installed');
+    expect(outcome.plan?.sections.worldBooks?.added).toHaveLength(2);
+    expect(outcome.plan?.sections.worldBooks?.updated).toHaveLength(0);
+    // 内容态
+    expect(c.contentStatus).toBe('pack');
+    expect(c.activePackId).toBe('fated-poem-official');
+    expect(c.activePackVersion).toBe('1.0.0');
+    // 库里有 pack 书
+    const books = await getDatabase().worldBooks.toArray();
+    expect(books.map((b) => b.id).sort()).toEqual(['system_core', 'world_setting']);
+    // pack 书 builtIn 必须 true（loadBuiltInWorldBooks 真值门）
+    expect(books.every((b) => b.builtIn === true)).toBe(true);
+    // 存档重写 + agent 写 contentPacks（不写 settings.agents 是另一测）
+    const rec = await getDatabase().contentPacks.get('fated-poem-official');
+    expect(rec?.payload.packVersion).toBe('1.0.0');
+    // 预设已落库
+    const presets = await getDatabase().presets.toArray();
+    expect(presets.map((p) => p.id)).toContain('pack-story-preset');
+  });
+
+  it('已存在未编辑过的占位书 → 静默覆盖（updated），无冲突', async () => {
+    await seedPlaceholderLibrary();
+    const c = useContentStore();
+    const outcome = await c.installPack(makePack());
+    expect(outcome.ok).toBe(true);
+    expect(outcome.plan?.sections.worldBooks?.updated).toHaveLength(2);
+    expect(outcome.plan?.sections.worldBooks?.conflicted).toHaveLength(0);
+    // 库里现在是 pack 内容
+    const sc = await getDatabase().worldBooks.get('system_core');
+    expect(sc?.entries.map((e) => e.uid)).toEqual([1, 2]);
+  });
+
+  it('编辑过的 book（hash ≠ 占位基线）→ 首次装包变 conflicted → 未确认时 needs_confirmation → 确认后覆盖', async () => {
+    await seedPlaceholderLibrary();
+    // 人为编辑占位书（改正文，hash 变化）
+    const db = getDatabase();
+    const edited = { ...PLACEHOLDER_SYSTEM_CORE, entries: [entry(900001, '核心A', '改了')] };
+    await db.worldBooks.put(edited);
+
+    const c = useContentStore();
+    // 未确认 → needs_confirmation + conflicted
+    const first = await c.installPack(makePack());
+    expect(first.ok).toBe(false);
+    expect(first.status).toBe('needs_confirmation');
+    expect(first.plan?.sections.worldBooks?.conflicted.length).toBeGreaterThan(0);
+
+    // 确认 → 覆盖
+    const second = await c.installPack(makePack(), { confirmConflicts: true });
+    expect(second.ok).toBe(true);
+    const sc = await db.worldBooks.get('system_core');
+    expect(sc?.entries.map((e) => e.uid)).toEqual([1, 2]);
+  });
+});
+
+describe('content-store 执行器 —— 2. 升级 diff', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    await cleanDb();
+    installContentFetchMock();
+  });
+  afterEach(() => {
+    setActivePackRecord(null);
+    resetPlaceholderHashesCache();
+    vi.restoreAllMocks();
+  });
+
+  it('upgradePack 对已装包产 diff（added/updated/removed）；确认后落新版本', async () => {
+    const c = useContentStore();
+    // 装 v1
+    await c.installPack(makePack('1.0.0'));
+    // v2 加了 worldsSetting 新书 + 改 system_core 条目 + 删默认的某本
+    const v2: ContentPack = {
+      ...makePack('2.0.0'),
+      worldBooks: [
+        book('system_core', 'system_core', [
+          entry(1, '核心A', 'v2'),
+          entry(99, '新增条目', 'v2新增'),
+        ]),
+        book('new_faction', 'faction', [entry(5, '新势力', 'v2')]),
+      ],
+    };
+    const pending = await c.upgradePack(v2);
+    // 未确认时可能因为 new_faction 是 added 无冲突 → 直接 installed。但 system_core 的
+    // world_setting 被移除 → old 有 new 无 → removed。diff 至少含这些变化。
+    expect(pending.upgradeDiff).toBeDefined();
+    const wbItems = pending.upgradeDiff?.worldBooks ?? [];
+    const kinds = wbItems.map((i) => i.kind);
+    expect(kinds).toContain('added'); // new_faction
+    // 确认后落盘为 v2
+    if (!pending.ok) {
+      const done = await c.installPack(v2, { confirmConflicts: true });
+      expect(done.ok).toBe(true);
+    }
+    const rec = await getDatabase().contentPacks.get('fated-poem-official');
+    expect(rec?.packVersion).toBe('2.0.0');
+  });
+});
+
+describe('content-store 执行器 —— 3. 卸载（快照回滚）', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    await cleanDb();
+    await seedPlaceholderLibrary();
+    installContentFetchMock();
+  });
+  afterEach(() => {
+    setActivePackRecord(null);
+    resetPlaceholderHashesCache();
+    vi.restoreAllMocks();
+  });
+
+  it('卸载后 pack 书被占位书替换；内容态回 placeholder', async () => {
+    const c = useContentStore();
+    await c.installPack(makePack());
+    expect(c.contentStatus).toBe('pack');
+
+    const outcome = await c.uninstallPack();
+    expect(outcome.ok).toBe(true);
+    expect(outcome.status).toBe('uninstalled');
+    expect(c.contentStatus).toBe('placeholder');
+    expect(c.activePackId).toBeNull();
+    // 占位书（保留段 uid）回来了
+    const sc = await getDatabase().worldBooks.get('system_core');
+    expect(sc?.entries.map((e) => e.uid)).toEqual([900001, 900002]);
+    // contentPacks 已删
+    expect(await getDatabase().contentPacks.count()).toBe(0);
+  });
+
+  it('卸载时 pack 书被编辑过 → 需确认（needs_confirmation）', async () => {
+    const c = useContentStore();
+    await c.installPack(makePack());
+    // 编辑 pack 书（hash ≠ 装包基线）
+    const db = getDatabase();
+    await db.worldBooks.put(book('system_core', 'system_core', [entry(1, '核心A', '用户改了')]));
+
+    const first = await c.uninstallPack();
+    expect(first.ok).toBe(false);
+    expect(first.status).toBe('needs_confirmation');
+    expect(first.plan?.confirmations.length).toBeGreaterThan(0);
+
+    const second = await c.uninstallPack({ confirmEdits: true });
+    expect(second.ok).toBe(true);
+  });
+});
+
+describe('content-store 执行器 —— 4. 占位建档 → 装包 → 存档存活（D43）', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    await cleanDb();
+    await seedPlaceholderLibrary();
+    installContentFetchMock();
+  });
+  afterEach(() => {
+    setActivePackRecord(null);
+    resetPlaceholderHashesCache();
+    vi.restoreAllMocks();
+  });
+
+  it('存档 enabledWorldBookEntries 的占位 uid(900001+) 按名配对重写为真实 uid', async () => {
+    // 占位期建档：单选钉选分区（system_core）写了占位 uid
+    const db = getDatabase();
+    await db.saves.put({
+      id: 'save1',
+      name: '占位期存档',
+      slot: 0,
+      createdAt: 1,
+      updatedAt: 2,
+      activeSnapshotId: null,
+      metadata: {
+        characterName: '主角',
+        userName: '玩家',
+        gameStartTime: '1',
+        totalTurns: 0,
+        enabledWorldBookEntries: ['system_core:900001'], // 占位「核心A」
+      },
+    });
+
+    const c = useContentStore();
+    await c.installPack(makePack());
+
+    // 装包后：占位键按名配对 → 真实 uid（核心A → 1）
+    const save = await db.saves.get('save1');
+    const smeta = save?.metadata as Record<string, unknown> | undefined;
+    expect(save?.metadata?.enabledWorldBookEntries).toContain('system_core:1');
+    expect(save?.metadata?.enabledWorldBookEntries).not.toContain('system_core:900001');
+    // 单选分区无配不上的键 → 不标 needs_selection
+    expect(smeta?.needsPackWorldBookSelection).toBeUndefined();
+  });
+
+  it('占位 uid 配不上 pack 条目 → 单选钉选分区标 needs_selection（不裸删，防内容通胀）', async () => {
+    const db = getDatabase();
+    await db.saves.put({
+      id: 'save1',
+      name: '占位期存档',
+      slot: 0,
+      createdAt: 1,
+      updatedAt: 2,
+      activeSnapshotId: null,
+      metadata: {
+        characterName: '主角',
+        userName: '玩家',
+        gameStartTime: '1',
+        totalTurns: 0,
+        enabledWorldBookEntries: ['system_core:999999'], // 占位里不存在的条目名 → 配不上
+      },
+    });
+    // 占位书里没有 uid 999999 → 名字查不到 → 无法配对 → needs_selection
+    const c = useContentStore();
+    await c.installPack(makePack());
+    const save = await db.saves.get('save1');
+    const smeta = save?.metadata as Record<string, unknown> | undefined;
+    // 键保留原样（不裸删），标 needs_selection
+    expect(save?.metadata?.enabledWorldBookEntries).toContain('system_core:999999');
+    expect(smeta?.needsPackWorldBookSelection).toBe(true);
+  });
+});
+
+describe('content-store 执行器 —— 5. 装包后 boot 时序（D44 默认层）', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    await cleanDb();
+  });
+  afterEach(() => {
+    setActivePackRecord(null);
+    resetPlaceholderHashesCache();
+    vi.restoreAllMocks();
+  });
+
+  it('装包后 loadProjectDefaults 返回 pack agentDefaults（pack > 占位 fetch）', async () => {
+    const c = useContentStore();
+    await c.installPack(makePack());
+    // 即便占位 fetch 会返回别的，pack 层已接管
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ version: 1, agents: { story: { systemPrompt: 'PLACEHOLDER' } } }),
+          { status: 200 },
+        ),
+      );
+    const defaults = (await c.loadProjectDefaults()) as {
+      agents: Record<string, { systemPrompt: string }>;
+    };
+    fetchSpy.mockRestore();
+    expect(defaults.agents.story.systemPrompt).toBe('pack-story-prompt');
+  });
+
+  it('未装包 → loadProjectDefaults 回落占位 fetch（占位 agent 值生效）', async () => {
+    const c = useContentStore();
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ version: 1, agents: { story: { systemPrompt: 'PLACEHOLDER' } } }),
+          { status: 200 },
+        ),
+      );
+    const defaults = (await c.loadProjectDefaults()) as {
+      agents: Record<string, { systemPrompt: string }>;
+    };
+    fetchSpy.mockRestore();
+    expect(defaults.agents.story.systemPrompt).toBe('PLACEHOLDER');
+    expect(c.contentStatus).toBe('placeholder');
+  });
+});
+
+describe('content-store 执行器 —— 6. D42 重播种', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    await cleanDb();
+    // 占位内容升级到了版本 2（新 baseline）
+    installContentFetchMock({ version: '2' });
+  });
+  afterEach(() => {
+    setActivePackRecord(null);
+    resetPlaceholderHashesCache();
+    vi.restoreAllMocks();
+  });
+
+  it('占位版本前进：hash 仍等于占位基线的书重播种；动过的不覆盖', async () => {
+    // 先种两本占位书，一本保持原样、一本被用户编辑过
+    const db = getDatabase();
+    await db.worldBooks.put({ ...PLACEHOLDER_SYSTEM_CORE, id: 'system_core' });
+    await db.worldBooks.put({
+      ...PLACEHOLDER_WORLD,
+      id: 'world_setting',
+      entries: [entry(900003, '背景常识', '用户自己改过的内容')],
+    });
+
+    const c = useContentStore();
+    // settings 里记上一个旧版本戳（1）；占位内容升级到 v2（beforeEach 的 mock 提供 v2 baseline）
+    const { useSettingsStore } = await import('./settings-store');
+    const cfg = useSettingsStore();
+    cfg.settings.placeholderVersion = '1';
+
+    const result = await c.reseedPlaceholder();
+    // system_core 被重播（hash 命中占位基线 → 从占位文件重灌）；world_setting 用户编辑被保留
+    expect(result.reseeded).toContain('system_core');
+    expect(result.reseeded).not.toContain('world_setting');
+    const sc = await db.worldBooks.get('system_core');
+    expect(sc?.entries[0].content).toBe('占位A');
+    const ws = await db.worldBooks.get('world_setting');
+    expect(ws?.entries[0].content).toBe('用户自己改过的内容');
+    // 戳已更新
+    expect(cfg.settings.placeholderVersion).toBe('2');
+  });
+});

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -691,13 +691,12 @@ export const useContentStore = defineStore('content', () => {
 
   /** 装包/卸载末尾统一重灌缓存与内容态 */
   async function finalizePackState(pack: ContentPack): Promise<void> {
-    const rec: ContentPackRecord = {
-      packId: pack.packId,
-      packVersion: pack.packVersion,
-      installedAt: Date.now(),
-      payload: pack,
-    };
-    setActivePackRecord(rec);
+    // 🔴 从 Dexie 读回**完整行**（含 sectionHashes/notes）再进缓存——否则模块级
+    // activePackRecord 只有 4 个字段，与落库行不一致。眼下消费方只读 payload，
+    // 但保持一致是防御性的：未来任何读 record.notes/sectionHashes 的路径不会拿到
+    // 一个「看着装了、其实少了字段」的缓存。
+    const row = await getDatabase().contentPacks.get(pack.packId);
+    setActivePackRecord(row ?? null);
     activePackId.value = pack.packId;
     activePackVersion.value = pack.packVersion;
     contentStatus.value = 'pack';
@@ -867,12 +866,10 @@ export const useContentStore = defineStore('content', () => {
       };
 
     const pack = rawPack as ContentPack;
-    // 已装同 id 且版本不同 → 交由 upgradePack（同 id 同版本则视为重装/无操作）
+    // 已装同 id → 用旧包 payload 现算基线（D18 hash 分工：冲突判定从 payload 现算）。
+    // 升级的 diff 展示由 upgradePack 单独提供（UI 层按 packId 分流）；installPack 本身
+    // 只负责「装这一版」—— 旧基线用于四态规则判「现 hash = 基线 → updated 静默覆盖」。
     const existing = await getDatabase().contentPacks.get(pack.packId);
-    if (existing && existing.packVersion !== pack.packVersion) {
-      // 版本变化走升级（diff 展示后用户确认），这里委托 upgrade 逻辑返回 diff 由 UI 决定，
-      // 但简化为：直接走同一条安装路径（升级的 diff 展示由 upgradePack 单独提供）。
-    }
 
     try {
       const packBaseline = existing ? buildPackBaseline(existing.payload) : {};

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -40,7 +40,37 @@
 import { defineStore, getActivePinia } from 'pinia';
 import { ref } from 'vue';
 import type { ContentStatus } from '@engine/types-content';
-import { setContentFetchReporter } from '@engine/content-source';
+import type { SaveSlot, WorkshopNote, WorldBook } from '@engine/types';
+import type {
+  ContentPack,
+  PackBaseline,
+  PackInstallPlan,
+  PackSaveUidMigration,
+  PackValidationNote,
+} from '@engine/types-content';
+import {
+  setContentFetchReporter,
+  validatePackOrThrow,
+  planPackInstall,
+  hashWorldBook,
+  setPackRulesProvider,
+} from '@engine/content-source';
+import {
+  planPackUninstall,
+  diffPackUpgrade,
+  buildPackBaseline,
+  type CurrentLibrary,
+  type PackUninstallPlan,
+  type PackUpgradeDiff,
+} from '@engine/content-pack-plan';
+import {
+  getDatabase,
+  exportAllData,
+  importAllData,
+  savePreset,
+  deletePreset,
+} from '@engine/database';
+import type { ContentPackRecord } from '@engine/database';
 
 // ═══════════════════════════════════════════════════════════
 // 1. 模块级 ready promise（D16 时序契约）
@@ -76,6 +106,155 @@ export function markContentReady(): void {
   if (isContentReady) return;
   isContentReady = true;
   resolveReady();
+}
+
+// ═══════════════════════════════════════════════════════════
+// 1b. 占位基线清单（D20 / D42，面 4）—— `placeholder-hashes.json` 加载接口
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * `placeholder-hashes.json` 的装载产出（D20 / D42）。
+ *
+ * 🔴 **占位基线来源 = 构建期生成、随引擎打包的占位 hash 清单**（`placeholder-hashes.json`），
+ * **不许运行时 fetch `/data/*` 现算**（D20 裁定：POEM_CONTENT_DIR overlay 生效时那里是
+ * 真实内容树）。它是 D20 四态基线、D42 重播种、卸载 re-seed 三处的共同输入。
+ *
+ * 本波（T7）占位 hash 清单由 T15 产出并随引擎打包；文件可能不存在 → 返回**空清单**，
+ * 不报错（四态规则的「无占位基线 → 首次安装回落 updated / conflicted」分支仍可用，
+ * 卸载 re-seed 与 D42 重播种在该态是 no-op）。
+ *
+ * `version` 戳供 D42 重播种比对：戳前进时对「hash 仍等于占位基线」的书重播种。
+ */
+export interface PlaceholderHashManifest {
+  /** 占位集版本戳（D42）：settings.placeholderVersion 与之比对，前进时才重播种 */
+  version: string;
+  /** 世界书 id → 正文确定性 hash */
+  byBook?: Readonly<Record<string, string>>;
+  /** 预设 id → 行 hash */
+  byPreset?: Readonly<Record<string, string>>;
+  /** 美化规则 id → 行 hash */
+  byBeautifierRule?: Readonly<Record<string, string>>;
+}
+
+let placeholderHashesPromise: Promise<PlaceholderHashManifest> | null = null;
+let placeholderHashesCache: PlaceholderHashManifest = { version: '' };
+
+/**
+ * 加载占位基线清单（幂等，结果缓存到模块级）。
+ *
+ * fetch `/data/placeholder-hashes.json`；404 / 网络失败 → 返回空清单 `{ version: '' }`，
+ * **不报错**（面 4：本波文件不存在是常态，占位 hash 清单 T15 产出后接真值）。
+ */
+function loadPlaceholderHashes(): Promise<PlaceholderHashManifest> {
+  if (placeholderHashesPromise) return placeholderHashesPromise;
+  placeholderHashesPromise = (async () => {
+    try {
+      const res = await fetch('/data/placeholder-hashes.json');
+      if (res.ok) {
+        const raw = await res.json();
+        placeholderHashesCache = {
+          version: typeof raw?.version === 'string' ? raw.version : '',
+          byBook: raw?.byBook,
+          byPreset: raw?.byPreset,
+          byBeautifierRule: raw?.byBeautifierRule,
+        };
+      }
+    } catch {
+      // 404 / 网络失败 → 空清单（本波常态）
+    }
+    return placeholderHashesCache;
+  })();
+  return placeholderHashesPromise;
+}
+
+/** 取已加载的占位基线（未加载返回空清单；内部同步读） */
+function getPlaceholderHashes(): PlaceholderHashManifest {
+  return placeholderHashesCache;
+}
+
+/** 重置占位基线缓存（仅供测试 afterEach 隔离；生产不调） */
+export function resetPlaceholderHashesCache(): void {
+  placeholderHashesPromise = null;
+  placeholderHashesCache = { version: '' };
+}
+
+/** 占位清单 → PackBaseline（喂给 planner 的双基线之一；内部用） */
+function placeholderHashesToBaseline(manifest: PlaceholderHashManifest): PackBaseline {
+  return {
+    byBook: manifest.byBook,
+    byPreset: manifest.byPreset,
+    byBeautifierRule: manifest.byBeautifierRule,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════
+// 1c. 已装 pack 的模块级缓存（D18：整包入库，恢复默认/卸载/升级无须重读文件）
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * 模块级已装 pack 缓存（`contentPacks` 表最新一条/主 pack 的投影）。
+ *
+ * 🔴 **模块级而非 store 实例级**：beautifier-store 的 `refreshPresetRules`（§5.6 恢复默认）
+ * 和 branding 等同步消费方在读它，不能等 Pinia store 构造。装包 / 卸载执行器 update 它，
+ * boot 时序 `hydratePackState()` 从 Dexie 载入。
+ */
+let activePackRecord: ContentPackRecord | null = null;
+
+/** 当前已装的 pack 记录（未装返回 null；同步读） */
+function getActivePackRecord(): ContentPackRecord | null {
+  return activePackRecord;
+}
+
+/** 当前已装的 pack payload（未装返回 undefined） */
+function getActivePackPayload(): ContentPack | undefined {
+  return activePackRecord?.payload;
+}
+
+/** 整份替换模块级 pack 缓存（装包/卸载执行器 + boot hydrate 用） */
+export function setActivePackRecord(record: ContentPackRecord | null): void {
+  activePackRecord = record;
+  // 同步 pack 美化规则 provider（D20：pack 规则走 provider 内存层）。
+  // 传 null = 占位态，beautifier-store 回落占位文件。
+  setPackRulesProvider(record ? () => record.payload.beautifierRules?.rules ?? [] : null);
+}
+
+// ═══════════════════════════════════════════════════════════
+// 1d. 「恢复默认」的 provider 真源（D21 / §5.6）
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * 取一本书的「默认真源」—— 已装 pack payload > 占位文件（§5.6 恢复默认矩阵）。
+ *
+ * per-book `resetSingleWorldBook` 与全局 `resetToDefaults` 都用它：恢复这些书 = 拿
+ * pack.payload 里这本书（装包后）或占位文件里的书（未装/没发这本书）。语义与 `resolveSection`
+ * 一致：pack 声明了 worldBooks 分节就用它（含刻意 `[]`），否则占位。
+ *
+ * @param id 世界书 id
+ * @returns pack payload 里的书；pack 未声明 worldBooks 分节时回落占位文件；都没有 → undefined
+ */
+export async function loadDefaultBook(id: string): Promise<WorldBook | undefined> {
+  const pack = getActivePackPayload();
+  if (pack?.worldBooks !== undefined) {
+    const found = pack.worldBooks.find((b) => b.id === id);
+    if (found) return { ...found, builtIn: true };
+  }
+  const { loadBuiltInWorldBooks } = await import('@engine/builtin-worldbooks');
+  const books = await loadBuiltInWorldBooks();
+  return books.find((b) => b.id === id);
+}
+
+/**
+ * 取「整套默认世界书」—— 已装 pack payload > 占位文件（§5.6 全局恢复）。
+ *
+ * global `resetToDefaults` 用它：恢复全部默认书 = pack.payload.worldBooks（装包后）> 占位书。
+ */
+export async function loadAllDefaultBooks(): Promise<WorldBook[]> {
+  const pack = getActivePackPayload();
+  if (pack?.worldBooks !== undefined) {
+    return pack.worldBooks.map((b) => ({ ...b, builtIn: true }));
+  }
+  const { loadBuiltInWorldBooks } = await import('@engine/builtin-worldbooks');
+  return loadBuiltInWorldBooks();
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -192,6 +371,24 @@ export interface ContentFetchReport {
 // 4. Pinia store（contentStatus + load* 入口）
 // ═══════════════════════════════════════════════════════════
 
+/**
+ * 写存档 metadata（D43 needs_selection 标记 + enabledWorldBookEntries 重写）。
+ *
+ * 🔴 `SaveSlot.metadata` 的 TS 类型没声明 `needsPackWorldBookSelection`（不常驻 schema，
+ * 只在装/卸包后有意义的运行时键）。在写回 Dexie 前用它把这两类合并进 `Record<string, unknown>`
+ * 透传，避免拿严格类型撞墙（与 `*-migration.ts` 用 `Record<string, unknown>` 参数同一口径）。
+ */
+function writePackSelectionMetadata(
+  meta: SaveSlot['metadata'],
+  patch: { enabledWorldBookEntries?: string[] },
+  needsSelection: boolean,
+): SaveSlot['metadata'] {
+  const out: Record<string, unknown> = { ...(meta ?? {}) };
+  if (patch.enabledWorldBookEntries) out.enabledWorldBookEntries = patch.enabledWorldBookEntries;
+  if (needsSelection) out.needsPackWorldBookSelection = true;
+  return out as SaveSlot['metadata'];
+}
+
 export const useContentStore = defineStore('content', () => {
   /** 应用级内容态（D16）。占位态起步；七处 fetch 上报后可能切到 error。 */
   const contentStatus = ref<ContentStatus>('placeholder');
@@ -242,6 +439,18 @@ export const useContentStore = defineStore('content', () => {
    */
   async function loadProjectDefaults(): Promise<unknown> {
     await contentReadyPromise;
+    // 先确保已装 pack 从 Dexie 载入模块缓存（boot 时序；idempotent）
+    await hydratePackState();
+    // 🔴 D44 / §5.4：pack 已装 → 默认层 = pack agentDefaults > 占位 fetch。
+    const pack = getActivePackPayload();
+    if (pack?.agentDefaults?.agents) {
+      // D20 三态：pack 有 agentDefaults 分节 → 用它（不再是占位 fetch）。
+      reportContentFetch({
+        source: 'content-store.loadProjectDefaults',
+        ok: true,
+      });
+      return pack.agentDefaults;
+    }
     try {
       const res = await fetch('/data/defaults/agent-config.json');
       if (res.ok) {
@@ -289,6 +498,648 @@ export const useContentStore = defineStore('content', () => {
     }
   }
 
+  // ═══════════════════════════════════════════════════════════
+  // 5. 安装 / 升级 / 卸载执行器（D19 / §5.2）—— T7 交付
+  // ═══════════════════════════════════════════════════════════
+
+  let hydratePromise: Promise<void> | null = null;
+
+  /**
+   * 从 Dexie 把已装 pack 载入模块缓存 + store 内容态（幂等，boot 时序）。
+   *
+   * 🔴 不重置 ready（ready 只 resolve 一次，幂等闸）。装包/卸载则直接由执行器
+   * update 模块缓存，不需要再走这里（但重复调也无害——它读的是最新 Dexie 行）。
+   *
+   * 内容态规则：有已装 pack → `'pack'`；没有 → `'placeholder'`（若之前是 error
+   * 由 reportContentFetch 管，这里不越权清 error，除非显式占位态成立）。
+   */
+  async function hydratePackState(): Promise<void> {
+    if (hydratePromise) return hydratePromise;
+    hydratePromise = (async () => {
+      try {
+        const records = await getDatabase().contentPacks.toArray();
+        const active = records.find((r) => r.packId === r.payload?.packId && r.packId) ?? null;
+        // 💡 单 pack 场景：取最后一条（主 pack）。多 pack 共存留待后续波次扩展。
+        const activeRecord = records.length > 0 ? records[records.length - 1] : active;
+        setActivePackRecord(activeRecord);
+        if (activeRecord) {
+          activePackId.value = activeRecord.packId;
+          activePackVersion.value = activeRecord.packVersion;
+          if (contentStatus.value === 'placeholder') contentStatus.value = 'pack';
+        } else {
+          activePackId.value = null;
+          activePackVersion.value = null;
+          if (contentStatus.value === 'pack') contentStatus.value = 'placeholder';
+        }
+      } catch {
+        // Dexie 不可用 → 缓存保持现状，不阻断（boot 兜底）
+      }
+    })();
+    return hydratePromise;
+  }
+
+  /** 收集当前库状态喂给 planner（D43：含存档级 uid 允许清单联合） */
+  async function buildCurrentLibrary(): Promise<CurrentLibrary> {
+    const db = getDatabase();
+    const [worldBooks, presets, beautifierRules, saves] = await Promise.all([
+      db.worldBooks.toArray(),
+      db.presets.toArray(),
+      db.beautifierRules.toArray(),
+      db.saves.toArray(),
+    ]);
+    const enabled: string[] = [];
+    for (const s of saves) {
+      const entries = s.metadata?.enabledWorldBookEntries;
+      if (entries) enabled.push(...entries);
+    }
+    return { worldBooks, presets, beautifierRules, enabledWorldBookEntries: enabled };
+  }
+
+  /**
+   * 备份快照 → 任一步 throw 回滚。
+   *
+   * ✅ 只要 `contentPacks.put` 放在执行序列**最后**（§5.2 顺序），且分节写失败时
+   * 新 pack 行未落库，`importAllData(snapshot)` 就能把 worldBooks / presets 等
+   * 全部还原到装前状态（reconcilePackState 读到无 pack → 无对账）。
+   */
+  async function rollbackTo(snapshot: Awaited<ReturnType<typeof exportAllData>>): Promise<void> {
+    await importAllData(snapshot);
+  }
+
+  /** 有没有任何分节 planner 标了 conflicted（两阶段提交第一段判定） */
+  function hasAnyConflict(plan: PackInstallPlan): boolean {
+    const sections = plan.sections;
+    return Object.values(sections).some((s) => s && s.conflicted && s.conflicted.length > 0);
+  }
+
+  /**
+   * 收集装包各分节的 WorkshopNote（三类处置）—— 与 reportContentFetch 不同，这是
+   * **安装后**的处置记录（D19），UI 两阶段确认 Modal + 安装结果分组渲染。
+   */
+  function collectNotes(plan: PackInstallPlan): WorkshopNote[] {
+    const notes: WorkshopNote[] = [];
+    // planner 已经产出的侧链 note（D43 多选分区清除）直接透传
+    notes.push(...plan.notes.filter((n) => !!n && typeof n === 'object' && 'kind' in n));
+    return notes;
+  }
+
+  /**
+   * 解析「pack 的 story 预设 id」—— 用于装包后 activePresetId 切换（D20/D22）。
+   *
+   * pack presets 里名称为「占位 story 预设名」的那条，或第一条。占位 story 预设名
+   * 取自当前默认层（装包前是占位文件）的 projectAgentDefaults.agents.story.preset 名。
+   */
+  function resolvePackStoryPresetId(pack: ContentPack): string | undefined {
+    const packs = pack.presets;
+    if (!packs || packs.length === 0) return undefined;
+    return packs[0].id;
+  }
+
+  /** 执行一次安装的写入序列（§5.2 第 5 步）。装入前**必须**已 exportAllData() 快照。 */
+  async function applyInstall(
+    pack: ContentPack,
+    plan: PackInstallPlan,
+    existing: ContentPackRecord | undefined,
+    confirmConflicts: boolean,
+    _packBaseline: PackBaseline,
+  ): Promise<WorkshopNote[]> {
+    const notes = collectNotes(plan);
+    const wb = await useWbStore();
+    const beaut = await useBeautStore();
+    const settings = await useSettingsStoreLazy();
+
+    // a. worldBooks 分节（upsertBooks / 删 id / 冲突确认覆盖）
+    const wbPlan = plan.sections.worldBooks;
+    if (wbPlan) {
+      const toUpsert: WorldBook[] = [];
+      const toDelete: string[] = [];
+      for (const b of wbPlan.added) toUpsert.push(ensureBookBuiltIn(b));
+      for (const b of wbPlan.updated) toUpsert.push(ensureBookBuiltIn(b));
+      for (const b of wbPlan.removed) toDelete.push(b.id);
+      for (const c of wbPlan.conflicted) {
+        if (confirmConflicts) {
+          // 冲突确认后覆盖 = 用 pack 行整体覆盖当前行（含删除用户编辑）
+          const packBook = (pack.worldBooks ?? []).find((b) => b.id === c.key);
+          if (packBook) toUpsert.push(ensureBookBuiltIn(packBook));
+          else toDelete.push(c.key);
+        }
+      }
+      if (toDelete.length > 0) {
+        for (const id of toDelete) await wb.deleteBook(id);
+      }
+      if (toUpsert.length > 0) await wb.upsertBooks(toUpsert);
+    }
+
+    // b. presets 分节（savePreset 按 pack id upsert / deletePreset）
+    const prePlan = plan.sections.presets;
+    if (prePlan) {
+      for (const p of prePlan.added) await savePreset(p);
+      for (const p of prePlan.updated) await savePreset(p);
+      for (const p of prePlan.removed) await deletePreset(p.id);
+      for (const c of prePlan.conflicted) {
+        if (confirmConflicts) {
+          const packPreset = (pack.presets ?? []).find((p) => p.id === c.key);
+          if (packPreset) await savePreset(packPreset);
+          else await deletePreset(c.key);
+        }
+      }
+    }
+
+    // c. beautifierRules（provider 内存层，不写用户表）—— 装包后重算 presetRules
+    if (plan.sections.beautifierRules || pack.beautifierRules !== undefined) {
+      await beaut.refreshPresetRules(new Set(), new Set(), new Set(), pack.beautifierRules?.rules);
+    }
+
+    // d. agents / catalog / locations / bloodlines / namePools / markers / branding：
+    //    provider-owned。agentDefaults 只进 contentPacks（下面 put），**永不写 settings.agents**
+    //    （D44）。同步注册表在装包成功后由 setActivePackRecord 重灌（六面交给后续波次
+    //    逐面接管，本波至少把各面标记成 pack payload 的 resolveSection）。
+
+    // 注册表重灌：六面 = pack payload > 占位 undefined（本波 phases 未逐面接管，先透传）。
+    // 🔴 这里只做「pack 各面存在则灌入」的基础灌注；真实形状由波 2（D24/D25）收窄。
+    const reg = getContentRegistry();
+    setContentRegistry({
+      catalog: pack.catalog !== undefined ? pack.catalog.data : reg.catalog,
+      locations: pack.locations !== undefined ? pack.locations : reg.locations,
+      bloodlines: pack.bloodlines !== undefined ? pack.bloodlines : reg.bloodlines,
+      namePools: pack.namePools !== undefined ? pack.namePools.data : reg.namePools,
+      markers: pack.mapMarkers !== undefined ? pack.mapMarkers : reg.markers,
+      branding: pack.branding !== undefined ? pack.branding : reg.branding,
+    });
+
+    // e. 存档 uid 迁移（D43）：rewrite 应用 + needsSelectionPartitions 标记
+    await applySaveUidMigration(plan.saveUidMigration);
+
+    // f. activePresetId 切换（D20/D22）：原来指向占位预设/未设 → 切到 pack 预设
+    await switchActivePresetToPack(pack, settings);
+
+    // g. contentPacks.put（**最后**，失败回滚时不残留新 pack 行）
+    await getDatabase().contentPacks.put({
+      packId: pack.packId,
+      packVersion: pack.packVersion,
+      installedAt: Date.now(),
+      payload: pack,
+      sectionHashes: pack.sectionHashes,
+      notes,
+    } satisfies ContentPackRecord);
+
+    // h. 缓存 + 内容态
+    await finalizePackState(pack);
+
+    return notes;
+  }
+
+  /** 装包/卸载末尾统一重灌缓存与内容态 */
+  async function finalizePackState(pack: ContentPack): Promise<void> {
+    const rec: ContentPackRecord = {
+      packId: pack.packId,
+      packVersion: pack.packVersion,
+      installedAt: Date.now(),
+      payload: pack,
+    };
+    setActivePackRecord(rec);
+    activePackId.value = pack.packId;
+    activePackVersion.value = pack.packVersion;
+    contentStatus.value = 'pack';
+  }
+
+  /** worldBook 书行保证 `builtIn: true`（缺了被 loadBuiltInWorldBooks 真值门静默丢弃） */
+  function ensureBookBuiltIn(b: WorldBook): WorldBook {
+    if (b.builtIn) return b;
+    return { ...b, builtIn: true };
+  }
+
+  /** 惰性取 settings-store（避免与 content-store 的静态循环依赖） */
+  async function useSettingsStoreLazy() {
+    const { useSettingsStore } = await import('./settings-store');
+    return useSettingsStore();
+  }
+
+  /** 惰性取 worldbook-store（避免 content-store ⟷ worldbook-store 静态循环） */
+  async function useWbStore() {
+    const { useWorldBookStore } = await import('./worldbook-store');
+    return useWorldBookStore();
+  }
+
+  /** 惰性取 beautifier-store（避免 content-store ⟷ beautifier-store 静态循环） */
+  async function useBeautStore() {
+    const { useBeautifierStore } = await import('./beautifier-store');
+    return useBeautifierStore();
+  }
+
+  /** 装包后 activePresetId 切到 pack 预设（D20/D22） */
+  async function switchActivePresetToPack(
+    pack: ContentPack,
+    settings: SettingsStoreType,
+  ): Promise<void> {
+    const packPresetId = resolvePackStoryPresetId(pack);
+    if (!packPresetId) return;
+    const prev = settings.settings.activePresetId;
+    // 指向占位预设（当前默认层的 story presetId）或未设 → 切到 pack 预设；
+    // 指向用户第三方预设 → 不动
+    const placeholderStoryId = settings.projectAgentDefaults?.agents?.story?.presetId || '';
+    if (!prev || prev === placeholderStoryId) {
+      settings.settings.activePresetId = packPresetId;
+      settings.saveNow();
+    }
+  }
+
+  /** 卸载后 activePresetId 从 pack 预设切回占位 story 预设 */
+  async function switchActivePresetToPlaceholder(
+    placeholderStoryId: string,
+    packPresetIds: string[],
+  ): Promise<void> {
+    const settings = await useSettingsStoreLazy();
+    const prev = settings.settings.activePresetId;
+    if (prev && packPresetIds.includes(prev)) {
+      settings.settings.activePresetId = placeholderStoryId;
+      settings.saveNow();
+    }
+  }
+
+  /**
+   * 全局卸载后 world-book 恢复占位：清空 pack 拥有 id → upsert 占位书。
+   * 🔴 **禁用 mergeBuiltIns**（id-presence-only，对仍占着 15 个 id 的 pack 内容是 no-op）——
+   * 卸载要显式「删 pack 行 → 灌占位书」（§5.2 v1.2 修订）。
+   */
+  async function restorePlaceholderBooks(ownedIds: string[]): Promise<void> {
+    const wb = await useWbStore();
+    // 1) 删 pack 拥有的 id
+    for (const id of ownedIds) {
+      await wb.deleteBook(id);
+    }
+    // 2) 从占位文件灌回同 id 的占位书（builtIn:true，uid 保留段）
+    const { loadBuiltInWorldBooks } = await import('@engine/builtin-worldbooks');
+    const placeholders = await loadBuiltInWorldBooks();
+    const toReload = placeholders.filter((b) => ownedIds.includes(b.id));
+    if (toReload.length > 0) {
+      await wb.upsertBooks(toReload);
+    }
+  }
+
+  /** 存档 uid 迁移执行（D43）—— 装包正向：rewrite 重写 + needsSelectionPartitions 标记 */
+  async function applySaveUidMigration(migration: PackSaveUidMigration | undefined): Promise<void> {
+    if (!migration) return;
+    const db = getDatabase();
+    const saves = await db.saves.toArray();
+    const { rewrite, needsSelectionPartitions } = migration;
+    let changed = false;
+    for (const save of saves) {
+      const entries = save.metadata?.enabledWorldBookEntries;
+      if (!entries || entries.length === 0) continue;
+      let mutated = false;
+      const next = [...entries];
+      for (let i = 0; i < next.length; i++) {
+        const oldKey = next[i];
+        const newUid = rewrite[oldKey];
+        if (newUid !== undefined) {
+          const partition = oldKey.slice(0, oldKey.indexOf(':'));
+          next[i] = `${partition}:${newUid}`;
+          mutated = true;
+        }
+      }
+      // needs_selection（D43）：单选钉选分区的**失配键**（不在 rewrite 里的）触发。
+      // rewrite 只含配对成功者；某分区在 needsSelectionPartitions 里且该存档含该分区
+      // 的键但没被 rewrite → 需重选。裸删这些键 = 分区「整本原样通过」= 内容通胀。
+      const needsSelection = (needsSelectionPartitions ?? []).some((p) =>
+        entries.some((e) => e.startsWith(`${p}:`) && rewrite[e] === undefined),
+      );
+      if (needsSelection) {
+        mutated = true;
+      }
+      if (mutated) {
+        save.metadata = writePackSelectionMetadata(
+          save.metadata,
+          { enabledWorldBookEntries: next },
+          needsSelection,
+        );
+        await db.saves.put(save);
+        changed = true;
+      }
+    }
+    if (changed) {
+      // 触发存档 UI 重读（loadSaves）；失败静默（装包路径的存档刷新不是硬依赖）
+      try {
+        const { useGameStore } = await import('./game-store');
+        const g = useGameStore();
+        if (g.loadSaves) await g.loadSaves();
+      } catch {
+        /* no-op */
+      }
+    }
+  }
+
+  // 一次性装包守卫：仅同一时刻允许一个装/卸进行（执行器自身可控；并发由调用方串行）
+  let execBusy = false;
+
+  /**
+   * 安装内容包（D19 / §5.2 安装流）。
+   *
+   * 两阶段提交：
+   * 1. 无 `opts.confirmConflicts` 且计划有 conflicted → 返回 `ok:false, status:'needs_confirmation'`
+   *    带着 plan，UI 逐节展示后以 `{ confirmConflicts: true }` 重入。
+   * 2. 确认（或无冲突）→ exportAllData 快照 → 分节写入 → 存档迁移 → contentPacks.put
+   *    → 注册表重灌 + 缓存 + 内容态 pack；任一步 throw → 快照回滚。
+   *
+   * `validatePackOrThrow` 出 error 级 note → 直接返回 `ok:false, status:'invalid'`，**零写入**。
+   */
+  async function installPack(
+    rawPack: unknown,
+    opts: { confirmConflicts?: boolean } = {},
+  ): Promise<PackInstallOutcome> {
+    const validationErrors = validatePackOrThrow(rawPack);
+    if (validationErrors.some((n) => n.level === 'error')) {
+      return {
+        ok: false,
+        status: 'invalid',
+        packId: String((rawPack as ContentPack).packId ?? ''),
+        packVersion: String((rawPack as ContentPack).packVersion ?? ''),
+        validationErrors,
+      };
+    }
+    if (execBusy)
+      return {
+        ok: false,
+        status: 'busy',
+        packId: String((rawPack as ContentPack).packId ?? ''),
+        packVersion: String((rawPack as ContentPack).packVersion ?? ''),
+        validationErrors: [],
+      };
+
+    const pack = rawPack as ContentPack;
+    // 已装同 id 且版本不同 → 交由 upgradePack（同 id 同版本则视为重装/无操作）
+    const existing = await getDatabase().contentPacks.get(pack.packId);
+    if (existing && existing.packVersion !== pack.packVersion) {
+      // 版本变化走升级（diff 展示后用户确认），这里委托 upgrade 逻辑返回 diff 由 UI 决定，
+      // 但简化为：直接走同一条安装路径（升级的 diff 展示由 upgradePack 单独提供）。
+    }
+
+    try {
+      const packBaseline = existing ? buildPackBaseline(existing.payload) : {};
+      // 🔴 先装载占位基线（D20：占位 hash 清单是四态规则的操作数；T15 产出前文件 404 → 空基线，
+      //    首安装覆盖占位书会退化为 conflicted —— D42 面占位清单落地后自动补上。）
+      await loadPlaceholderHashes();
+      const placeholderBaseline = placeholderHashesToBaseline(getPlaceholderHashes());
+      const current = await buildCurrentLibrary();
+      const plan = planPackInstall(pack, current, packBaseline, placeholderBaseline);
+
+      const hasConflicts = hasAnyConflict(plan);
+      if (hasConflicts && !opts.confirmConflicts) {
+        return {
+          ok: false,
+          status: 'needs_confirmation',
+          packId: pack.packId,
+          packVersion: pack.packVersion,
+          plan,
+          validationErrors: plan.validationErrors,
+        };
+      }
+
+      execBusy = true;
+      const snapshot = await exportAllData();
+      try {
+        const notes = await applyInstall(
+          pack,
+          plan,
+          existing,
+          opts.confirmConflicts ?? false,
+          packBaseline,
+        );
+        return {
+          ok: true,
+          status: 'installed',
+          packId: pack.packId,
+          packVersion: pack.packVersion,
+          plan,
+          notes,
+          validationErrors: plan.validationErrors,
+        };
+      } catch (err) {
+        await rollbackTo(snapshot);
+        throw err;
+      } finally {
+        execBusy = false;
+      }
+    } catch (err) {
+      // 回滚在内部已做；这里再包一层让调用方拿到结构化错误
+      throw err;
+    }
+  }
+
+  /**
+   * 升级内容包（D40 / §5.2）：产升级 diff（两个已算好的安装计划派生）供 UI 展示，
+   * 确认后走 installPack。返回 outcome，其中 `upgradeDiff` 字段携带「这一版会改什么」。
+   *
+   * diff 语义：`oldPlan` = 用旧 payload 对当前状态（= 旧包已装）重算出的计划，
+   * `newPlan` = 用新 payload 对同一状态算出的计划；`diffPackUpgrade(oldPlan, newPlan)`
+   * 即新旧两版安装间 added/removed/updated/conflicted 的变化。
+   */
+  async function upgradePack(
+    rawPack: unknown,
+    opts: { confirmConflicts?: boolean } = {},
+  ): Promise<PackInstallOutcome> {
+    const validationErrors = validatePackOrThrow(rawPack);
+    if (validationErrors.some((n) => n.level === 'error')) {
+      return {
+        ok: false,
+        status: 'invalid',
+        packId: String((rawPack as ContentPack).packId ?? ''),
+        packVersion: String((rawPack as ContentPack).packVersion ?? ''),
+        validationErrors,
+      };
+    }
+    const pack = rawPack as ContentPack;
+    const existing = await getDatabase().contentPacks.get(pack.packId);
+    if (!existing) {
+      // 没装过同 id → 不是升级，走安装
+      return installPack(pack, opts);
+    }
+    try {
+      const packBaseline = buildPackBaseline(existing.payload);
+      await loadPlaceholderHashes();
+      const placeholderBaseline = placeholderHashesToBaseline(getPlaceholderHashes());
+      const current = await buildCurrentLibrary();
+      const oldPlan = planPackInstall(existing.payload, current, packBaseline, placeholderBaseline);
+      const newPlan = planPackInstall(pack, current, packBaseline, placeholderBaseline);
+      const upgradeDiff = diffPackUpgrade(oldPlan, newPlan);
+
+      const hasConflicts = hasAnyConflict(newPlan);
+      if (hasConflicts && !opts.confirmConflicts) {
+        return {
+          ok: false,
+          status: 'needs_confirmation',
+          packId: pack.packId,
+          packVersion: pack.packVersion,
+          plan: newPlan,
+          upgradeDiff,
+          validationErrors: newPlan.validationErrors,
+        };
+      }
+
+      // 确认后落盘 —— 复用安装序列（同一执行路径，含快照回滚）
+      const outcome = await installPack(pack, { confirmConflicts: opts.confirmConflicts ?? false });
+      return { ...outcome, upgradeDiff };
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  /**
+   * 卸载内容包（§5.2 卸载流）。
+   *
+   * 预检（planPackUninstall）→ 编辑确认 → exportAllData 快照 → 删 pack 拥有 id →
+   * upsert 占位书 → 删 pack 预设 → activePresetId 切回占位 → contentPacks.delete →
+   * 注册表重灌 → 内容态回 placeholder；任一步 throw → 快照回滚。
+   */
+  async function uninstallPack(
+    opts: { confirmEdits?: boolean } = {},
+  ): Promise<PackUninstallOutcome> {
+    const active = getActivePackRecord();
+    if (!active) {
+      return { ok: false, status: 'no_pack' };
+    }
+    const installedPack = active.payload;
+    execBusy = true;
+    try {
+      const packBaseline = buildPackBaseline(installedPack);
+      const current = await buildCurrentLibrary();
+      const plan = planPackUninstall(installedPack, current, packBaseline);
+      const hasEdits = plan.confirmations.length > 0;
+      if (hasEdits && !opts.confirmEdits) {
+        return {
+          ok: false,
+          status: 'needs_confirmation',
+          plan,
+        };
+      }
+
+      const snapshot = await exportAllData();
+      try {
+        // 世界书：删 pack 拥有 id → 灌占位书（显式删后播，禁用 mergeBuiltIns）
+        await restorePlaceholderBooks(plan.ownedBookIds);
+
+        // 存档 uid 迁移（D43 反向：真实 uid 消失 → 按名配对回占位/needs_selection）
+        // 反向语义用 planPackInstall 重新规划一次当前状态（占位基线命中 → 回占位书）
+        await applySaveMigrationReverse();
+
+        // presets：删 pack 预设行；activePresetId 指向它时切回占位
+        const packPresetIds = (installedPack.presets ?? []).map((p) => p.id);
+        if (packPresetIds.length > 0) {
+          for (const id of packPresetIds) {
+            try {
+              await deletePreset(id);
+            } catch {
+              /* 行可能已经被用户改过/不存在 */
+            }
+          }
+        }
+        const settings = await useSettingsStoreLazy();
+        const placeholderStoryId = settings.projectAgentDefaults?.agents?.story?.presetId || '';
+        await switchActivePresetToPlaceholder(placeholderStoryId, packPresetIds);
+
+        // agents/beautifier/catalog/sync registry：provider-owned，删 pack 行即回落
+        // 注册表灌回占位（各面 undefined → 波 2 接管）
+        seedPlaceholderRegistry();
+
+        // contentPacks.delete（**最后**）
+        await getDatabase().contentPacks.delete(installedPack.packId);
+
+        // 缓存 + 内容态回 placeholder
+        setActivePackRecord(null);
+        activePackId.value = null;
+        activePackVersion.value = null;
+        contentStatus.value = 'placeholder';
+
+        return {
+          ok: true,
+          status: 'uninstalled',
+          plan,
+          notes:
+            plan.confirmations.length > 0
+              ? [
+                  {
+                    kind: 'sideEffect',
+                    text: `卸载丢弃了 ${plan.confirmations.length} 本被编辑过的内容包世界书`,
+                  } as WorkshopNote,
+                ]
+              : [],
+        };
+      } catch (err) {
+        await rollbackTo(snapshot);
+        throw err;
+      }
+    } catch (err) {
+      throw err;
+    } finally {
+      execBusy = false;
+    }
+  }
+
+  /** 卸载的反向存档迁移（D43 反向语义）：把真实 uid 键按名配对回占位 uid / needs_selection */
+  async function applySaveMigrationReverse(): Promise<void> {
+    // 占位书（装包后仍存在）是反向配对的对照物；占位书 uid 在 900001+ 保留段。
+    // 卸载把 pack 书换成占位书后，真实 uid 键失配 → planner 的迁移逻辑在 re-install
+    // 一次占位时产生 rewrite。这里用 planSaveUidMigration 的镜像：把 pack 书当「旧」、
+    // 当前（占位）书当「新」。由于占位书不可枚举（placeholder-hashes 未产出），
+    // 本波对反向往迁做保守处理：命中去重条目配对已由 planPackUninstall 覆盖，
+    // 这里只重跑一次占位 installedPack 的 buildCurrentLibrary 并标记 needs_selection 兜底。
+    // —— 完整反向 uid 配对留待占位 hash 清单（T15）落地后补真值。
+    const db = getDatabase();
+    const saves = await db.saves.toArray();
+    for (const save of saves) {
+      const entries = save.metadata?.enabledWorldBookEntries;
+      if (!entries) continue;
+      // 检查是否仍含 pack 拥有的真实 uid（< 900001）——有则这些键在卸载后失配
+      const stillHasPackUid = entries.some((e) => {
+        const uid = parseInt(e.slice(e.indexOf(':') + 1), 10);
+        return Number.isFinite(uid) && uid < 900001;
+      });
+      if (stillHasPackUid) {
+        save.metadata = writePackSelectionMetadata(save.metadata, {}, true);
+        await db.saves.put(save);
+      }
+    }
+  }
+
+  /**
+   * D42 重播种（面 4）：占位内容升级后，对「hash 仍等于占位基线」的书重播种。
+   *
+   * settings.placeholderVersion（见 settings-types）与内置占位 hash 清单的 version 比对；
+   * 戳前进时对 `byBook` 基线命中（用户没动过）的书从占位文件重播，动过的不覆盖。
+   *
+   * 本波（T7）占位 hash 清单由 T15 产出；文件不存在 → manifest.version 为空 → **无操作**。
+   */
+  async function reseedPlaceholder(): Promise<{ reseeded: string[] }> {
+    const manifest = await loadPlaceholderHashes();
+    const settings = await useSettingsStoreLazy();
+    const prev = settings.settings.placeholderVersion;
+    if (!prev || prev === manifest.version || !manifest.byBook) {
+      settings.settings.placeholderVersion = manifest.version || prev;
+      settings.saveNow();
+      return { reseeded: [] };
+    }
+    const reseeded: string[] = [];
+    const db = getDatabase();
+    const books = await db.worldBooks.toArray();
+    const { loadBuiltInWorldBooks } = await import('@engine/builtin-worldbooks');
+    const placeholderBooks = await loadBuiltInWorldBooks();
+    const wbPlan = new Map(placeholderBooks.map((b) => [b.id, b]));
+    for (const book of books) {
+      const base = manifest.byBook[book.id];
+      if (base === undefined) continue;
+      if (hashWorldBook(book) === base) {
+        const fresh = wbPlan.get(book.id);
+        if (fresh) {
+          await db.worldBooks.put(ensureBookBuiltIn(fresh));
+          reseeded.push(book.id);
+        }
+      }
+    }
+    settings.settings.placeholderVersion = manifest.version;
+    settings.saveNow();
+    return { reseeded };
+  }
+
   return {
     contentStatus,
     activePackId,
@@ -298,8 +1149,41 @@ export const useContentStore = defineStore('content', () => {
     reportContentFetch,
     loadProjectDefaults,
     loadRawProjectDefaults,
+    hydratePackState,
+    installPack,
+    upgradePack,
+    uninstallPack,
+    reseedPlaceholder,
   };
 });
+
+/** settings-store 返回实例类型（避免在 content-store 内引入静态循环依赖） */
+type SettingsStoreType = {
+  settings: { activePresetId: string; placeholderVersion?: string };
+  projectAgentDefaults?: { agents?: Record<string, { presetId?: string }> };
+  saveNow: () => void;
+};
+
+/** 安装/升级结果（两阶段提交各段共用） */
+export interface PackInstallOutcome {
+  ok: boolean;
+  status: 'invalid' | 'needs_confirmation' | 'busy' | 'installed';
+  packId: string;
+  packVersion: string;
+  plan?: PackInstallPlan;
+  /** 升级 diff（upgradePack 产；installPack 走升级路径时也可能带） */
+  upgradeDiff?: PackUpgradeDiff;
+  notes?: WorkshopNote[];
+  validationErrors?: PackValidationNote[];
+}
+
+/** 卸载结果 */
+export interface PackUninstallOutcome {
+  ok: boolean;
+  status: 'no_pack' | 'needs_confirmation' | 'uninstalled';
+  plan?: PackUninstallPlan;
+  notes?: WorkshopNote[];
+}
 
 // ═══════════════════════════════════════════════════════════
 // 模块加载时同步初始化（D16 时序契约的执行点）

--- a/src/ui/stores/settings-types.ts
+++ b/src/ui/stores/settings-types.ts
@@ -72,6 +72,11 @@ export type UiSettings = {
   //    响应式视图经 `usePresets` composable。这里只剩「当前选中哪条」的 UI 状态。
   activePresetId: string;
 
+  // ═══ 内容-引擎分离波 1 / D42：占位内容版本戳 ═══
+  // 占位集随引擎打包；戳前进时 content-store 对「hash 仍等于占位基线」的书重播种（D42）。
+  // 缺省 = 未比对过（首启），D42 重播种当作需要写入当前占位版本。不常驻、非必填。
+  placeholderVersion?: string;
+
   // ═══ 世界书（书本体在 Dexie，这里只有 UI 选择/开关）═══
   activeWorldBookId: string | null;
   worldBookDirty: boolean;

--- a/src/ui/stores/worldbook-store.ts
+++ b/src/ui/stores/worldbook-store.ts
@@ -136,25 +136,28 @@ export const useWorldBookStore = defineStore('worldbook', () => {
   }
 
   /**
-   * 恢复默认：清空整表，重新从 `data/worldbooks/` 加载。
-   * 语义与迁移前的 `settings.resetWorldBooksToDefaults()` 一致（含清 activeWorldBookId）。
-   * fetch 失败 → 什么都不动（绝不先清表再发现加载不到）。
+   * 恢复默认：清空整表，从**默认真源**重新加载（§5.6 / D21）。
+   *
+   * 🔴 内容-引擎分离波 1：默认真源 = 已装 content pack 的 payload > 占位文件
+   * （provider `loadAllDefaultBooks`）。导入真实包后 restore 不再把真实书打回占位。
+   * 语义与迁移前一致（含清 activeWorldBookId）；fetch 失败 → 什么都不动（绝不先清表再发现拿不回来）。
    */
   async function resetToDefaults(): Promise<void> {
-    let builtIn: WorldBook[];
     try {
-      builtIn = await loadBuiltInWorldBooks();
+      // 先 await 确保 pack 已装载到模块缓存（boot 顺序：loadProjectDefaults → 这里）
+      const { loadAllDefaultBooks } = await import('./content-store');
+      const builtIn = await loadAllDefaultBooks();
+      const rows = builtIn.map(toRow);
+      const db = getDatabase();
+      await db.transaction('rw', db.worldBooks, async () => {
+        await db.worldBooks.clear();
+        if (rows.length > 0) await db.worldBooks.bulkPut(rows);
+      });
+      books.value = rows;
+      useSettingsStore().settings.activeWorldBookId = null;
     } catch {
-      return;
+      return; // fetch / IndexedDB 不可用时静默跳过
     }
-    const rows = builtIn.map(toRow);
-    const db = getDatabase();
-    await db.transaction('rw', db.worldBooks, async () => {
-      await db.worldBooks.clear();
-      if (rows.length > 0) await db.worldBooks.bulkPut(rows);
-    });
-    books.value = rows;
-    useSettingsStore().settings.activeWorldBookId = null;
   }
 
   return {


### PR DESCRIPTION
## 波 1 T7（收波）：内容包安装/升级/卸载执行器 + 导入 UI

内容-引擎分离波 1 收尾任务。设计见 `docs/planning/2026-08-05-content-engine-separation-design.md` §5.1 / §5.2 / §5.6 / §5.7 / D19-D22 / D42 / D43。

### 交付面

1. **执行器**（content-store.ts）：`installPack` / `upgradePack` / `uninstallPack` 完整 §5.2 序列
   - 两阶段提交（无冲突直装 / 有冲突 needs_confirmation 后 confirmConflicts 重入）
   - `exportAllData()` 快照 + 任一步 throw 回滚
   - 分节写入：worldBooks（upsert/删/冲突确认覆盖）、presets（savePreset/deletePreset）、
     beautifier（provider 内存层不写用户表）、agents（只写 contentPacks + 缓存失效，D44）
   - 存档 uid 迁移（D43 按名配对 rewrite + needs_selection 标记）
   - 卸载反向迁移（占位书不可枚举阶段保守处理：真实 uid 键标 needs_selection）
   - `loadProjectDefaults` 装包后返回 pack agentDefaults（D44 默认层）
2. **导入 UI**：DataSection「内容包」卡片（导入/升级/卸载 + 两阶段确认 Modal）+ ContentStatusBanner（placeholder→导入 / pack→卸载按钮）
3. **恢复默认矩阵**（§5.6）：`resetToDefaults` / `resetSingleWorldBook` / beautifier `refreshPresetRules` 全部改走 provider（pack payload > 占位文件）
4. **D42 重播种接口**：`reseedPlaceholder` + `placeholderVersion` 设置字段 + placeholder-hashes.json 加载接口（T15 产出前 404 → 空清单，无操作）

### 验证（主会话独立跑六道门）

- ✅ typecheck ×3（tsc / vue-tsc / tsc-tools）
- ✅ lint（--max-warnings 0）
- ✅ knip:ratchet（145 已知，无新增）
- ✅ format:check（11 改动文件全过，修了 agent 漏的 PackInstallConfirmModal）
- ✅ 全量 test：266 files / 6858 passed / 4 skipped
- ✅ 编码检查：11 个含中文文件 U+FFFD=0 / ctrl=0

### 审查修复（主会话波末 review，commit 4b5bcad）

- content-store.ts: 删 installPack 空 if 死代码；`finalizePackState` 改从 Dexie 读回完整行
  进模块缓存（含 sectionHashes/notes，不再 4 字段手搓 rec）——缓存与落库一致
- PackInstallConfirmModal.vue: prettier 格式化

### 已知偏差（agent 报告）

- 占位基线 T7 为空（placeholder-hashes.json 由 T15 产出）→ 首装覆盖占位书退化为 conflicted，确认后覆盖
- 卸载反向 uid 配对保守处理（占位书不可枚举，真实 uid 键标 needs_selection 兜底，完整按名反向配对留 T15）
- D42 只留接口 + 测试，未接线 boot（文件不存在时无操作，defer）
- banner 冲突确认用系统 window.confirm（复杂 Modal 留在设置页数据分区）
- contentPacks 多 pack 共存只取最后一条（单 pack 场景，多包叠加留后续波）

### 测试

新增 content-store-executor.test.ts 11 条，覆盖 6 类验收：装（含冲突确认）/ 升（diff）/ 卸（快照回滚）/ 占位建档→装包→存档 uid 迁移（D43）/ 装包后 boot 时序（D44 默认层）/ D42 重播种（动过的不覆盖）。