### PR TITLE
feat(home): polish magic circle experiment

### DIFF
--- a/design-qa.md
+++ b/design-qa.md
@@ -3,18 +3,24 @@
 ## Evidence
 
 - Reference: `tmp/magic-circle-qa/reference.png` (`1672 x 941`)
-- Implementation: `tmp/magic-circle-qa/stronger-glow-wide.png` (`1672 x 941`)
-- Responsive evidence: `tmp/magic-circle-qa/stronger-glow-portrait.png` (`800 x 1000`)
+- Implementation: `tmp/magic-circle-qa/more-particles-glow-wide.png` (`1600 x 1000`)
+- Responsive evidence: `tmp/magic-circle-qa/more-particles-glow-portrait.png` (`900 x 1200`)
+- Control evidence: `tmp/magic-circle-qa/glow-dials-wide.png` (`1440 x 900`)
+- Responsive control evidence: `tmp/magic-circle-qa/glow-dials-portrait.png` (`720 x 980`)
+- Channel isolation evidence: `tmp/magic-circle-qa/glow-dials-extremes.png` (`1440 x 900`, runes 200%, rims 0%)
+- Responsive glow evidence: `tmp/magic-circle-qa/glow-radius-final-wide.png` (`1440 x 900`) and `tmp/magic-circle-qa/glow-radius-final-narrow.png` (`720 x 980`)
+- Random rune evidence: `tmp/magic-circle-qa/random-runes-wide-a.png` and `tmp/magic-circle-qa/random-runes-wide-b.png` (`1280 x 720`, two states 4.2 seconds apart)
+- Premium rune evidence: `tmp/magic-circle-qa/premium-runes-wide-a.png` and `tmp/magic-circle-qa/premium-runes-wide-b.png` (`1280 x 720`, two traveling-highlight states 1.15 seconds apart)
 - Runtime: `src/ui/components/home/MagicCircle.standalone.html`
-- Captured state: autonomous animation after approximately 3 seconds; no interaction state exists
+- Captured state: autonomous animation after approximately 3 seconds with the glow controls at the then-current 100% neutral baseline and tested extremes
 
 ## Simplification outcome
 
 - Composition: the full astrolabe occupies the same shallow oblique ellipse, uses a long-lens perspective, and keeps the aperture aligned with the supplied reference.
 - Hierarchy: four broad engraved registers, a separate guardian filigree layer, cardinal sigils, black aperture, and sparse void atmosphere.
 - Rim budget: five visible metallic rims total: one outer crown, three register rails, and one aperture rim.
-- Finish: the annular slab and crystalline sidewall remain absent. Smoke-bronze and moon-silver rims now combine physical metal, bright emissive cores, localized traveling energy veins, close additive halos, and restrained bloom. Rune spill comes from a separate optically blurred texture rather than a sharp duplicate.
-- Motion: all four registers retain independent direction, speed, phase, height, and restrained vertical drift. Filigree, sigils, patina, aperture ticks, stars, and glints keep separate motion tracks.
+- Finish: the annular slab and crystalline sidewall remain absent. Smoke-bronze and moon-silver rims now combine physical metal, bright emissive cores, localized traveling energy veins, close additive halos, and restrained bloom. Rune spill, cardinal sigils, central filigree, aperture ticks, and rim halos compensate from the camera's projected pixels-per-world so their apparent radius stays stable as the composition refits.
+- Motion: all four registers retain independent direction, speed, phase, height, and restrained vertical drift. Filigree, sigils, patina, aperture ticks, stars, and glints keep separate motion tracks. A single authored radial surge periodically travels through the particle field, tangent-aligned orbital streaks, rim veins, aperture light, and bloom. Each register charges one randomly selected rune at a time; the complete engraving eases into a bronze or silver radiance with a pale-metal edge, then fades without segment flashing.
 - Constraint: no raster, SVG, model, video, or other visual asset is loaded at runtime. Geometry, CanvasTextures, particles, and shaders are generated in the standalone file.
 
 ## Iteration history
@@ -26,6 +32,14 @@
 5. The floating-light pass removed every solid annular support and the remaining sidewall while preserving the approved pattern geometry. Existing rims and rune textures gained controlled bronze and silver inner radiance without adding sparks or ornament.
 6. The bounded polish loop added soft rune scatter, a transparent violet atmospheric underlight, and slowly orbiting warm/cool illumination. The final hierarchy grades energy inward so the aperture leads without changing the four registers or five-rim budget.
 7. The glow-strength pass increased emissive energy, halo width, optical rune scatter, localized hot-vein intensity, and restrained bloom while reducing the already sparse glints. Engraving cores remain legible at both verified sizes.
+8. The spectacle pass added one GPU particle draw call containing subdued orbital dust, brighter bronze/silver motes at the existing five radii, and a violet-silver stream rising around the aperture. Particles use real height and depth testing; the radial surge briefly intensifies them and the existing glow system without changing any approved pattern geometry.
+9. The energy-density pass increased the structured particle field to 620 motes, added 72 instanced tangent-aligned streaks on the same five radii, strengthened rune scatter, and gave the cardinal sigils, central filigree, and aperture ticks independent additive halos. Wide and portrait renders preserve the approved geometry and show no clipping or runtime errors.
+10. The tuning pass added two compact 0-200% radial controls. Runes scales letter, sigil, filigree, and aperture-tick halos; Rims independently scales emissive cores, additive rim halos, traveling veins, and the aperture light. Pointer, wheel, arrow, Home/End, and Reset paths share one value pipeline, while 100% remains the neutral calibration baseline.
+11. The responsive-glow correction replaced viewport-relative object-space spread with projection-compensated texture blur and rim-halo geometry. A repeated screenshot falloff probe improved the outer glow from 18 px versus 6 px (3.0x) to 16 px versus 15 px (1.07x) at 1440x900 and 720x980; the remaining pixel is raster rounding.
+12. The owner-set presentation defaults now start and reset Runes at 180% and Rims at 160%; Reset reads each control's declared default so the two channels retain their distinct values.
+13. The random-rune pass added one glyph-only mask and one shader overlay per register. Deterministic per-glyph clocks asynchronously select sparse runes, give them a fast white-hot ignition and slow colored decay, and remain coupled to the Runes dial. The animation adds four draw calls without rebuilding canvases or creating per-rune scene objects each frame.
+14. The premium-material correction removed the rejected flat-white, many-at-once pulse. Each mask now encodes an exact glyph ID so selection cannot fall between filtered symbols; every ring chooses one primary rune, occasionally favoring a larger major glyph. A radial highlight traverses the engraving in either direction, revealing a tempered bronze/silver charge behind it while edge sampling keeps the cut profile sharp. The Runes dial still scales the complete effect and 0% disables it.
+15. The rune-flicker correction enabled mipmapped anisotropic sampling for the rotating glyph mask and removed the narrow radial hot front that made disconnected strokes pop as it crossed them. The selected rune now charges as one eased engraved-metal surface. A 70-frame on/off browser probe reduced the illuminated-layer frame-jump ratio from 1.78x to 1.39x against a 1.45x limit.
 
 ## Findings
 

--- a/src/ui/components/home/MagicCircle.standalone.html
+++ b/src/ui/components/home/MagicCircle.standalone.html
@@ -41,6 +41,217 @@
         width: 100%;
         height: 100%;
       }
