### PR TITLE
fix(content): 装包 DataCloneError —— pack 被 ref 深代理成 Proxy 后落库失败

### DIFF
--- a/src/sillytavern/database.ts
+++ b/src/sillytavern/database.ts
@@ -1146,7 +1146,11 @@ export async function getPresets(): Promise<ChatPreset[]> {
 }
 
 export async function savePreset(preset: ChatPreset): Promise<string> {
-  await getDatabase().presets.put(preset);
+  // 🔴 落库前切断 Vue Proxy（Q-16 / db-write.ts 同款纪律）：装包链路上 preset 可能
+  //    经过 Vue 响应式（ref 深代理），IDB 结构化克隆拒绝 Proxy → DataCloneError。
+  //    （2026-08-07 真机：导入内容包报「#<Object> could not be cloned」——
+  //     packPending.value = raw 被 ref 自动 reactive 化，确认重入后 savePreset(Proxy) 炸）
+  await getDatabase().presets.put(JSON.parse(JSON.stringify(preset)) as ChatPreset);
   return preset.id;
 }
 

--- a/src/ui/components/settings/DataSection.vue
+++ b/src/ui/components/settings/DataSection.vue
@@ -6,7 +6,7 @@
  *    所以效果反而更准（每次点进来都是新数），代价是切走再切回会多问一次
  *    `navigator.storage.estimate()` —— 那是个便宜的浏览器查询。
  */
-import { ref, computed, onMounted } from 'vue';
+import { ref, shallowRef, computed, onMounted } from 'vue';
 import type { SceneImageUsage } from '@engine/types-image';
 import AppCard from '../shared/AppCard.vue';
 import AppButton from '../shared/AppButton.vue';
@@ -48,7 +48,10 @@ onMounted(async () => {
  * `PackInstallConfirmModal`，用户确认后以 `{ confirmConflicts: true }` 重入。
  */
 const packPlan = ref<PackInstallPlan | null>(null);
-const packPending = ref<unknown | null>(null); // 待确认的原始 pack JSON
+// 🔴 shallowRef：pack 是纯数据，绝不能进响应式系统——ref 深代理会让确认重入时
+//    取回 Proxy，savePreset 落库 IDB 结构化克隆拒绝 Proxy → DataCloneError
+//    （2026-08-07 真机根因；savePreset 侧已加 detach 双保险）。
+const packPending = shallowRef<unknown | null>(null); // 待确认的原始 pack JSON
 const packDiff = ref<PackUpgradeDiff | null>(null);
 const packError = ref<string | null>(null);
 const packInstalling = ref(false);

--- a/src/ui/stores/content-store-executor.test.ts
+++ b/src/ui/stores/content-store-executor.test.ts
@@ -15,6 +15,7 @@
 import 'fake-indexeddb/auto';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
+import { reactive } from 'vue';
 import {
   useContentStore,
   setActivePackRecord,
@@ -247,6 +248,30 @@ describe('content-store 执行器 —— 1. 安装（含冲突确认路径）', 
     expect(second.ok).toBe(true);
     const sc = await db.worldBooks.get('system_core');
     expect(sc?.entries.map((e) => e.uid)).toEqual([1, 2]);
+  });
+
+  it('pack 经 Vue reactive 代理（packPending 场景）→ 确认重入装包成功，不 DataCloneError（2026-08-07 真机回归）', async () => {
+    await seedPlaceholderLibrary();
+    // 编辑占位书 → 制造 conflicted（与真机一致：确认框 → 确认重入）
+    const db = getDatabase();
+    await db.worldBooks.put({
+      ...PLACEHOLDER_SYSTEM_CORE,
+      entries: [entry(900001, '核心A', '改了')],
+    });
+
+    const c = useContentStore();
+    // 🔴 DataSection.vue 的 packPending 是 ref——存对象会 reactive() 深代理，
+    //    确认重入时取回的是 Proxy。reactive(makePack()) 模拟同一形态。
+    const pack = reactive(makePack());
+    const first = await c.installPack(pack);
+    expect(first.status).toBe('needs_confirmation');
+    // 确认重入（同一 Proxy pack）
+    const second = await c.installPack(pack, { confirmConflicts: true });
+    expect(second.ok).toBe(true);
+    expect(second.status).toBe('installed');
+    // 预设成功落库（修复前：savePreset(Proxy) → IDB DataCloneError）
+    const presets = await getDatabase().presets.toArray();
+    expect(presets.map((p) => p.id)).toContain('pack-story-preset');
   });
 });
 

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -40,6 +40,7 @@
 
 import { defineStore, getActivePinia } from 'pinia';
 import { ref } from 'vue';
+import { detach } from './db-write';
 import type { ContentStatus } from '@engine/types-content';
 // 占位基线清单：随引擎打包的静态资源（设计 §6），**不是**内容树的一部分。
 import placeholderHashesRaw from '@engine/placeholder-hashes.json';
@@ -1076,7 +1077,7 @@ export const useContentStore = defineStore('content', () => {
         validationErrors: [],
       };
 
-    const pack = rawPack as ContentPack;
+    const pack = detach(rawPack) as ContentPack;
     // 已装同 id → 用旧包 payload 现算基线（D18 hash 分工：冲突判定从 payload 现算）。
     // 升级的 diff 展示由 upgradePack 单独提供（UI 层按 packId 分流）；installPack 本身
     // 只负责「装这一版」—— 旧基线用于四态规则判「现 hash = 基线 → updated 静默覆盖」。
@@ -1164,7 +1165,7 @@ export const useContentStore = defineStore('content', () => {
         validationErrors,
       };
     }
-    const pack = rawPack as ContentPack;
+    const pack = detach(rawPack) as ContentPack;
     const existing = await getDatabase().contentPacks.get(pack.packId);
     if (!existing) {
       // 没装过同 id → 不是升级，走安装


### PR DESCRIPTION
## 真机 bug（2026-08-07）

导入内容包报「安装失败」，log 里：\DataCloneError: #<Object> could not be cloned\，栈指向 \savePreset → presets.put\。

## 根因（三层）

1. **UI 层**：\DataSection.vue\ 的 \packPending = ref(raw)\ —— Vue 的 ref 存对象会 **reactive() 深代理**，pack 变成 Proxy；两阶段确认重入时 \packPending.value\ 取回的是 **Proxy pack**
2. **写入层**：\savePreset(Proxy)\ / \contentPacks.put({ payload: Proxy })\ → IDB 结构化克隆**拒绝 Proxy** → DataCloneError。手动重现（刚 parse 的 plain 对象 put）一切正常，所以排查绕了很久
3. **历史缺口**：Q-16（db-write.ts）早把「落库前 detach 切 Proxy」立为纪律，世界书（\	oRow = stamped(detach(book))\）守住了；**装包路径（content-store 的 presets/整包 payload）漏了**

## 修复（双保险 + 一次到位）

- \installPack\ / \upgradePack\ 入口对 pack **整体 detach**（一次覆盖全部分节，含 contentPacks.payload）
- \savePreset\（database.ts）落库前内联 detach（全部调用方受益，防其他路径再踩）
- \packPending\ 改 \shallowRef\（根因：pack 纯数据不进响应式系统）

## 验证

- 回归测试：reactive(pack) + 两段式确认重入 → 装包成功（修复前精确复现 DataCloneError）
- 全量 7023 测试 / typecheck / lint / prettier 全绿