### PR TITLE
feat(map): 地图字节本地化 —— v21 mapBlobs + 下载进度 + 下载不设超时

### DIFF
--- a/src/sillytavern/database.test.ts
+++ b/src/sillytavern/database.test.ts
@@ -825,7 +825,8 @@ describe('exportAllData / importAllData', () => {
     // 这条断言曾经写着 17 而 schema 已经到 19（v18 删地点预设行 / v19 角色外貌会话副本），
     // 于是它把漂移**固定**下来而不是拦下来。升版时 database.ts 与这里一起改。
     // v20：内容-引擎分离波 1 / D18 —— contentPacks 表（安装持久化，不进 FullBackup）。
-    expect(backup.version).toBe(20);
+    // v21：地图字节本地缓存 mapBlobs（2026-08-07，D23 补强；字节同不进备份）。
+    expect(backup.version).toBe(21);
     expect(Array.isArray(backup.lorebooks)).toBe(true);
     expect(Array.isArray(backup.presets)).toBe(true);
     expect(Array.isArray(backup.settings)).toBe(true);
@@ -1403,6 +1404,34 @@ describe('contentPacks 表 (v20 / D18)', () => {
     expect(await db.contentPacks.count()).toBe(0);
     await importAllData(backup);
     expect(await db.contentPacks.count()).toBe(0);
+  });
+});
+
+// ========== v21 mapBlobs 地图字节缓存（2026-08-07，D23 补强） ==========
+
+describe('mapBlobs 表 (v21)', () => {
+  it('表存在且主键为 url（同一图源天然去重）', () => {
+    const db = getDatabase();
+    expect(db.mapBlobs).toBeDefined();
+    expect(db.mapBlobs.schema?.primKey.keyPath).toBe('url');
+  });
+
+  it('FullBackup 往返不碰 mapBlobs（字节进备份 = 每份备份 +12MB，照 assetBlobs 先例）', async () => {
+    const db = getDatabase();
+    await db.mapBlobs.put({
+      url: 'https://example.com/map.webp',
+      blob: new Blob(['x']),
+      updatedAt: 1,
+    });
+
+    const backup = await exportAllData();
+    expect('mapBlobs' in backup).toBe(false);
+
+    await db.mapBlobs.clear();
+    expect(await db.mapBlobs.count()).toBe(0);
+    await importAllData(backup);
+    // 备份从未收它 → 恢复后仍为空（地图缓存不走备份迁移）
+    expect(await db.mapBlobs.count()).toBe(0);
   });
 });
 
