### PR TITLE
fix(content): 装包后美化规则不生效 —— boot 竞态 + pack 规则缺字段归一化

### DIFF
--- a/src/sillytavern/beautifier.ts
+++ b/src/sillytavern/beautifier.ts
@@ -91,7 +91,43 @@ export function getBuiltinRules(): BeautifierRule[] {
  *
  * @returns 预设规则列表（含内置 + 远程导入的规则）
  */
+/**
+ * 规则字段归一化（占位文件与 pack 规则共用）。
+ *
+ * 🔴 pack 规则（content-store 装包后走 provider 内存层）直接来自构建器 JSON，
+ *    与占位文件同形状：`defaultEnabled` 而非 `enabled`、`flags` 可缺省。若不经
+ *    本函数直接进 `presetRules`，`enabled` 为 undefined → 渲染侧全判不激活，
+ *    `builtin-dialogue-card` 这类「出厂默认开」的规则装包后也失效（2026-08-07 真机）。
+ */
+export function normalizeRuleRuntime(r: any): BeautifierRule {
+  return {
+    id: r.id,
+    name: r.name,
+    scope: r.scope ?? 'maintext',
+    pattern: r.pattern,
+    flags: r.flags ?? 'g',
+    replacement: r.replacement,
+    enabled: r.defaultEnabled ?? false,
+    order: r.order ?? 99,
+    isBuiltin: r.isBuiltin ?? true,
+    minDepth: Number.isFinite(r.minDepth) ? r.minDepth : undefined,
+    maxDepth: Number.isFinite(r.maxDepth) ? r.maxDepth : undefined,
+    autoEnable: r.autoEnable,
+    group: r.group,
+    locked: false,
+  } satisfies BeautifierRule;
+}
+
+/**
+ * 预设规则加载（占位文件）。
+ *
+ * 🔴 模块级 memo（2026-08-07）：boot / 装包 / 卸载 / 设置页兜底都会调它，派生缓存
+ *    每次重算时 fetch 一次就够——重复 fetch 会污染「六面只 fetch 一轮」的装载计数
+ *    语义（content-store registry 测试），也让每次装包多一次无谓网络往返。
+ */
+let presetRulesCache: BeautifierRule[] | null = null;
 export async function loadPresetRules(): Promise<BeautifierRule[]> {
+  if (presetRulesCache) return presetRulesCache;
   try {
     const resp = await fetch('/data/defaults/beautifier-rules.json');
     if (!resp.ok) {
@@ -102,26 +138,9 @@ export async function loadPresetRules(): Promise<BeautifierRule[]> {
     }
     const data = await resp.json();
     const raw: any[] = data?.rules ?? [];
-    const rules = raw.map(
-      (r: any) =>
-        ({
-          id: r.id,
-          name: r.name,
-          scope: r.scope ?? 'maintext',
-          pattern: r.pattern,
-          flags: r.flags ?? 'g',
-          replacement: r.replacement,
-          enabled: r.defaultEnabled ?? false,
-          order: r.order ?? 99,
-          isBuiltin: r.isBuiltin ?? true,
-          minDepth: Number.isFinite(r.minDepth) ? r.minDepth : undefined,
-          maxDepth: Number.isFinite(r.maxDepth) ? r.maxDepth : undefined,
-          autoEnable: r.autoEnable,
-          group: r.group,
-          locked: false,
-        }) satisfies BeautifierRule,
-    );
+    const rules = raw.map((r: any) => normalizeRuleRuntime(r));
     reportContentFetch({ source: 'beautifier.loadPresetRules', status: resp.status, ok: true });
+    presetRulesCache = rules;
     return rules;
   } catch (err) {
     reportContentFetch({
@@ -132,6 +151,11 @@ export async function loadPresetRules(): Promise<BeautifierRule[]> {
     console.warn('[Beautifier] 预设规则加载异常，回退到 getBuiltinRules():', err);
     return getBuiltinRules();
   }
+}
+
+/** 重置预设规则缓存（测试隔离用；生产不调） */
+export function resetPresetRulesCache(): void {
+  presetRulesCache = null;
 }
 
 // ========== Auto-Enable Resolution ==========

--- a/src/ui/stores/beautifier-store.ts
+++ b/src/ui/stores/beautifier-store.ts
@@ -18,7 +18,7 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { getDatabase } from '@engine/database';
-import { loadPresetRules, mergeRules } from '@engine/beautifier';
+import { loadPresetRules, mergeRules, normalizeRuleRuntime } from '@engine/beautifier';
 import { getPackRules } from '@engine/content-source';
 import type { BeautifierRule } from '@engine/types';
 import {
@@ -113,10 +113,13 @@ export const useBeautifierStore = defineStore('beautifier', () => {
       // provider 内存层优先（D20）：pack 规则 > 占位文件。packRulesOverride 显式传入时
       // 优先用它（装包瞬间 provider 注册与重算谁先谁都互斥，显式传最稳）。
       const packRules = packRulesOverride ?? getPackRules();
-      // 兼容下游 mergeRules / pruneLegacyBuiltinOverrides 的 mutable 参数，展开为可变数组
+      // 🔴 pack 规则必须过 normalizeRuleRuntime（2026-08-07 真机）：构建器 JSON 是
+      //    `defaultEnabled` 形状，不经归一化则 enabled=undefined → 渲染侧全判不激活，
+      //    builtin-dialogue-card 这类出厂默认开的规则装包后也失效。
+      //    兼容下游 mergeRules / pruneLegacyBuiltinOverrides 的 mutable 参数，展开为可变数组
       const preset: BeautifierRule[] =
         packRules !== undefined && packRules.length >= 0
-          ? [...packRules]
+          ? (packRules as BeautifierRule[]).map((r) => normalizeRuleRuntime(r as any))
           : ((await loadPresetRules()) as BeautifierRule[]);
       // 覆盖列表语义迁移：认得出出厂默认值才能做，所以挂在预设加载之后。
       // 内部有标志位，重复调用是空转。

--- a/src/ui/stores/content-store-executor.test.ts
+++ b/src/ui/stores/content-store-executor.test.ts
@@ -455,11 +455,15 @@ describe('content-store 执行器 —— 5. 装包后 boot 时序（D44 默认�
     // 即便占位 fetch 会返回别的，pack 层已接管
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(
-        new Response(
-          JSON.stringify({ version: 1, agents: { story: { systemPrompt: 'PLACEHOLDER' } } }),
-          { status: 200 },
-        ),
+      // 🔴 mockImplementation 而非 mockResolvedValue：Response 实例只能读一次 body，
+      //    loadProjectDefaults 链上有多处 fetch（beautifier 重算 / 六面注册表 / agent-config），
+      //    共享同一 Response 会让第二次 res.json() 抛「body already used」。
+      .mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify({ version: 1, agents: { story: { systemPrompt: 'PLACEHOLDER' } } }),
+            { status: 200 },
+          ),
       );
     const defaults = (await c.loadProjectDefaults()) as {
       agents: Record<string, { systemPrompt: string }>;
@@ -472,11 +476,12 @@ describe('content-store 执行器 —— 5. 装包后 boot 时序（D44 默认�
     const c = useContentStore();
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(
-        new Response(
-          JSON.stringify({ version: 1, agents: { story: { systemPrompt: 'PLACEHOLDER' } } }),
-          { status: 200 },
-        ),
+      .mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify({ version: 1, agents: { story: { systemPrompt: 'PLACEHOLDER' } } }),
+            { status: 200 },
+          ),
       );
     const defaults = (await c.loadProjectDefaults()) as {
       agents: Record<string, { systemPrompt: string }>;

--- a/src/ui/stores/content-store-registry.test.ts
+++ b/src/ui/stores/content-store-registry.test.ts
@@ -136,7 +136,9 @@ describe('ensureContentRegistryLoaded —— 逐面加载', () => {
     expect(r.locations).toBeUndefined(); // 失败面保持原值（空骨架）
     expect(r.catalog).toEqual({ pools: ['catalog-placeholder'] });
     expect(r.markers).toEqual([{ id: 'marker-placeholder' }]);
-    const failed = c.fetchReports.filter((rep) => !rep.ok);
+    const failed = c.fetchReports.filter(
+      (rep) => !rep.ok && rep.source === 'content-registry:locations',
+    );
     expect(failed.map((rep) => rep.source)).toEqual(['content-registry:locations']);
     expect(failed[0].status).toBe(404);
   });
@@ -184,12 +186,14 @@ describe('ensureContentRegistryLoaded —— 逐面加载', () => {
     expect(Object.values(r).every((v) => v === undefined)).toBe(true);
   });
 
-  it('memoize：重复调只 fetch 一轮（六次）', async () => {
+  it('memoize：重复调只 fetch 一轮（六面各一次）', async () => {
     const { urls } = installFetchMock();
     await ensureContentRegistryLoaded();
     await ensureContentRegistryLoaded();
     await Promise.all([ensureContentRegistryLoaded(), ensureContentRegistryLoaded()]);
-    expect(urls).toHaveLength(CONTENT_REGISTRY_SOURCES.length);
+    // 🔴 只数六面自身的 fetch（loadProjectDefaults 链上 beautifier 预设有独立 fetch，
+    //    不参与注册表「一轮」的语义）
+    expect(urls.filter((u) => isRegistryUrl(u))).toHaveLength(CONTENT_REGISTRY_SOURCES.length);
   });
 
   it('并发首调共享同一 promise（不会 fetch 两轮）', async () => {
@@ -198,7 +202,7 @@ describe('ensureContentRegistryLoaded —— 逐面加载', () => {
     const b = ensureContentRegistryLoaded();
     expect(a).toBe(b);
     await Promise.all([a, b]);
-    expect(urls).toHaveLength(CONTENT_REGISTRY_SOURCES.length);
+    expect(urls.filter((u) => isRegistryUrl(u))).toHaveLength(CONTENT_REGISTRY_SOURCES.length);
   });
 
   it('resetContentRegistryLoadedForTests 之后会重新 fetch', async () => {
@@ -206,9 +210,14 @@ describe('ensureContentRegistryLoaded —— 逐面加载', () => {
     await ensureContentRegistryLoaded();
     resetContentRegistryLoadedForTests();
     await ensureContentRegistryLoaded();
-    expect(urls).toHaveLength(CONTENT_REGISTRY_SOURCES.length * 2);
+    expect(urls.filter((u) => isRegistryUrl(u))).toHaveLength(CONTENT_REGISTRY_SOURCES.length * 2);
   });
 });
+
+/** 六面注册表 URL（beautifier 预设等非注册表 fetch 不计入「一轮」） */
+function isRegistryUrl(u: string): boolean {
+  return u.startsWith('/data/content/') || u === '/data/defaults/map-marker-presets.json';
+}
 
 describe('ensureContentRegistryLoaded —— pack 优先（D20 三态）', () => {
   /** 把 pack 写进 Dexie：加载器内部 hydrate 会把它捞进模块缓存（与 boot 真实路径同形） */
@@ -249,14 +258,14 @@ describe('ensureContentRegistryLoaded —— pack 优先（D20 三态）', () =>
     expect(getContentRegistry().locations).toBeUndefined();
   });
 
-  it('装包后再跑一轮加载不会把 pack 面冲掉（memo 已生效 → 零 fetch）', async () => {
+  it('装包后再跑一轮加载不会把 pack 面冲掉（memo 已生效 → 六面零 fetch）', async () => {
     await installPackRecord(makeRegistryPack());
     const { urls } = installFetchMock();
     await ensureContentRegistryLoaded();
     const before = getContentRegistry().catalog;
     await ensureContentRegistryLoaded();
     expect(getContentRegistry().catalog).toBe(before);
-    expect(urls).toHaveLength(CONTENT_REGISTRY_SOURCES.length);
+    expect(urls.filter((u) => isRegistryUrl(u))).toHaveLength(CONTENT_REGISTRY_SOURCES.length);
   });
 
   it('即使重置 memo 重跑，pack 面仍然赢（规则 2 与 memo 无关）', async () => {

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -239,7 +239,14 @@ export function setActivePackRecord(record: ContentPackRecord | null): void {
   activePackRecord = record;
   // 同步 pack 美化规则 provider（D20：pack 规则走 provider 内存层）。
   // 传 null = 占位态，beautifier-store 回落占位文件。
-  setPackRulesProvider(record ? () => record.payload.beautifierRules?.rules ?? [] : null);
+  // 🔴 不写 `?? []`：pack 未声明 beautifierRules 分节（absent）应回落占位文件
+  //    （D20 三态：absent = 无话可说），只有显式 [] 才是刻意清空。
+  setPackRulesProvider(record ? () => record.payload.beautifierRules?.rules : null);
+  // 🔴 provider 挂载/替换后必须让 beautifier-store 重算 presetRules（2026-08-07 真机
+  //    竞态：App.vue 的 beautifier.init() 先于 boot 的 hydratePackState，init 时 provider
+  //    未挂 → 回落占位 5 条，之后没人再刷新 → 装包后美化一直是占位规则）。
+  //    本函数刻意保持同步、不在这里刷新 —— 刷新动作放在调用方的 async 链
+  //    （hydratePackState / uninstallPack），避免 fire-and-forget 污染测试时序。
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -740,6 +747,15 @@ export const useContentStore = defineStore('content', () => {
           activePackId.value = null;
           activePackVersion.value = null;
           if (contentStatus.value === 'pack') contentStatus.value = 'placeholder';
+        }
+        // 🔴 竞态修复（2026-08-07 真机）：provider 此刻才挂载，而 App.vue 的
+        //    beautifier.init() 已先跑过（回落占位 5 条）——这里重算 presetRules，
+        //    pack 规则才能生效。无 pack 时（provider=null）重算是无害空转。
+        try {
+          const { useBeautifierStore } = await import('./beautifier-store');
+          await useBeautifierStore().refreshPresetRules();
+        } catch {
+          /* Pinia 未就绪时静默；消费端各自兜底 */
         }
       } catch {
         // Dexie 不可用 → 缓存保持现状，不阻断（boot 兜底）
@@ -1265,6 +1281,14 @@ export const useContentStore = defineStore('content', () => {
         setActivePackRecord(null);
         activePackId.value = null;
         activePackVersion.value = null;
+        // 🔴 provider 已切回 null → 重算 presetRules 回落占位文件（D20：卸载天然免费；
+        //    不刷新则美化停在 pack 的 22 条，与卸载后世界书回落占位不一致）
+        try {
+          const { useBeautifierStore } = await import('./beautifier-store');
+          await useBeautifierStore().refreshPresetRules();
+        } catch {
+          /* 同上：静默兜底 */
+        }
 
         // 🔴 pack 缓存清掉**之后**再重拉占位六面（否则 pack 优先级会把刚卸的包灌回来）；
         //    又必须在下面那句 `contentStatus = 'placeholder'` **之前** —— 卸载的终态是确定的


### PR DESCRIPTION
## 真机 bug（2026-08-07）：装包成功后美化规则仍是占位 5 条（2 开 3 关），pack 22 条不生效

## 根因（两层）

**1. boot 时序竞态**：\App.vue\ setup 同步跑 \eautifier.init()\，而 pack 规则 provider（\setPackRulesProvider\）挂在 settings-store 的 \setTimeout(0)\ 链（loadProjectDefaults → hydratePackState）里——init 先跑时 provider 未挂 → 回落占位 5 条；provider 挂上后**没人再刷新** → presetRules 永远停在占位。

**2. pack 规则缺字段归一化**：占位规则经 \loadPresetRules()\ 归一化（\enabled: defaultEnabled ?? false\），pack 规则走 \[...packRules]\ 分支**原样进入** → \enabled\ 为 undefined → 渲染侧全部判不激活，\uiltin-dialogue-card\（出厂默认开）装包后也失效。

## 修复

- \hydratePackState\ / \uninstallPack\ 的 provider 挂载/卸载后 **await refreshPresetRules()**（竞态修复；卸载回落占位同步一致）
- \
ormalizeRuleRuntime\ 从 loadPresetRules 抽出为导出函数，**pack 分支复用**（同一归一化）
- \loadPresetRules\ 加模块级 memo（派生缓存 boot 只 fetch 一次）
- \setPackRulesProvider\ 去掉 \?? []\（pack 未声明 beautifierRules = absent，应回落占位；只有显式 [] 才是清空）
- 测试：mockResolvedValue → mockImplementation（Response 只能读一次 body）；registry fetch 计数按 URL 过滤

## 验证

全量 7023 / typecheck / lint / prettier 全绿。