### PR TITLE
chore(content): 补内容恢复面防误提交网 —— 波 4 删掉的 reference/ ignore 在 R1 之后成了缺口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,22 @@ dist-ui/
 # 波 6 (T21) 从这里迁入私有仓；本目录绝不允许进公开仓。
 _private-staging/
 
+# 🔒 内容分离 v1.3：真实内容已离开公开树，但**在本机随时会回来** —— 设计 v1.3 节写明
+# 任何机器都可从历史 2afc23c 提取，私有内容仓 fated_poem_independent_assets 也发整树。
+# 以下路径一旦恢复到本机就是未跟踪且未忽略，`git add -A` 一次即把正文级语料推回公开仓。
+# 🔴 守门测试 tests/no-world-content.test.ts 按 D32 只扫 public/data/**，扫不到这一面。
+/data/
+# reference/ 下还有两类纯本机件：workshop-reference/（公共工坊条目镜像，兼容性调研用）
+# 与 _local-notes/（第三方实现行为审计笔记）。都只供本机参考，不进仓库、不被代码或文档引用。
+/reference/
+# 含 key 的 .api-config*.json 也在这个目录里，一并罩住。
+tests/agent-framework/
+src/sillytavern/worldbook-ejs-corpus.test.ts
+scripts/scramble-worldbook-ejs.mjs
+scripts/build-agent-fingerprints.mjs
+scripts/extract-map-markers.cjs
+scripts/import-regex-rules.mjs
+
 # 系统文件
 .DS_Store
 Thumbs.db
@@ -31,15 +47,6 @@ Thumbs.db
 # 环境变量 / 本地配置
 .env
 .env.local
-
-# 世界书临时/中间文件
-data/worldbooks/_batch_*.json
-data/worldbooks/_batch_*.txt
-data/worldbooks/_mapping_*
-data/worldbooks/_classification_guide.md
-
-# 本地 API 配置（含 key，不提交）
-tests/agent-framework/.api-config*.json
 
 # 临时脚本目录（Q-15 清仓已把 59 个历史 tracked 文件全删；这里现在是纯 ignore）
 tmp/
@@ -63,7 +70,3 @@ public/audio/**/*.ogg
 public/audio/**/*.wav
 public/audio/**/*.m4a
 public/audio/**/*.flac
-
-# Local mirror of public workshop entries used for compatibility research.
-
-# 本地调研笔记（第三方实现的行为审计等）。只供本机参考，不进仓库、不被代码或文档引用。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,16 @@ combat-v3-stress-test / narrative_context_example）移私有仓——工作树�
 | #51 | 装包后美化规则仍是占位 5 条                          | ① boot 竞态：beautifier.init 先于 pack provider 注册，之后没人刷新 ② pack 规则缺字段归一化（`defaultEnabled` 未转 `enabled` → 全判不激活）                           |
 | #52 | 地图加载失败（12.48MB 图源 30 秒超时中断）           | `MAP_OPEN_TIMEOUT_MS=30000` 砍掉慢网下载 + 只有内存缓存每次刷新重下 → v21 `mapBlobs` 字节本地化 + 下载不设超时 + 进度显示                                            |
 
+**R1-R4 之后补的一处仓库面缺口（2026-08-07）**：波 4 交换时顺手删掉了
+`reference/workshop-reference/` 与 `reference/_local-notes/` 两条 ignore（留下两条无 pattern
+的孤儿注释）。当时理由成立——`reference/` 整树已离场；但 R1 之后**真实内容会回到本机**
+（设计 v1.3 写明可从 `2afc23c` 提取，私有内容仓也发整树），于是这些路径变成
+「未跟踪且未忽略」，`git add -A` 一次就能把正文级语料推回公开仓。守门测试按 D32 只扫
+`public/data/**`，扫不到这一面。现补一张恢复面防误提交网：`/data/`、`/reference/`、
+`tests/agent-framework/`、`worldbook-ejs-corpus.test.ts`、四个内容工具脚本；同时删掉被它
+覆盖的三条旧规则（`data/worldbooks/_batch_*`、`.api-config*.json`、两条孤儿注释）。
+`git ls-files -i -c` 为空——没有任何已跟踪文件因此被忽略。
+
 ---
 
 ### 内容-引擎分离 波 4 + v1.3 缩减裁定 ｜ ✅ 波 4 完成（2026-08-07）


### PR DESCRIPTION
## 问题

波 4（T17，#45）原子交换时删掉了两条 ignore：

```diff
 # Local mirror of public workshop entries used for compatibility research.
-reference/workshop-reference/
 # 本地调研笔记（第三方实现的行为审计等）。只供本机参考，不进仓库、不被代码或文档引用。
-reference/_local-notes/
```

留下两条**没有 pattern 的孤儿注释**。当时理由成立 —— `reference/` 整树已离开公开树，规则看着是死的。

但 **R1 之后真实内容会回到本机**：设计 v1.3 明写「任何机器都可从历史 `2afc23c` 完整提取」，私有内容仓 `fated_poem_independent_assets` 也发整树。于是这些路径变成**未跟踪且未忽略** —— 本机 `reference/` 此刻 42MB，`git status` 里就是一条裸 `?? reference/`，一次 `git add -A` 即把正文级语料推回**公开**仓。

守门测试 `tests/no-world-content.test.ts` 按 D32 钉死只扫 `public/data/**`，**扫不到这一面**。

这与已记录的两个坑同形状：**兜底状态与正常状态无法区分**（空 manifest 是合法状态 / 未忽略的未跟踪目录是合法状态），测试不会红。

## 改动

补一张**恢复面防误提交网**，覆盖 T17 移出的全部路径：

| 路径 | 来源 |
| --- | --- |
| `/data/` | 15 本世界书 + defaults + content 七件 + `regex-remote-snapshot.json` |
| `/reference/` | 整树语料（含 `workshop-reference/`、`_local-notes/` 两类纯本机件） |
| `tests/agent-framework/` | 语料 + 含 key 的 `.api-config*.json` |
| `src/sillytavern/worldbook-ejs-corpus.test.ts` | D29 全语料门 |
| `scripts/{scramble-worldbook-ejs,build-agent-fingerprints,extract-map-markers,import-regex-rules}` | 四个内容工具脚本 |

同时删掉被它**完全覆盖**的三条旧规则：`data/worldbooks/_batch_*`（`data/` 已整个离树）、`tests/agent-framework/.api-config*.json`、两条孤儿注释。

`tests/realtime_export/*.preset.json`（同样是 T17 移出件）已被现有的 `tests/realtime_export/*.json` 覆盖，未重复。

## 验证

- **12 条恢复路径全部 IGNORED**（逐条 `git check-ignore` 实测）
- **不该动的没动**：`public/data/agent-config.json`、`public/audio/manifest.json`、`src/sillytavern/types.ts` 均 not-ignored
- **`git ls-files -i -c` 为空** —— 没有任何已跟踪文件因此被误忽略
- `npm run typecheck` 0 错 / `npm run lint` 0 warning / `npm run knip:ratchet` 145 无新增
- `npm test -- --run`：**274 files / 7025 passed / 8 skipped**
- 与 #48（同样改 `.gitignore`）`git merge-tree` 试合并**无冲突**

## 残留

`git add -f` 仍能绕过；`.gitignore` 是防误操作不是防有意。真正的机制面兜底是把守门测试的轴扩到 `git ls-files` 全树，但 D32 在 v1.3 明确「钉死 `public/data/**` 面，不再扩面」—— 本 PR 不动那条裁定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