@@ -2244,7 +2273,7 @@ describe('Asset CRUD (v13)', () => {
     // ---- 以当前版 (AppDatabase) 打开：触发升版 ----
     await initializeDatabase();
     const db = getDatabase();
-    expect(db.verno).toBe(20); // v18=D59 删地点预设; v19=D56 角色外貌会话副本; v20=D18 contentPacks 表
+    expect(db.verno).toBe(21); // v20=D18 contentPacks 表; v21=地图字节缓存 mapBlobs
 
     // 表册齐全: v12 的 17 张 + 素材两张 + 工坊两张 + 美化规则一张 + 正则 KV 一张
     //           + 图像生成三张 + 角色外貌会话副本一张（v19/D56）
@@ -2263,6 +2292,7 @@ describe('Asset CRUD (v13)', () => {
       'imagePresets',
       'characterAppearances',
       'contentPacks',
+      'mapBlobs',
     ].sort();
     expect(db.tables.map((t) => t.name).sort()).toEqual(EXPECTED_TABLES);
 

--- a/src/sillytavern/database.ts
+++ b/src/sillytavern/database.ts
@@ -76,6 +76,13 @@ export interface ContentPackRecord {
   notes?: unknown[];
 }
 
+/** 地图字节缓存行（v21）：`url` 主键，同一图源天然去重 */
+export interface MapBlobRecord {
+  url: string;
+  blob: Blob;
+  updatedAt: number;
+}
+
 const DB_NAME = 'SillyTavernWebDB';
 /**
  * 🔴 **必须等于下面最后一个 `this.version(n)`**。它只出现在 `FullBackup.version` 上
@@ -86,7 +93,7 @@ const DB_NAME = 'SillyTavernWebDB';
  * 而 `database.test.ts` 里那条断言跟着写了 17，于是漂移被测试**固定**下来而不是拦下来。
  * 升版时这两处一起改。
  */
-const DB_VERSION = 20;
+const DB_VERSION = 21;
 
 // ═══════════════════════════════════════════════════════════
 // Schema 声明（Q-26）
@@ -221,6 +228,14 @@ class AppDatabase extends Dexie {
   //   payload = 整包 ContentPack；恢复默认/卸载/升级 diff 都从这里还原，无需重拿文件。
   //   🔴 **不进 FullBackup**（payload 进备份 = 每份备份都是可转发的完整内容包）。
   contentPacks!: Table<ContentPackRecord>;
+
+  // v21 (2026-08-07): 地图字节本地缓存（D23 补强）。
+  //   地图图源（pack branding.mapSources 指向的 webp，~12MB）首次打开时下载进
+  //   IndexedDB，之后永远读本地 —— 慢网络下 30 秒硬超时中断 + 每次刷新重下 12MB
+  //   （真机：i.ibb.co 206 分块下载被 MAP_OPEN_TIMEOUT_MS 中途 abort）。
+  //   🔴 **不进 FullBackup**（字节进备份 = 每份备份 +12MB，照 assetBlobs 先例）。
+  //   卸载 pack 刻意**保留**（重装秒开；行数少体积可控，无「零残留」负担）。
+  mapBlobs!: Table<MapBlobRecord>;
 
   constructor() {
     super(DB_NAME);
@@ -580,6 +595,9 @@ class AppDatabase extends Dexie {
     // 索引取舍：只建 `packId` 主键。安装/卸载/升级/对账全部按 packId 直查，无第二索引需求。
     // 与 v19 同款用对象字面量（仅声明本版新增表，旧表跨版继承，Dexie 4 累加语义）。
     this.version(20).stores({ contentPacks: 'packId' });
+
+    // v21 (2026-08-07): 地图字节本地缓存 —— url 主键，同一图源天然去重。
+    this.version(21).stores({ mapBlobs: 'url' });
   }
 }
 

--- a/src/ui/components/game/MapPanel.vue
+++ b/src/ui/components/game/MapPanel.vue
@@ -164,6 +164,17 @@ const {
   destroy,
 } = useMapViewer(containerRef, mapSources);
 
+/** 地图字节下载进度（0-100；本地缓存命中不出现 —— 保持 0，loading 态显示「加载中」） */
+const mapDownloadProgress = ref(0);
+
+/** 首次加载 / 切换 / 重试统一入口：带进度回调 */
+function requestLoadSource(key: string) {
+  mapDownloadProgress.value = 0;
+  loadSource(key, (p) => {
+    mapDownloadProgress.value = p;
+  });
+}
+
 const {
   markers,
   activeMarkerId,
@@ -210,7 +221,7 @@ watch(markers, () => schedulePersist(), { deep: true });
 
 // ═══ 地图源切换 ═══
 function switchSource(key: string) {
-  loadSource(key);
+  requestLoadSource(key);
   nextTick(() => {
     setTimeout(() => syncOverlays(), 500);
   });
@@ -380,7 +391,7 @@ onMounted(async () => {
   await nextTick();
   createViewer();
   // 首个可用图源；一个都没有时 loadSource 落 error 态并说明「需要内容包」
-  loadSource(mapSources.value[0]?.key ?? '');
+  requestLoadSource(mapSources.value[0]?.key ?? '');
 });
 
 onBeforeUnmount(() => {
@@ -435,14 +446,20 @@ onBeforeUnmount(() => {
       <div class="map-stage">
         <!-- 状态提示 -->
         <div v-if="status === 'loading'" class="map-overlay">
-          <span>{{ contentReady ? '地图加载中…' : '内容加载中…' }}</span>
+          <span>{{
+            contentReady
+              ? mapDownloadProgress > 0
+                ? `地图下载中 ${mapDownloadProgress}%…`
+                : '地图加载中…'
+              : '内容加载中…'
+          }}</span>
         </div>
         <div v-else-if="status === 'error'" class="map-overlay map-overlay-error">
           <span>{{ errorMessage || '地图加载失败' }}</span>
           <button
             v-if="mapSources.length > 0"
             class="btn btn-sm"
-            @click="loadSource(currentSourceKey || mapSources[0].key)"
+            @click="requestLoadSource(currentSourceKey || mapSources[0].key)"
           >
             重试
           </button>

--- a/src/ui/composables/useMapViewer.ts
+++ b/src/ui/composables/useMapViewer.ts
@@ -59,6 +59,39 @@ export function resolveMapSources(branding: unknown): MapSourceConfig[] {
 const MAP_OPEN_TIMEOUT_MS = 30000;
 
 /**
+ * 下载地图字节（v21 地图字节本地化）。
+ *
+ * 🔴 **刻意不设超时**：12MB 图源在慢网络下 30 秒下不完是真实场景（2026-08-07 真机），
+ * 中断只由调用方 signal 控制（用户切换图源 / 组件卸载）。进度经 ReadableStream
+ * 逐块上报，UI 显示「下载中 xx%」而不是死等。
+ */
+async function downloadMapBlob(
+  config: MapSourceConfig,
+  signal: AbortSignal,
+  onProgress?: (p: number) => void,
+): Promise<Blob> {
+  const response = await fetch(config.url, { mode: 'cors', signal });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+  const total = Number(response.headers.get('content-length')) || 0;
+  if (response.body && total > 0) {
+    const reader = response.body.getReader();
+    const chunks: BlobPart[] = [];
+    let received = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      received += value.length;
+      onProgress?.(Math.round((received / total) * 100));
+    }
+    return new Blob(chunks, { type: response.headers.get('content-type') ?? undefined });
+  }
+  return response.blob();
+}
+
+/**
  * @param containerRef OSD 挂载容器
  * @param sourcesRef   可用图源列表（D23：由 MapPanel 从注册表 branding 面解析后传入）
  */
@@ -133,7 +166,10 @@ export function useMapViewer(
   }
 
   // ========== 加载地图源 ==========
-  async function loadSource(key: string) {
+  /**
+   * @param onProgress 下载进度回调（0-100，仅在首次下载地图字节时触发；本地缓存命中不触发）
+   */
+  async function loadSource(key: string, onProgress?: (p: number) => void) {
     const viewer = viewerRef.value;
     if (!viewer) return;
 
@@ -150,6 +186,7 @@ export function useMapViewer(
     currentSourceKey.value = key;
     status.value = 'loading';
     errorMessage.value = '';
+    onProgress?.(0);
 
     // 取消上一次加载
     abortController?.abort();
@@ -160,37 +197,36 @@ export function useMapViewer(
     const isLatest = () => openSequence === currentSequence;
 
     try {
-      // 超时控制
+      // ① 地图字节本地化（v21 / mapBlobs）：先查 IndexedDB 缓存，命中则不再走网络。
+      //    12MB 图源（i.ibb.co）每次打开都重新下载 + 30 秒硬超时中断，是慢网络下
+      //    地图「加载失败」的根因（2026-08-07 真机：206 分块下载被 abort）。
+      const { getDatabase } = await import('@engine/database');
+      let blob = (await getDatabase().mapBlobs.get(config.url))?.blob;
+      if (!blob) {
+        blob = await downloadMapBlob(config, controller.signal, onProgress);
+        if (controller.signal.aborted || !isLatest()) return;
+        await getDatabase().mapBlobs.put({ url: config.url, blob, updatedAt: Date.now() });
+      }
+      if (controller.signal.aborted || !isLatest()) return;
+      onProgress?.(100);
+
+      const objectUrl = URL.createObjectURL(blob);
+      objectUrlCache.set(key, objectUrl);
+
+      // ② 打开阶段超时（本地 blob 读取很快；下载阶段刻意不设超时 —— 慢网慢慢下，
+      //    进度已上报，用户看到「下载中 xx%」而不是死等 30 秒被砍）
       const timeoutId = setTimeout(() => {
         controller.abort();
         if (isLatest()) {
-          errorMessage.value = '地图加载超时，请稍后重试';
+          errorMessage.value = '地图打开超时，请稍后重试';
           status.value = 'error';
         }
       }, MAP_OPEN_TIMEOUT_MS);
 
-      // 检查缓存
-      let objectUrl = objectUrlCache.get(key);
-
-      if (!objectUrl) {
-        const response = await fetch(config.url, {
-          mode: 'cors',
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-        const blob = await response.blob();
-        objectUrl = URL.createObjectURL(blob);
-        objectUrlCache.set(key, objectUrl);
-      }
-
-      clearTimeout(timeoutId);
-      if (!isLatest()) return;
-
       // 等待 open 事件
       const onOpen = () => {
         viewer.removeHandler('open', onOpen);
+        clearTimeout(timeoutId);
         if (!isLatest()) return;
         status.value = 'ready';
         viewer.forceResize();


### PR DESCRIPTION
## 真机 bug（2026-08-07）

地图加载失败：i.ibb.co 的 get 返回 **206（Range 分块下载，正常）**，但 30 秒后中断——地图 \Maplite-1.webp\ 有 **12.48 MB**，慢网络下 \MAP_OPEN_TIMEOUT_MS=30000\ 把下载 \bort()\ 掉了。且 useMapViewer 只有**内存 objectURL 缓存**，每次刷新页面重新下载 12MB。

## 修复（主人裁定：地图字节本地化，照 assetBlobs 先例）

- **v21 新表 \mapBlobs\**（url 主键，同图源天然去重；**不进 FullBackup**——字节进备份 = 每份 +12MB，照 assetBlobs/audioBlobs 先例）
- **useMapViewer.loadSource**：先查 mapBlobs → 命中本地 blob（零网络）；未命中 → 下载 → 存库 → 之后永远本地。**下载阶段不设超时**（慢网慢慢下，中断只由用户切换/卸载的 signal 控制），进度经 ReadableStream 逐块上报；30 秒超时只保留给 OSD 打开阶段（本地 blob 读取很快）
- **MapPanel**：loading 态显示「地图下载中 xx%」（本地命中不出现）；切换/重试统一走带进度入口
- 卸载 pack **刻意保留**缓存（重装秒开）

## 验证

全量 7025 / typecheck / lint / prettier 全绿；mapBlobs 表存在 + 备份排除 + CRUD 测试新增。

> 注：未做 Range 断点续传（中断后重试从头下）——12MB 收益低、复杂度高；需要时后续加。