### PR TITLE
fix(content): 装包失败路径补日志

### DIFF
--- a/src/ui/components/settings/DataSection.vue
+++ b/src/ui/components/settings/DataSection.vue
@@ -102,7 +102,12 @@ async function runInstall(raw: unknown) {
     }
     await afterPackApplied(outcome.notes ?? []);
     ui.toast('内容包已安装', 'success');
-  } catch {
+  } catch (err) {
+    // 🔴 安装异常必须留痕：此前空 catch 吞掉全部错误，只弹 toast、控制台零输出，
+    //    失败原因无从排查（2026-08-07 真机：导入 pack 报「安装失败」但无任何日志）。
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[content-pack] 内容包安装失败:', err);
+    packError.value = msg || '内容包安装失败（无错误信息）';
     ui.toast('内容包安装失败', 'error');
   } finally {
     packInstalling.value = false;
@@ -136,6 +141,10 @@ async function runUpgradeRaw(
     await afterPackApplied(outcome.notes ?? []);
     ui.toast('内容包已升级', 'success');
   } else if (outcome.status === 'invalid') {
+    packError.value =
+      ((outcome as { validationErrors?: unknown[] }).validationErrors ?? [])
+        .map((e: any) => e.text ?? String(e))
+        .join('\n') || '内容包校验未通过';
     ui.toast('内容包校验未通过', 'error');
   }
 }
@@ -161,7 +170,10 @@ async function confirmPackInstall() {
     }
     await afterPackApplied(outcome.notes ?? []);
     ui.toast(wasUpgrade ? '内容包已升级' : '内容包已安装', 'success');
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[content-pack] 内容包安装失败（确认重入）:', err);
+    packError.value = msg || '内容包安装失败（无错误信息）';
     ui.toast('内容包安装失败', 'error');
   } finally {
     packInstalling.value = false;

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -1125,7 +1125,12 @@ export const useContentStore = defineStore('content', () => {
       } catch (err) {
         // 🔴 回滚前先留痕：快照回滚可能掩盖原始异常（2026-08-07 真机教训——此前
         //    catch 无任何日志，装包失败只弹 toast）。
-        console.error('[content-pack] 安装写入失败，回滚中（packId=%s, version=%s）:', pack.packId, pack.packVersion, err);
+        console.error(
+          '[content-pack] 安装写入失败，回滚中（packId=%s, version=%s）:',
+          pack.packId,
+          pack.packVersion,
+          err,
+        );
         await rollbackTo(snapshot);
         throw err;
       } finally {
@@ -1282,7 +1287,11 @@ export const useContentStore = defineStore('content', () => {
               : [],
         };
       } catch (err) {
-        console.error('[content-pack] 卸载写入失败，回滚中（packId=%s）:', installedPack.packId, err);
+        console.error(
+          '[content-pack] 卸载写入失败，回滚中（packId=%s）:',
+          installedPack.packId,
+          err,
+        );
         await rollbackTo(snapshot);
         throw err;
       }

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -1123,6 +1123,9 @@ export const useContentStore = defineStore('content', () => {
           validationErrors: plan.validationErrors,
         };
       } catch (err) {
+        // 🔴 回滚前先留痕：快照回滚可能掩盖原始异常（2026-08-07 真机教训——此前
+        //    catch 无任何日志，装包失败只弹 toast）。
+        console.error('[content-pack] 安装写入失败，回滚中（packId=%s, version=%s）:', pack.packId, pack.packVersion, err);
         await rollbackTo(snapshot);
         throw err;
       } finally {
@@ -1279,6 +1282,7 @@ export const useContentStore = defineStore('content', () => {
               : [],
         };
       } catch (err) {
+        console.error('[content-pack] 卸载写入失败，回滚中（packId=%s）:', installedPack.packId, err);
         await rollbackTo(snapshot);
         throw err;
       }


### PR DESCRIPTION
## 背景（2026-08-07 真机）

导入内容包报「安装失败」，控制台零输出 —— 失败原因无从排查。

## 根因

\DataSection.vue\ 的 \unInstall\ / \confirmPackInstall\ 是**空 catch**：\catch { ui.toast('内容包安装失败') }\ 把异常整体吞掉，既不接 \err\ 也不打日志。\PackInstallConfirmModal\ 的 \errorMessage\ 槽位一直在，但从没被喂过。

## 修复

- 三处 catch 全部 \catch (err)\：\console.error('[content-pack] …', err)\ + 错误消息写入 \packError\（Modal 展示失败原因，用户看不到 console 但看得到原因）
- 升级路径 invalid 分支同步补 \packError\（原来只 toast）
- 执行器层（content-store.ts installPack/uninstallPack）回滚前 \console.error\ 留痕（packId/version + 原始异常）——快照回滚可能掩盖原始异常，必须先记

## 验证

typecheck / lint 全绿；DataSection 24 测试 + content-store 全绿。

> 注意：本 PR 只是让失败**可见**。真机失败根因待补日志后重现取证。