+
+      .glow-console {
+        position: absolute;
+        right: clamp(12px, 2vw, 28px);
+        bottom: clamp(12px, 2vw, 28px);
+        z-index: 3;
+        display: grid;
+        width: 236px;
+        gap: 12px;
+        padding: 12px 14px 14px;
+        color: #e8e5ee;
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+        background: rgba(4, 3, 11, 0.9);
+        border-radius: 14px;
+        box-shadow:
+          0 14px 42px rgba(0, 0, 0, 0.52),
+          inset 0 0 0 1px rgba(181, 129, 101, 0.24),
+          inset 0 1px 0 rgba(221, 210, 255, 0.08);
+        user-select: none;
+      }
+
+      .glow-console__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        min-height: 36px;
+      }
+
+      .glow-console__title {
+        margin: 0;
+        color: #ddd8e7;
+        font-size: 0.82rem;
+        font-weight: 650;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .glow-console__reset {
+        min-width: 56px;
+        min-height: 36px;
+        padding: 0 10px;
+        color: #aaa3b7;
+        font: inherit;
+        font-size: 0.62rem;
+        letter-spacing: 0.06em;
+        background: rgba(169, 187, 255, 0.045);
+        border: 1px solid rgba(169, 187, 255, 0.16);
+        border-radius: 8px;
+        cursor: pointer;
+        transition:
+          color 150ms ease,
+          background-color 150ms ease,
+          border-color 150ms ease;
+      }
+
+      .glow-console__reset:hover {
+        color: #e3e8f7;
+        background-color: rgba(169, 187, 255, 0.1);
+        border-color: rgba(169, 187, 255, 0.32);
+      }
+
+      .glow-console__reset:focus-visible {
+        outline: 2px solid #cbd9ff;
+        outline-offset: 2px;
+      }
+
+      .glow-console__dials {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 18px;
+      }
+
+      .glow-dial {
+        display: grid;
+        justify-items: center;
+        gap: 6px;
+      }
+
+      .glow-dial__label {
+        color: #beb8c8;
+        font-size: 0.62rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .glow-dial__control {
+        position: relative;
+        width: 76px;
+        height: 76px;
+        touch-action: none;
+      }
+
+      .glow-dial__input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        clip-path: inset(50%);
+      }
+
+      .glow-dial__face {
+        --dial-progress: 135deg;
+        --dial-angle: 0deg;
+        --dial-color: #ff9a55;
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        background: conic-gradient(
+          from 225deg,
+          var(--dial-color) 0deg var(--dial-progress),
+          rgba(115, 112, 137, 0.24) var(--dial-progress) 270deg,
+          transparent 270deg 360deg
+        );
+        box-shadow: 0 7px 16px rgba(0, 0, 0, 0.5);
+        cursor: ns-resize;
+      }
+
+      .glow-dial[data-tone='silver'] .glow-dial__face {
+        --dial-color: #a9bbff;
+      }
+
+      .glow-dial__face::before {
+        position: absolute;
+        inset: 7px;
+        content: '';
+        background: radial-gradient(circle at 42% 34%, #1d1a29 0%, #090811 58%, #030307 100%);
+        border-radius: inherit;
+        box-shadow:
+          inset 0 0 0 1px rgba(223, 217, 235, 0.12),
+          inset 0 -7px 14px rgba(0, 0, 0, 0.56);
+      }
+
+      .glow-dial__face::after {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        z-index: 2;
+        width: 7px;
+        height: 7px;
+        content: '';
+        background: #d9d5e0;
+        border-radius: 50%;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.62);
+        transform: translate(-50%, -50%);
+      }
+
+      .glow-dial__needle {
+        position: absolute;
+        inset: 9px;
+        z-index: 1;
+        pointer-events: none;
+        transform: rotate(var(--dial-angle));
+        transition: transform 110ms cubic-bezier(0.16, 1, 0.3, 1);
+      }
+
+      .glow-dial__needle::before {
+        position: absolute;
+        top: 0;
+        left: 50%;
+        width: 2px;
+        height: 15px;
+        content: '';
+        background: linear-gradient(to bottom, #ffffff, var(--dial-color));
+        border-radius: 2px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+        transform: translateX(-50%);
+      }
+
+      .glow-dial__input:focus-visible + .glow-dial__face {
+        outline: 2px solid #d3ddff;
+        outline-offset: 4px;
+      }
+
+      .glow-dial__value {
+        color: #e6e1ec;
+        font-size: 0.62rem;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0.02em;
+      }
+
+      @media (max-width: 560px), (max-height: 620px) {
+        .glow-console {
+          width: 214px;
+          gap: 9px;
+          padding: 9px 11px 11px;
+        }
+
+        .glow-console__dials {
+          gap: 12px;
+        }
+
+        .glow-dial__control {
+          width: 68px;
+          height: 68px;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .glow-dial__needle,
+        .glow-console__reset {
+          transition: none;
+        }
+      }
     </style>
     <script type="importmap">
       {
@@ -55,8 +266,8 @@
     <!--
       THESIS: A single ancient astrolabe fills the viewport; it refuses the chunky game-dial look.
       OWN-WORLD: Smoke bronze and moon-silver engravings float above restrained violet space, lit from within.
-      STORY: Four broad fate registers turn independently around an unreadable central aperture with no solid annular substrate.
-      FIRST VIEWPORT: One shallow oblique disc occupies roughly ninety percent of a landscape frame with no UI chrome.
+      STORY: Four broad fate registers turn independently around an unreadable central aperture while ordered energy motes surge along their paths.
+      FIRST VIEWPORT: One shallow oblique disc occupies roughly ninety percent of a landscape frame with a compact glow tuning console.
       FORM: Faithful reproduction of the supplied approved reference; seed key reference-b1121ab9.
       FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review, the verdict, and DESIGN.md
     -->
@@ -65,6 +276,54 @@
       aria-label="An ancient engraved obsidian astrolabe turning in a dark violet void"
     >
       <canvas id="magic-circle-canvas" aria-hidden="true"></canvas>
+      <aside class="glow-console" aria-label="Magic circle glow controls">
+        <div class="glow-console__header">
+          <h2 class="glow-console__title">Glow tuning</h2>
+          <button class="glow-console__reset" id="glow-reset" type="button">Reset</button>
+        </div>
+        <div class="glow-console__dials">
+          <label class="glow-dial" data-tone="bronze">
+            <span class="glow-dial__label">Runes</span>
+            <span class="glow-dial__control" data-dial-control>
+              <input
+                class="glow-dial__input"
+                id="letter-glow"
+                data-glow-channel="letters"
+                aria-label="Rune and pattern glow"
+                type="range"
+                min="0"
+                max="200"
+                step="1"
+                value="180"
+              />
+              <span class="glow-dial__face" aria-hidden="true">
+                <span class="glow-dial__needle"></span>
+              </span>
+            </span>
+            <output class="glow-dial__value" for="letter-glow">180%</output>
+          </label>
+          <label class="glow-dial" data-tone="silver">
+            <span class="glow-dial__label">Rims</span>
+            <span class="glow-dial__control" data-dial-control>
+              <input
+                class="glow-dial__input"
+                id="rim-glow"
+                data-glow-channel="rims"
+                aria-label="Rim glow"
+                type="range"
+                min="0"
+                max="200"
+                step="1"
+                value="160"
+              />
+              <span class="glow-dial__face" aria-hidden="true">
+                <span class="glow-dial__needle"></span>
+              </span>
+            </span>
+            <output class="glow-dial__value" for="rim-glow">160%</output>
+          </label>
+        </div>
+      </aside>
     </main>
 
     <script type="module">
@@ -80,6 +339,7 @@
       const TAU = Math.PI * 2;
       const canvas = document.querySelector('#magic-circle-canvas');
       const stage = document.querySelector('.magic-circle-stage');
+      const glowSettings = { letters: 1.8, rims: 1.6 };
       const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
       const random = mulberry32(0xb1121ab9);
 
@@ -111,6 +371,9 @@
 
       const camera = new THREE.PerspectiveCamera(10.5, 1, 0.08, 100);
       const cameraTarget = new THREE.Vector3(0, 0.03, 0);
+      const outerGlowProjectionSample = new THREE.Vector3(0, -0.075, 4.33);
+      const outerGlowProjectionSampleInward = new THREE.Vector3(0, -0.075, 4.32);
+      const referenceOuterGlowPixelsPerWorld = 108.1;
       const cameraDirection = new THREE.Vector3(
         0,
         Math.sin(THREE.MathUtils.degToRad(36.5)),
@@ -120,7 +383,7 @@
       const composer = new EffectComposer(renderer);
       composer.addPass(new RenderPass(scene, camera));
 
-      const bloom = new UnrealBloomPass(new THREE.Vector2(1, 1), 0.38, 0.48, 0.56);
+      const bloom = new UnrealBloomPass(new THREE.Vector2(1, 1), 0.42, 0.52, 0.52);
       composer.addPass(bloom);
 
       const gradePass = new ShaderPass({
@@ -190,7 +453,15 @@
       const materials = createMaterials();
       const motionTracks = [];
       const energyTracks = [];
+      const runeIgnitionTracks = [];
       const energyUniformTracks = [];
+      const energySurgeTracks = [];
+      const rimEnergyStrengthTracks = [];
+      const screenSpaceTextureGlows = [];
+      const screenSpaceRimHalos = [];
+      let screenGlowScale = 1;
+
+      setupGlowControls();
 
       const nebula = createNebulaDome();
       scene.add(nebula.mesh);
@@ -300,6 +571,12 @@
 
       const aperture = createAperture();
       astrolabe.add(aperture.group);
+
+      const particleField = createParticleField();
+      astrolabe.add(particleField.points);
+
+      const orbitStreaks = createOrbitStreaks();
+      astrolabe.add(orbitStreaks.mesh);
 
       const glints = createGlints();
       astrolabe.add(glints.group);
@@ -419,7 +696,7 @@
           map: texture.userData.glowTexture,
           color: config.color === 'bronze' ? palette.bronzeEnergy : palette.silverEnergy,
           transparent: true,
-          opacity: (config.color === 'bronze' ? 0.46 : 0.41) * registerEnergyScale,
+          opacity: (config.color === 'bronze' ? 0.58 : 0.54) * registerEnergyScale,
           side: THREE.DoubleSide,
           depthWrite: false,
           blending: THREE.AdditiveBlending,
@@ -437,10 +714,29 @@
         energyTracks.push({
           material: runeGlowMaterial,
           property: 'opacity',
+          channel: 'letters',
           base: runeGlowMaterial.opacity,
-          amplitude: 0.018,
+          amplitude: 0.025,
           phase: index * 1.71 + 0.4,
           speed: 0.24 + index * 0.017,
+        });
+
+        const runeIgnitionMaterial = createRuneIgnitionMaterial(
+          texture.userData.glyphTexture,
+          texture.userData.glyphCount,
+          config,
+          index,
+        );
+        const runeIgnition = new THREE.Mesh(engraving.geometry, runeIgnitionMaterial);
+        runeIgnition.rotation.x = -Math.PI / 2;
+        runeIgnition.position.y = 0.021;
+        runeIgnition.scale.setScalar(1.0008);
+        runeIgnition.renderOrder = 3;
+        group.add(runeIgnition);
+        runeIgnitionTracks.push({
+          time: runeIgnitionMaterial.uniforms.uTime,
+          strength: runeIgnitionMaterial.uniforms.uStrength,
+          base: registerEnergyScale,
         });
 
         return group;
@@ -453,6 +749,10 @@
         textureCanvas.width = size;
         textureCanvas.height = size;
         const context = textureCanvas.getContext('2d');
+        const glyphCanvas = document.createElement('canvas');
+        glyphCanvas.width = size;
+        glyphCanvas.height = size;
+        const glyphContext = glyphCanvas.getContext('2d');
         const layerRandom = mulberry32(0x9173a1 + layerIndex * 701);
         const color = config.color === 'bronze' ? '#ad7657' : '#9eacc8';
         const highlight = config.color === 'bronze' ? '#d2a080' : '#d3dced';
@@ -469,6 +769,8 @@
         context.strokeStyle = color;
         context.shadowColor = color;
         context.shadowBlur = config.color === 'silver' ? 1.4 : 0.8;
+        glyphContext.clearRect(0, 0, size, size);
+        glyphContext.translate(center, center);
 
         context.globalAlpha = 0.78;
         const runeAlphabet = Array.from('ᚠᚢᚦᚨᚱᚲᚷᚹᚺᚾᛁᛃᛇᛈᛉᛋᛏᛒᛖᛗᛚᛜᛞᛟ');
@@ -477,17 +779,30 @@
           const angle = (glyphIndex / glyphCount) * TAU;
           const major = glyphIndex % 11 === 0;
           const wobble = (layerRandom() - 0.5) * bandPixels * 0.08;
+          const glyph = runeAlphabet[(glyphIndex + layerIndex * 5) % runeAlphabet.length];
+          const font = `${major ? 600 : 500} ${glyphScale * (major ? 1.82 : 1.58)}px "Segoe UI Historic", "Segoe UI Symbol", serif`;
           context.save();
           context.rotate(angle);
           context.translate(0, -midPixel - wobble);
           context.globalAlpha = (major ? 0.9 : 0.5) + layerRandom() * (major ? 0.1 : 0.42);
           context.fillStyle = major ? highlight : color;
-          context.font = `${major ? 600 : 500} ${glyphScale * (major ? 1.82 : 1.58)}px "Segoe UI Historic", "Segoe UI Symbol", serif`;
+          context.font = font;
           context.textAlign = 'center';
           context.textBaseline = 'middle';
           context.shadowBlur = major ? 2.2 : 0.8;
-          context.fillText(runeAlphabet[(glyphIndex + layerIndex * 5) % runeAlphabet.length], 0, 0);
+          context.fillText(glyph, 0, 0);
           context.restore();
+
+          glyphContext.save();
+          glyphContext.rotate(angle);
+          glyphContext.translate(0, -midPixel - wobble);
+          glyphContext.globalAlpha = 1;
+          glyphContext.fillStyle = `rgb(${glyphIndex + 1}, 0, 0)`;
+          glyphContext.font = font;
+          glyphContext.textAlign = 'center';
+          glyphContext.textBaseline = 'middle';
+          glyphContext.fillText(glyph, 0, 0);
+          glyphContext.restore();
         }
 
         const tickCount = config.ticks ? glyphCount * 2 : glyphCount;
@@ -528,20 +843,193 @@
         texture.minFilter = THREE.LinearMipmapLinearFilter;
         texture.needsUpdate = true;
 
+        const glyphTexture = new THREE.CanvasTexture(glyphCanvas);
+        glyphTexture.anisotropy = Math.min(8, renderer.capabilities.getMaxAnisotropy());
+        glyphTexture.minFilter = THREE.LinearMipmapLinearFilter;
+        glyphTexture.magFilter = THREE.LinearFilter;
+        glyphTexture.needsUpdate = true;
+
+        texture.userData.glowTexture = createScreenSpaceGlowTexture(
+          texture,
+          config.color === 'bronze' ? 9 : 8,
+        );
+        texture.userData.glyphTexture = glyphTexture;
+        texture.userData.glyphCount = glyphCount;
+        return texture;
+      }
+
+      function createRuneIgnitionMaterial(glyphTexture, glyphCount, config, layerIndex) {
+        const textureSize = glyphTexture.image.width;
+        const bandOuter = (textureSize * 0.5 - 5) / textureSize;
+        const energyColor =
+          config.color === 'bronze'
+            ? palette.bronzeEnergy.clone().lerp(palette.bronzeLight, 0.28)
+            : palette.silverEnergy.clone().lerp(palette.silverLight, 0.24);
+        const hotColor =
+          config.color === 'bronze'
+            ? palette.bronzeLight.clone().lerp(palette.coldWhite, 0.68)
+            : palette.silverLight.clone().lerp(palette.coldWhite, 0.82);
+
+        return new THREE.ShaderMaterial({
+          uniforms: {
+            uGlyphMap: { value: glyphTexture },
+            uTime: { value: 0 },
+            uStrength: { value: 0 },
+            uSeed: { value: 17.31 + layerIndex * 29.17 },
+            uGlyphCount: { value: glyphCount },
+            uCycleSeconds: { value: 5.1 + layerIndex * 0.83 },
+            uBandInner: { value: (config.inner / config.outer) * bandOuter },
+            uBandOuter: { value: bandOuter },
+            uTexel: { value: new THREE.Vector2(1 / textureSize, 1 / textureSize) },
+            uColor: { value: energyColor },
+            uHotColor: { value: hotColor },
+          },
+          vertexShader: /* glsl */ `
+            varying vec2 vUv;
+
+            void main() {
+              vUv = uv;
+              gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+          `,
+          fragmentShader: /* glsl */ `
+            uniform sampler2D uGlyphMap;
+            uniform float uTime;
+            uniform float uStrength;
+            uniform float uSeed;
+            uniform float uGlyphCount;
+            uniform float uCycleSeconds;
+            uniform float uBandInner;
+            uniform float uBandOuter;
+            uniform vec2 uTexel;
+            uniform vec3 uColor;
+            uniform vec3 uHotColor;
+            varying vec2 vUv;
+
+            float hash11(float value) {
+              return fract(sin(value * 127.1 + 311.7) * 43758.5453123);
+            }
+
+            void main() {
+              vec4 glyphSample = texture2D(uGlyphMap, vUv);
+              float glyphAlpha = glyphSample.a;
+              if (glyphAlpha < 0.02 || uStrength < 0.002) discard;
+              float encodedGlyph = glyphSample.r / max(glyphAlpha, 0.001);
+              float glyphIndex = clamp(
+                floor(encodedGlyph * 255.0 + 0.5) - 1.0,
+                0.0,
+                uGlyphCount - 1.0
+              );
+
+              float neighborLeft = texture2D(uGlyphMap, vUv - vec2(uTexel.x, 0.0)).a;
+              float neighborRight = texture2D(uGlyphMap, vUv + vec2(uTexel.x, 0.0)).a;
+              float neighborDown = texture2D(uGlyphMap, vUv - vec2(0.0, uTexel.y)).a;
+              float neighborUp = texture2D(uGlyphMap, vUv + vec2(0.0, uTexel.y)).a;
+              float interior = min(
+                glyphAlpha,
+                min(min(neighborLeft, neighborRight), min(neighborDown, neighborUp))
+              );
+              float engravedEdge = clamp(glyphAlpha - interior * 0.88, 0.0, 1.0);
+
+              vec2 centered = vUv - 0.5;
+              float localClock = uTime / uCycleSeconds + fract(uSeed * 0.113) * 7.0;
+              float epoch = floor(localClock);
+              float life = fract(localClock);
+              float eventSeed = hash11(epoch * 73.17 + uSeed * 5.13);
+              float arbitraryGlyph = floor(eventSeed * uGlyphCount);
+              float majorCount = floor((uGlyphCount - 1.0) / 11.0) + 1.0;
+              float majorGlyph = min(
+                uGlyphCount - 1.0,
+                floor(hash11(epoch * 91.37 + uSeed * 2.71) * majorCount) * 11.0
+              );
+              float favorMajor = step(0.58, hash11(epoch * 43.19 + uSeed * 7.23));
+              float targetGlyph = mix(arbitraryGlyph, majorGlyph, favorMajor);
+              float selected = 1.0 - step(0.5, abs(glyphIndex - targetGlyph));
+
+              float attack = smoothstep(0.04, 0.2, life);
+              float release = 1.0 - smoothstep(0.62, 0.96, life);
+              float envelope = selected * attack * release;
+              if (envelope < 0.002) discard;
+
+              float radial = clamp(
+                (length(centered) - uBandInner) / max(0.001, uBandOuter - uBandInner),
+                0.0,
+                1.0
+              );
+              float eventSignature = hash11(epoch * 31.71 + uSeed * 9.41);
+              float radialPatina = mix(0.92, 1.08, radial);
+              float chargeVariation = mix(0.92, 1.08, eventSignature);
+              float metalVein =
+                (0.52 + interior * 0.16 + engravedEdge * 0.34) *
+                radialPatina * chargeVariation;
+              float hotVein = interior * 0.1 + engravedEdge * 0.38;
+              vec3 radiance = uColor * metalVein * 2.1 + uHotColor * hotVein * 1.9;
+              float dial = min(uStrength, 2.0);
+              float alpha = clamp(
+                envelope * dial * glyphAlpha *
+                  (0.5 + interior * 0.12 + engravedEdge * 0.18),
+                0.0,
+                0.86
+              );
+              gl_FragColor = vec4(radiance * (1.08 + dial * 0.44), alpha);
+            }
+          `,
+          transparent: true,
+          side: THREE.DoubleSide,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+          toneMapped: false,
+        });
+      }
+
+      function createScreenSpaceGlowTexture(sourceTexture, blurPixels, alpha = 1) {
+        const source = sourceTexture.image;
         const glowCanvas = document.createElement('canvas');
-        glowCanvas.width = size;
-        glowCanvas.height = size;
+        glowCanvas.width = source.width;
+        glowCanvas.height = source.height;
         const glowContext = glowCanvas.getContext('2d');
-        glowContext.filter = config.color === 'bronze' ? 'blur(7px)' : 'blur(6px)';
-        glowContext.globalAlpha = config.color === 'bronze' ? 0.98 : 0.94;
-        glowContext.drawImage(textureCanvas, 0, 0);
+        glowContext.filter = `blur(${blurPixels * screenGlowScale}px)`;
+        glowContext.globalAlpha = alpha;
+        glowContext.drawImage(source, 0, 0);
+
         const glowTexture = new THREE.CanvasTexture(glowCanvas);
         glowTexture.colorSpace = THREE.SRGBColorSpace;
         glowTexture.anisotropy = Math.min(4, renderer.capabilities.getMaxAnisotropy());
         glowTexture.generateMipmaps = false;
         glowTexture.minFilter = THREE.LinearFilter;
-        texture.userData.glowTexture = glowTexture;
-        return texture;
+        glowTexture.magFilter = THREE.LinearFilter;
+        screenSpaceTextureGlows.push({
+          source,
+          canvas: glowCanvas,
+          context: glowContext,
+          texture: glowTexture,
+          blurPixels,
+          alpha,
+        });
+        return glowTexture;
+      }
+
+      function updateScreenSpaceGlowScale(nextScale) {
+        if (Math.abs(nextScale - screenGlowScale) < 0.015) return;
+        screenGlowScale = nextScale;
+
+        for (const glow of screenSpaceTextureGlows) {
+          glow.context.clearRect(0, 0, glow.canvas.width, glow.canvas.height);
+          glow.context.filter = `blur(${glow.blurPixels * screenGlowScale}px)`;
+          glow.context.globalAlpha = glow.alpha;
+          glow.context.drawImage(glow.source, 0, 0);
+          glow.texture.needsUpdate = true;
+        }
+
+        for (const halo of screenSpaceRimHalos) {
+          halo.mesh.geometry.dispose();
+          halo.mesh.geometry = new THREE.TorusGeometry(
+            halo.radius,
+            halo.tube * screenGlowScale,
+            halo.radialSegments,
+            halo.tubularSegments,
+          );
+        }
       }
 
       function drawRune(context, index, scale) {
@@ -636,8 +1124,25 @@
         const group = new THREE.Group();
         group.position.y = 0.325;
         const texture = createSigilFieldTexture();
+        const glowMaterial = new THREE.MeshBasicMaterial({
+          map: createScreenSpaceGlowTexture(texture, 13),
+          transparent: true,
+          opacity: 0.54,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false,
+          depthTest: true,
+          toneMapped: false,
+          side: THREE.DoubleSide,
+        });
+        const geometry = new THREE.CircleGeometry(4.98, 256);
+        const glow = new THREE.Mesh(geometry, glowMaterial);
+        glow.rotation.x = -Math.PI / 2;
+        glow.position.y = -0.007;
+        glow.renderOrder = 3;
+        group.add(glow);
+
         const material = new THREE.MeshBasicMaterial({
-          map: texture,
+          map: createScreenSpaceGlowTexture(texture, 15),
           transparent: true,
           opacity: 0.44,
           blending: THREE.NormalBlending,
@@ -645,10 +1150,19 @@
           toneMapped: false,
           side: THREE.DoubleSide,
         });
-        const mesh = new THREE.Mesh(new THREE.CircleGeometry(4.98, 256), material);
+        const mesh = new THREE.Mesh(geometry, material);
         mesh.rotation.x = -Math.PI / 2;
         mesh.renderOrder = 4;
         group.add(mesh);
+        energyTracks.push({
+          material: glowMaterial,
+          property: 'opacity',
+          channel: 'letters',
+          base: glowMaterial.opacity,
+          amplitude: 0.04,
+          phase: 1.8,
+          speed: 0.2,
+        });
         return group;
       }
 
@@ -841,6 +1355,24 @@
         const group = new THREE.Group();
         group.position.y = 0.355;
         const texture = createFiligreeTexture();
+        const glowMaterial = new THREE.MeshBasicMaterial({
+          map: texture,
+          color: 0xd3dcff,
+          transparent: true,
+          opacity: 0.66,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false,
+          depthTest: true,
+          toneMapped: false,
+          side: THREE.DoubleSide,
+        });
+        const geometry = new THREE.CircleGeometry(2.92, 256);
+        const glow = new THREE.Mesh(geometry, glowMaterial);
+        glow.rotation.x = -Math.PI / 2;
+        glow.position.y = -0.008;
+        glow.renderOrder = 4;
+        group.add(glow);
+
         const material = new THREE.MeshBasicMaterial({
           map: texture,
           transparent: true,
@@ -850,10 +1382,19 @@
           toneMapped: false,
           side: THREE.DoubleSide,
         });
-        const mesh = new THREE.Mesh(new THREE.CircleGeometry(2.92, 256), material);
+        const mesh = new THREE.Mesh(geometry, material);
         mesh.rotation.x = -Math.PI / 2;
         mesh.renderOrder = 5;
         group.add(mesh);
+        energyTracks.push({
+          material: glowMaterial,
+          property: 'opacity',
+          channel: 'letters',
+          base: glowMaterial.opacity,
+          amplitude: 0.055,
+          phase: 0.7,
+          speed: 0.23,
+        });
         return group;
       }
 
@@ -1082,7 +1623,7 @@
 
         const tickTexture = createApertureTickTexture();
         const tickMaterial = new THREE.MeshBasicMaterial({
-          map: tickTexture,
+          map: createScreenSpaceGlowTexture(tickTexture, 11),
           transparent: true,
           opacity: 0.94,
           depthWrite: false,
@@ -1091,8 +1632,27 @@
         });
         const tickGroup = new THREE.Group();
         tickGroup.position.y = 0.015;
-        const ticks = new THREE.Mesh(new THREE.RingGeometry(1.03, 1.27, 192, 1), tickMaterial);
+        const tickRingGeometry = new THREE.RingGeometry(1.03, 1.27, 192, 1);
+        const tickGlowMaterial = new THREE.MeshBasicMaterial({
+          map: tickTexture,
+          color: 0xcbd9ff,
+          transparent: true,
+          opacity: 0.7,
+          depthWrite: false,
+          depthTest: true,
+          blending: THREE.AdditiveBlending,
+          toneMapped: false,
+          side: THREE.DoubleSide,
+        });
+        const tickGlow = new THREE.Mesh(tickRingGeometry, tickGlowMaterial);
+        tickGlow.rotation.x = -Math.PI / 2;
+        tickGlow.position.y = -0.007;
+        tickGlow.renderOrder = 5;
+        tickGroup.add(tickGlow);
+
+        const ticks = new THREE.Mesh(tickRingGeometry, tickMaterial);
         ticks.rotation.x = -Math.PI / 2;
+        ticks.renderOrder = 6;
         tickGroup.add(ticks);
 
         const tickPositions = [];
@@ -1114,13 +1674,24 @@
         const tickLines = new THREE.LineSegments(
           tickGeometry,
           new THREE.LineBasicMaterial({
-            color: 0xb9c7df,
+            color: 0xd8e4ff,
             transparent: true,
-            opacity: 0.7,
+            opacity: 0.78,
             depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            toneMapped: false,
           }),
         );
         tickGroup.add(tickLines);
+        energyTracks.push({
+          material: tickGlowMaterial,
+          property: 'opacity',
+          channel: 'letters',
+          base: tickGlowMaterial.opacity,
+          amplitude: 0.065,
+          phase: 2.4,
+          speed: 0.27,
+        });
         group.add(tickGroup);
         motionTracks.push({
           group: tickGroup,
@@ -1227,6 +1798,294 @@
         });
 
         return { group, items };
+      }
+
+      function createParticleField() {
+        const particleCount = 620;
+        const positions = new Float32Array(particleCount * 3);
+        const colors = new Float32Array(particleCount * 3);
+        const radii = new Float32Array(particleCount);
+        const angles = new Float32Array(particleCount);
+        const speeds = new Float32Array(particleCount);
+        const heights = new Float32Array(particleCount);
+        const lifts = new Float32Array(particleCount);
+        const sizes = new Float32Array(particleCount);
+        const opacities = new Float32Array(particleCount);
+        const phases = new Float32Array(particleCount);
+        const types = new Float32Array(particleCount);
+        const particleRandom = mulberry32(0x66d7a319);
+        const bandRadii = [1.08, 2.06, 3.0, 4.0, 5.06];
+        const bandTones = ['silver', 'silver', 'bronze', 'silver', 'bronze'];
+        const violetParticle = new THREE.Color(0x9f73ff);
+        const whiteParticle = new THREE.Color(0xf5f2ff);
+
+        for (let index = 0; index < particleCount; index += 1) {
+          const type = index < 360 ? 0 : index < 545 ? 1 : 2;
+          const bandIndex = Math.floor(particleRandom() * bandRadii.length);
+          const direction = bandIndex % 2 === 0 ? 1 : -1;
+          const tone = bandTones[bandIndex];
+          const baseColor = (
+            tone === 'bronze' ? palette.bronzeEnergy : palette.silverEnergy
+          ).clone();
+
+          types[index] = type;
+          angles[index] = particleRandom() * TAU;
+          phases[index] = particleRandom() * TAU;
+
+          if (type === 0) {
+            radii[index] = bandRadii[bandIndex] + (particleRandom() - 0.5) * 0.3;
+            speeds[index] = direction * (0.012 + particleRandom() * 0.025);
+            heights[index] = 0.14 + particleRandom() * 0.42 + bandIndex * 0.018;
+            lifts[index] = 0.025 + particleRandom() * 0.09;
+            sizes[index] = 0.52 + particleRandom() * 1.05;
+            opacities[index] = 0.13 + particleRandom() * 0.23;
+          } else if (type === 1) {
+            radii[index] = bandRadii[bandIndex] + (particleRandom() - 0.5) * 0.22;
+            speeds[index] = direction * (0.02 + particleRandom() * 0.034);
+            heights[index] = 0.2 + particleRandom() * 0.68;
+            lifts[index] = 0.07 + particleRandom() * 0.18;
+            sizes[index] = 1.15 + particleRandom() * 1.9;
+            opacities[index] = 0.26 + particleRandom() * 0.45;
+          } else {
+            radii[index] = 0.96 + particleRandom() * 0.72;
+            speeds[index] = (particleRandom() > 0.5 ? 1 : -1) * (0.018 + particleRandom() * 0.024);
+            heights[index] = 0.16;
+            lifts[index] = 1.05 + particleRandom() * 0.85;
+            sizes[index] = 0.9 + particleRandom() * 1.65;
+            opacities[index] = 0.24 + particleRandom() * 0.38;
+            baseColor.copy(violetParticle).lerp(palette.silverEnergy, particleRandom() * 0.7);
+          }
+
+          if (particleRandom() > 0.9) {
+            baseColor.lerp(whiteParticle, 0.58);
+          }
+          colors.set([baseColor.r, baseColor.g, baseColor.b], index * 3);
+        }
+
+        const geometry = new THREE.BufferGeometry();
+        geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.setAttribute('aColor', new THREE.BufferAttribute(colors, 3));
+        geometry.setAttribute('aRadius', new THREE.BufferAttribute(radii, 1));
+        geometry.setAttribute('aAngle', new THREE.BufferAttribute(angles, 1));
+        geometry.setAttribute('aSpeed', new THREE.BufferAttribute(speeds, 1));
+        geometry.setAttribute('aHeight', new THREE.BufferAttribute(heights, 1));
+        geometry.setAttribute('aLift', new THREE.BufferAttribute(lifts, 1));
+        geometry.setAttribute('aSize', new THREE.BufferAttribute(sizes, 1));
+        geometry.setAttribute('aOpacity', new THREE.BufferAttribute(opacities, 1));
+        geometry.setAttribute('aPhase', new THREE.BufferAttribute(phases, 1));
+        geometry.setAttribute('aType', new THREE.BufferAttribute(types, 1));
+
+        const uniforms = {
+          uTime: { value: 0 },
+          uPixelRatio: { value: 1 },
+          uSurge: { value: 0 },
+        };
+        const material = new THREE.ShaderMaterial({
+          uniforms,
+          transparent: true,
+          depthWrite: false,
+          depthTest: true,
+          blending: THREE.AdditiveBlending,
+          toneMapped: false,
+          vertexShader: /* glsl */ `
+            uniform float uTime;
+            uniform float uPixelRatio;
+            uniform float uSurge;
+            attribute vec3 aColor;
+            attribute float aRadius;
+            attribute float aAngle;
+            attribute float aSpeed;
+            attribute float aHeight;
+            attribute float aLift;
+            attribute float aSize;
+            attribute float aOpacity;
+            attribute float aPhase;
+            attribute float aType;
+            varying vec3 vColor;
+            varying float vAlpha;
+            varying float vHeat;
+
+            void main() {
+              float angle = aAngle + uTime * aSpeed;
+              float radius = aRadius + sin(uTime * 0.14 + aPhase) * 0.045;
+              float height = aHeight + sin(uTime * 0.37 + aPhase) * aLift;
+              float opacity = aOpacity;
+              float rise = 0.0;
+
+              if (aType > 1.5) {
+                rise = fract(aPhase / 6.28318530718 + uTime * (0.018 + abs(aSpeed) * 0.3));
+                radius += sin(uTime * 0.22 + aPhase + rise * 5.0) * 0.14;
+                height = aHeight + rise * aLift;
+                opacity *= smoothstep(0.0, 0.14, rise) * (1.0 - smoothstep(0.7, 1.0, rise));
+              } else if (aType > 0.5) {
+                radius += sin(uTime * 0.26 + aPhase * 1.7) * 0.075;
+              }
+
+              float waveRadius = mod(uTime * 0.34, 5.9);
+              float radialWave = exp(-pow((aRadius - waveRadius) * 1.85, 2.0));
+              vec3 localPosition = vec3(cos(angle) * radius, height, sin(angle) * radius);
+              vec4 viewPosition = modelViewMatrix * vec4(localPosition, 1.0);
+              float perspective = 78.0 / max(-viewPosition.z, 1.0);
+              float pointScale = 1.0 + radialWave * 1.35 + uSurge * 0.42;
+
+              gl_Position = projectionMatrix * viewPosition;
+              gl_PointSize = clamp(aSize * pointScale * uPixelRatio * perspective, 0.7, 15.0);
+              vColor = mix(aColor, vec3(1.0), radialWave * 0.36 + uSurge * 0.12);
+              vAlpha = opacity * (1.0 + radialWave * 1.15 + uSurge * 0.5);
+              vHeat = max(radialWave, uSurge * 0.7) + (aType > 0.5 ? 0.16 : 0.0);
+            }
+          `,
+          fragmentShader: /* glsl */ `
+            varying vec3 vColor;
+            varying float vAlpha;
+            varying float vHeat;
+
+            void main() {
+              vec2 point = gl_PointCoord - 0.5;
+              float radius = length(point) * 2.0;
+              if (radius > 1.0) discard;
+              float halo = pow(max(1.0 - radius, 0.0), 2.35);
+              float core = smoothstep(0.34, 0.0, radius);
+              vec3 color = mix(vColor, vec3(1.0), core * (0.56 + vHeat * 0.18));
+              float alpha = halo * vAlpha;
+              if (alpha < 0.004) discard;
+              gl_FragColor = vec4(color, alpha);
+            }
+          `,
+        });
+
+        const points = new THREE.Points(geometry, material);
+        points.frustumCulled = false;
+        points.renderOrder = 7;
+        return { points, uniforms };
+      }
+
+      function createOrbitStreaks() {
+        const streakCount = 72;
+        const bandRadii = [1.08, 2.06, 3, 4, 5.06];
+        const bandTones = ['silver', 'silver', 'bronze', 'silver', 'bronze'];
+        const streakRandom = mulberry32(0xb72ea951);
+        const angles = new Float32Array(streakCount);
+        const radii = new Float32Array(streakCount);
+        const speeds = new Float32Array(streakCount);
+        const heights = new Float32Array(streakCount);
+        const lengths = new Float32Array(streakCount);
+        const widths = new Float32Array(streakCount);
+        const phases = new Float32Array(streakCount);
+        const opacities = new Float32Array(streakCount);
+        const colors = new Float32Array(streakCount * 3);
+
+        for (let index = 0; index < streakCount; index += 1) {
+          const bandIndex = Math.floor(streakRandom() * bandRadii.length);
+          const direction = bandIndex % 2 === 0 ? 1 : -1;
+          const tone = bandTones[bandIndex];
+          const color = (tone === 'bronze' ? palette.bronzeEnergy : palette.silverEnergy).clone();
+
+          if (streakRandom() > 0.82) {
+            color.lerp(palette.coldWhite, 0.52);
+          } else if (bandIndex === 0 && streakRandom() > 0.58) {
+            color.lerp(new THREE.Color(0xa477ff), 0.34);
+          }
+
+          angles[index] = streakRandom() * TAU;
+          radii[index] = bandRadii[bandIndex] + (streakRandom() - 0.5) * 0.16;
+          speeds[index] = direction * (0.018 + streakRandom() * 0.036);
+          heights[index] = 0.26 + streakRandom() * 0.56 + bandIndex * 0.018;
+          lengths[index] = 0.16 + streakRandom() * 0.42;
+          widths[index] = 0.018 + streakRandom() * 0.036;
+          phases[index] = streakRandom() * TAU;
+          opacities[index] = 0.28 + streakRandom() * 0.46;
+          colors.set([color.r, color.g, color.b], index * 3);
+        }
+
+        const plane = new THREE.PlaneGeometry(1, 1, 1, 1);
+        const geometry = new THREE.InstancedBufferGeometry();
+        geometry.setIndex(plane.index.clone());
+        geometry.setAttribute('position', plane.attributes.position.clone());
+        geometry.setAttribute('uv', plane.attributes.uv.clone());
+        geometry.setAttribute('aAngle', new THREE.InstancedBufferAttribute(angles, 1));
+        geometry.setAttribute('aRadius', new THREE.InstancedBufferAttribute(radii, 1));
+        geometry.setAttribute('aSpeed', new THREE.InstancedBufferAttribute(speeds, 1));
+        geometry.setAttribute('aHeight', new THREE.InstancedBufferAttribute(heights, 1));
+        geometry.setAttribute('aLength', new THREE.InstancedBufferAttribute(lengths, 1));
+        geometry.setAttribute('aWidth', new THREE.InstancedBufferAttribute(widths, 1));
+        geometry.setAttribute('aPhase', new THREE.InstancedBufferAttribute(phases, 1));
+        geometry.setAttribute('aOpacity', new THREE.InstancedBufferAttribute(opacities, 1));
+        geometry.setAttribute('aColor', new THREE.InstancedBufferAttribute(colors, 3));
+        geometry.instanceCount = streakCount;
+        plane.dispose();
+
+        const uniforms = {
+          uTime: { value: 0 },
+          uSurge: { value: 0 },
+        };
+        const material = new THREE.ShaderMaterial({
+          uniforms,
+          transparent: true,
+          depthWrite: false,
+          depthTest: true,
+          side: THREE.DoubleSide,
+          blending: THREE.AdditiveBlending,
+          toneMapped: false,
+          vertexShader: /* glsl */ `
+            uniform float uTime;
+            uniform float uSurge;
+            attribute float aAngle;
+            attribute float aRadius;
+            attribute float aSpeed;
+            attribute float aHeight;
+            attribute float aLength;
+            attribute float aWidth;
+            attribute float aPhase;
+            attribute float aOpacity;
+            attribute vec3 aColor;
+            varying vec2 vUv;
+            varying vec3 vColor;
+            varying float vAlpha;
+            varying float vHeat;
+
+            void main() {
+              float angle = aAngle + uTime * aSpeed + sin(uTime * 0.17 + aPhase) * 0.012;
+              float direction = aSpeed < 0.0 ? -1.0 : 1.0;
+              float height = aHeight + sin(uTime * 0.3 + aPhase) * 0.07;
+              float pulse = sin(uTime * 0.62 + aPhase) * 0.5 + 0.5;
+              vec3 radial = vec3(cos(angle), 0.0, sin(angle));
+              vec3 tangent = vec3(-sin(angle), 0.0, cos(angle)) * direction;
+              vec3 localPosition =
+                radial * (aRadius + position.y * aWidth * (1.0 + uSurge * 0.32)) +
+                tangent * (position.x * aLength * (0.86 + pulse * 0.18 + uSurge * 0.22));
+              localPosition.y = height + position.y * aWidth * 0.32;
+
+              vUv = uv;
+              vColor = mix(aColor, vec3(1.0), uSurge * 0.16);
+              vAlpha = aOpacity * (0.76 + pulse * 0.24 + uSurge * 0.48);
+              vHeat = pulse * 0.45 + uSurge * 0.8;
+              gl_Position = projectionMatrix * modelViewMatrix * vec4(localPosition, 1.0);
+            }
+          `,
+          fragmentShader: /* glsl */ `
+            varying vec2 vUv;
+            varying vec3 vColor;
+            varying float vAlpha;
+            varying float vHeat;
+
+            void main() {
+              float edge = pow(max(sin(vUv.y * 3.14159265359), 0.0), 1.8);
+              float tail = smoothstep(0.0, 0.16, vUv.x) * (1.0 - smoothstep(0.86, 1.0, vUv.x));
+              float head = exp(-pow((vUv.x - 0.78) * 7.2, 2.0));
+              float energy = edge * tail * (0.34 + vUv.x * 0.66) + edge * head * 0.72;
+              float alpha = energy * vAlpha;
+              if (alpha < 0.006) discard;
+              vec3 color = mix(vColor, vec3(1.0), head * (0.5 + vHeat * 0.18));
+              gl_FragColor = vec4(color, alpha);
+            }
+          `,
+        });
+
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.frustumCulled = false;
+        mesh.renderOrder = 8;
+        return { mesh, uniforms };
       }
 
       function createNebulaDome() {
@@ -1472,6 +2331,7 @@
             uTime: { value: 0 },
             uPhase: { value: phase },
             uIntensity: { value: intensity },
+            uSurge: { value: 0 },
             uCoreColor: { value: coreColor },
             uHotColor: { value: hotColor },
           },
@@ -1492,6 +2352,7 @@
             uniform float uTime;
             uniform float uPhase;
             uniform float uIntensity;
+            uniform float uSurge;
             uniform vec3 uCoreColor;
             uniform vec3 uHotColor;
             varying vec2 vUv;
@@ -1502,13 +2363,20 @@
               float fine = sin(angle * 11.0 + uTime * 0.11 - uPhase * 1.7) * 0.5 + 0.5;
               float energy = pow(clamp(broad * 0.74 + fine * 0.26, 0.0, 1.0), 7.0);
               float crossSection = pow(sin(vUv.y * 3.14159265359), 0.72);
-              float alpha = (0.05 + energy * 0.86) * crossSection * uIntensity;
+              float alpha = (0.05 + energy * 0.86) * crossSection * uIntensity *
+                (1.0 + uSurge * 0.72);
               vec3 color = mix(uCoreColor, uHotColor, energy * 0.86);
+              color = mix(color, uHotColor, uSurge * 0.28);
               gl_FragColor = vec4(color, alpha);
             }
           `,
         });
         energyUniformTracks.push(material.uniforms.uTime);
+        energySurgeTracks.push(material.uniforms.uSurge);
+        rimEnergyStrengthTracks.push({
+          uniform: material.uniforms.uIntensity,
+          base: intensity,
+        });
         return material;
       }
 
@@ -1578,6 +2446,13 @@
         );
         halo.renderOrder = 1;
         group.add(halo);
+        screenSpaceRimHalos.push({
+          mesh: halo,
+          radius,
+          tube: tube * 3,
+          tubularSegments,
+          radialSegments: Math.max(8, radialSegments),
+        });
 
         const veinMaterial = createEnergyVeinMaterial(tone, radius * 1.73, energyScale);
         const vein = createHorizontalTorus(
@@ -1594,6 +2469,7 @@
           {
             material: coreMaterial,
             property: 'emissiveIntensity',
+            channel: 'rims',
             base: coreMaterial.emissiveIntensity,
             amplitude: 0.05 * energyScale,
             phase: radius * 1.13,
@@ -1602,6 +2478,7 @@
           {
             material: haloMaterial,
             property: 'opacity',
+            channel: 'rims',
             base: haloMaterial.opacity,
             amplitude: 0.012 * energyScale,
             phase: radius * 1.13 + 0.8,
@@ -1671,19 +2548,131 @@
         camera.position.copy(cameraTarget).addScaledVector(cameraDirection, distance);
         camera.lookAt(cameraTarget);
         camera.updateProjectionMatrix();
+        camera.updateMatrixWorld();
+
+        const projectedOuter = outerGlowProjectionSample.clone().project(camera);
+        const projectedInner = outerGlowProjectionSampleInward.clone().project(camera);
+        const projectedPixelsPerWorld =
+          (Math.abs(projectedOuter.y - projectedInner.y) * height * 0.5) / 0.01;
+        const nextScreenGlowScale = THREE.MathUtils.clamp(
+          referenceOuterGlowPixelsPerWorld / projectedPixelsPerWorld,
+          0.35,
+          4,
+        );
+        updateScreenSpaceGlowScale(nextScreenGlowScale);
 
         gradePass.uniforms.uResolution.value.set(width * pixelRatio, height * pixelRatio);
         stars.userData.material.uniforms.uPixelRatio.value = pixelRatio;
+        particleField.uniforms.uPixelRatio.value = pixelRatio;
+      }
+
+      function setupGlowControls() {
+        const inputs = [...document.querySelectorAll('[data-glow-channel]')];
+        const resetButton = document.querySelector('#glow-reset');
+
+        function commitValue(input, value) {
+          const minimum = Number(input.min);
+          const maximum = Number(input.max);
+          const step = Number(input.step) || 1;
+          const clamped = Math.min(maximum, Math.max(minimum, value));
+          const snapped = minimum + Math.round((clamped - minimum) / step) * step;
+          input.value = String(snapped);
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+
+        function updateFromPointer(input, face, event) {
+          const bounds = face.getBoundingClientRect();
+          const offsetX = event.clientX - (bounds.left + bounds.width * 0.5);
+          const offsetY = event.clientY - (bounds.top + bounds.height * 0.5);
+          if (Math.hypot(offsetX, offsetY) < bounds.width * 0.13) return;
+          let angle = (Math.atan2(offsetY, offsetX) * 180) / Math.PI + 90;
+          if (angle > 180) angle -= 360;
+          if (angle > 135 || angle < -135) angle = offsetX < 0 ? -135 : 135;
+          const normalized = (angle + 135) / 270;
+          commitValue(
+            input,
+            Number(input.min) + normalized * (Number(input.max) - Number(input.min)),
+          );
+        }
+
+        for (const input of inputs) {
+          const control = input.closest('[data-dial-control]');
+          const face = control.querySelector('.glow-dial__face');
+          const output = input.closest('.glow-dial').querySelector('output');
+
+          input.addEventListener('input', () => {
+            const normalized =
+              (Number(input.value) - Number(input.min)) / (Number(input.max) - Number(input.min));
+            face.style.setProperty('--dial-progress', `${normalized * 270}deg`);
+            face.style.setProperty('--dial-angle', `${-135 + normalized * 270}deg`);
+            output.value = `${input.value}%`;
+            input.setAttribute('aria-valuetext', `${input.value} percent`);
+            glowSettings[input.dataset.glowChannel] = Number(input.value) / 100;
+          });
+          input.addEventListener('keydown', (event) => {
+            const keySteps = {
+              ArrowDown: -1,
+              ArrowLeft: -1,
+              ArrowRight: 1,
+              ArrowUp: 1,
+              PageDown: -10,
+              PageUp: 10,
+            };
+            if (event.key === 'Home') {
+              event.preventDefault();
+              commitValue(input, Number(input.min));
+            } else if (event.key === 'End') {
+              event.preventDefault();
+              commitValue(input, Number(input.max));
+            } else if (event.key in keySteps) {
+              event.preventDefault();
+              commitValue(input, Number(input.value) + keySteps[event.key] * Number(input.step));
+            }
+          });
+
+          control.addEventListener('pointerdown', (event) => {
+            if (event.button !== 0) return;
+            control.setPointerCapture(event.pointerId);
+            input.focus({ preventScroll: true });
+            updateFromPointer(input, face, event);
+          });
+          control.addEventListener('pointermove', (event) => {
+            if (!control.hasPointerCapture(event.pointerId)) return;
+            updateFromPointer(input, face, event);
+          });
+          control.addEventListener(
+            'wheel',
+            (event) => {
+              event.preventDefault();
+              commitValue(input, Number(input.value) + (event.deltaY < 0 ? 5 : -5));
+            },
+            { passive: false },
+          );
+
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+
+        resetButton.addEventListener('click', () => {
+          for (const input of inputs) commitValue(input, Number(input.defaultValue));
+        });
       }
 
       function animate() {
         requestAnimationFrame(animate);
         const elapsed = reducedMotion ? reducedMotionTime : clock.getElapsedTime();
         const time = elapsed * 0.66;
+        const surge = Math.pow(Math.max(0, Math.sin(time * 0.24 - 0.9)), 10);
 
         nebula.uniforms.uTime.value = time;
         energyAura.uniforms.uTime.value = time;
+        particleField.uniforms.uTime.value = time;
+        particleField.uniforms.uSurge.value = surge;
         gradePass.uniforms.uTime.value = time;
+        orbitStreaks.uniforms.uTime.value = time;
+        orbitStreaks.uniforms.uSurge.value = surge;
+        const averageGlow = (glowSettings.letters + glowSettings.rims) * 0.5;
+        bloom.strength = 0.18 + averageGlow * 0.24 + surge * (0.12 + averageGlow * 0.07);
+        bloom.radius = 0.42 + Math.min(averageGlow, 2) * 0.1 + surge * 0.08;
 
         for (const track of motionTracks) {
           track.group.rotation.y = track.phase + (time * TAU * track.direction) / track.period;
@@ -1693,17 +2682,32 @@
           }
         }
 
-        aperture.light.intensity = 0.25 + Math.sin(time * 0.42) * 0.025;
+        aperture.light.intensity =
+          (0.3 + Math.sin(time * 0.42) * 0.035 + surge * 0.34) * Math.max(0.05, glowSettings.rims);
         for (const glint of glints.items) {
           glint.material.opacity =
             glint.baseOpacity * (0.58 + (Math.sin(time * 0.73 + glint.phase) * 0.5 + 0.5) * 0.22);
         }
         for (const track of energyTracks) {
-          track.material[track.property] =
-            track.base + Math.sin(time * track.speed + track.phase) * track.amplitude;
+          const channelStrength = glowSettings[track.channel];
+          track.material[track.property] = Math.max(
+            0,
+            (track.base + Math.sin(time * track.speed + track.phase) * track.amplitude) *
+              channelStrength,
+          );
+        }
+        for (const ignition of runeIgnitionTracks) {
+          ignition.time.value = time;
+          ignition.strength.value = ignition.base * glowSettings.letters;
         }
         for (const uniform of energyUniformTracks) {
           uniform.value = time;
+        }
+        for (const uniform of energySurgeTracks) {
+          uniform.value = surge;
+        }
+        for (const track of rimEnergyStrengthTracks) {
+          track.uniform.value = track.base * glowSettings.rims;
         }
         const warmAngle = time * 0.055 + 0.42;
         energyLights.warmDrift.position.set(
@@ -1717,6 +2721,8 @@
           0.72 + Math.sin(time * 0.11 + 1.3) * 0.07,
           Math.sin(coolAngle) * 3.8,
         );
+        energyLights.warmDrift.intensity = 0.98 + surge * 0.34;
+        energyLights.coolDrift.intensity = 0.84 + surge * 0.28;
         stars.rotation.y = time * 0.0012;
         composer.render();
       }


### PR DESCRIPTION
## What changed

- Polished the standalone Three.js magic-circle experiment with a five-rim composition, animated engraved registers, procedural particles, restrained bloom, and independent rune/rim glow controls.
- Added randomly selected rune illumination with premium bronze/silver material response.
- Fixed rune-lighting flicker by using mipmapped anisotropic mask sampling and a whole-glyph eased charge.
- Updated the visual QA record with responsive and temporal verification results.

## Why

This remains an isolated homepage visual experiment and is not connected to production UI. The changes preserve the accepted pattern geometry while improving the cinematic finish and motion quality.

## Root cause of the flicker fix

A narrow radial highlight crossed disconnected glyph strokes and made segments appear to pop on and off; the rotating mask also lacked mipmapped sampling.

## Validation

- `npm run build`
- Prettier on both changed files
- UTF-8 replacement/control-character checks
- `git diff --check`
- 70-frame browser on/off probe: frame-jump ratio improved from 1.78x to 1.39x (limit 1.45x)
