### PR TITLE
fix(char-gen): 幻影工具 call_item_gen 报错可行动 + 默认 prompt 工具白名单契约闸门

### DIFF
--- a/src/sillytavern/agent-tools.test.ts
+++ b/src/sillytavern/agent-tools.test.ts
@@ -287,8 +287,13 @@ describe('复用工具回归保护', () => {
     ).rejects.toThrow('未知物品类型');
   });
 
-  it('未知工具仍抛错', async () => {
-    await expect(executeToolCall('不存在的工具', {}, makeCtx())).rejects.toThrow('未知工具');
+  it('未知工具仍抛错（且报错可行动：提示白名单外 + 正确的替代做法）', async () => {
+    await expect(executeToolCall('call_item_gen', {}, makeCtx())).rejects.toThrow(
+      '未注册或不在本 Agent 白名单',
+    );
+    await expect(executeToolCall('call_item_gen', {}, makeCtx())).rejects.toThrow(
+      'skill_requests',
+    );
   });
 
   // 🆕 S2b（2026-08-01 制造反向链路）：craft_check 收集装备「生产检定」modifier → toolBonus

--- a/src/sillytavern/agent-tools.test.ts
+++ b/src/sillytavern/agent-tools.test.ts
@@ -291,9 +291,7 @@ describe('复用工具回归保护', () => {
     await expect(executeToolCall('call_item_gen', {}, makeCtx())).rejects.toThrow(
       '未注册或不在本 Agent 白名单',
     );
-    await expect(executeToolCall('call_item_gen', {}, makeCtx())).rejects.toThrow(
-      'skill_requests',
-    );
+    await expect(executeToolCall('call_item_gen', {}, makeCtx())).rejects.toThrow('skill_requests');
   });
 
   // 🆕 S2b（2026-08-01 制造反向链路）：craft_check 收集装备「生产检定」modifier → toolBonus

--- a/src/sillytavern/agent-tools.ts
+++ b/src/sillytavern/agent-tools.ts
@@ -1021,7 +1021,14 @@ temp.<path>    — 会话临时 (不持久化)
     }
 
     default:
-      throw new Error(`未知工具: ${functionName}`);
+      // 🔴 2026-08-08 真机：旧版 char_gen 提示词把 `call_item_gen` 列为可用工具，
+      // 但白名单（AGENT_TOOL_MAP）没有它 —— 模型一调就报「未知工具」，随即放弃
+      // **全部**工具、手编随机值（性格编码 WoAgy(F) 等）。报错必须可行动：
+      // 告诉模型别调它、以及正确的替代做法，而不是一句冷冰冰的「未知工具」。
+      throw new Error(
+        `工具 ${functionName} 未注册或不在本 Agent 白名单，不可调用。请只使用提示词「可用工具」列出的工具；` +
+          `如需生成技能/装备/物品，把需求写进 <skill_requests>/<equipment_requests>/<item_requests> XML 区块，由引擎自动派发。`,
+      );
   }
 }
 

--- a/tests/agent-tools-prompt-contract.test.ts
+++ b/tests/agent-tools-prompt-contract.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { AGENT_TOOL_MAP } from '../src/sillytavern/agent-tools';
+
+/**
+ * Agent 默认 prompt 与工具白名单契约（真机 bug 回归：2026-08-08）
+ *
+ * 背景：旧版 char_gen 提示词把 `call_item_gen` 列为可用工具，而
+ * `AGENT_TOOL_MAP.char_gen` 白名单里没有它 —— 模型一调就收到「未知工具」，
+ * 随即放弃全部工具、手编随机值（性格编码 `WoAgy(F)` 不符合 wOaGz(A) 格式、
+ * 五维/发色/瞳色全靠编）。报错侧已改可行动文案（agent-tools.ts default 分支），
+ * 这里防的是**默认提示词再把不存在的工具写进去**。
+ *
+ * 住 `tests/` 而非 `src/`：主 tsconfig `"types": []`，`node:fs` 在 src 会挂
+ * `tsc --noEmit`（与 memory-summary-prompt-contract.test.ts 同款仓库级闸门）。
+ */
+describe('Agent 默认提示词广告的工具 ⊆ 工具白名单', () => {
+  const cfg = JSON.parse(
+    readFileSync('public/data/defaults/agent-config.json', 'utf8'),
+  ) as { agents: Record<string, { systemPrompt?: string }> };
+
+  /** 从提示词「可用工具」小节抠工具名列表。
+   *  只抠**小节本身**（到下个空行/标题为止）：工具名是下划线 snake_case
+   * （`roll_d20` / `get_character`），但正文里也会出现 `item_gen`（下游 Agent 名）、
+   * `cost_type`（字段名）这类同形状的词 —— 截断到小节结尾就能排除它们。
+   *  `(?<!<)` 排除 `<skill_requests>` 这类 XML 标签。 */
+  function advertisedTools(prompt: string): string[] {
+    const start = prompt.indexOf('可用工具');
+    if (start < 0) return [];
+    const rest = prompt.slice(start);
+    const endMatch = rest.match(/\n\s*\n|\n#/);
+    const section = endMatch ? rest.slice(0, endMatch.index) : rest;
+    const names = new Set<string>();
+    for (const m of section.matchAll(/(?<!<)\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/g)) {
+      names.add(m[0]);
+    }
+    return [...names];
+  }
+
+  for (const agentId of Object.keys(cfg.agents)) {
+    const prompt = cfg.agents[agentId]?.systemPrompt ?? '';
+    if (!prompt.includes('可用工具')) continue;
+
+    it(`${agentId}: 提示词列出的工具必须都在 AGENT_TOOL_MAP 白名单内`, () => {
+      const whitelist = AGENT_TOOL_MAP[agentId] ?? [];
+      const advertised = advertisedTools(prompt);
+      expect(advertised.length).toBeGreaterThan(0);
+      for (const name of advertised) {
+        expect(whitelist, `「${agentId}」提示词广告了白名单外的工具 ${name}`).toContain(name);
+      }
+    });
+  }
+});

--- a/tests/agent-tools-prompt-contract.test.ts
+++ b/tests/agent-tools-prompt-contract.test.ts
@@ -15,9 +15,9 @@ import { AGENT_TOOL_MAP } from '../src/sillytavern/agent-tools';
  * `tsc --noEmit`（与 memory-summary-prompt-contract.test.ts 同款仓库级闸门）。
  */
 describe('Agent 默认提示词广告的工具 ⊆ 工具白名单', () => {
-  const cfg = JSON.parse(
-    readFileSync('public/data/defaults/agent-config.json', 'utf8'),
-  ) as { agents: Record<string, { systemPrompt?: string }> };
+  const cfg = JSON.parse(readFileSync('public/data/defaults/agent-config.json', 'utf8')) as {
+    agents: Record<string, { systemPrompt?: string }>;
+  };
 
   /** 从提示词「可用工具」小节抠工具名列表。
    *  只抠**小节本身**（到下个空行/标题为止）：工具名是下划线 snake_case

--- a/tests/contract/pack-install.contract.test.ts
+++ b/tests/contract/pack-install.contract.test.ts
@@ -100,10 +100,7 @@ describeIf('pack-install 契约（POEM_PACK_FILE 已设）', () => {
   //   ② 各 agent「可用工具」广告的工具名必须 ∈ 工具白名单（幻影工具会废掉整条工具链）
   it('agentDefaults 提示词契约：hiddenLine 非空 + 广告工具 ⊆ 白名单', () => {
     const pack = loadPack();
-    const agents = (pack.agentDefaults?.agents ?? {}) as Record<
-      string,
-      { systemPrompt?: string }
-    >;
+    const agents = (pack.agentDefaults?.agents ?? {}) as Record<string, { systemPrompt?: string }>;
 
     const ms = agents.memory_summary?.systemPrompt ?? '';
     expect(ms).toContain('hiddenLine 必须是非空字符串');

--- a/tests/contract/pack-install.contract.test.ts
+++ b/tests/contract/pack-install.contract.test.ts
@@ -100,7 +100,7 @@ describeIf('pack-install 契约（POEM_PACK_FILE 已设）', () => {
   //   ② 各 agent「可用工具」广告的工具名必须 ∈ 工具白名单（幻影工具会废掉整条工具链）
   it('agentDefaults 提示词契约：hiddenLine 非空 + 广告工具 ⊆ 白名单', () => {
     const pack = loadPack();
-    const agents = pack.agentDefaults.agents as Record<
+    const agents = (pack.agentDefaults?.agents ?? {}) as Record<
       string,
       { systemPrompt?: string }
     >;

--- a/tests/contract/pack-install.contract.test.ts
+++ b/tests/contract/pack-install.contract.test.ts
@@ -17,6 +17,7 @@ import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import 'fake-indexeddb/auto';
 import { planPackInstall, type CurrentLibrary } from '../../src/sillytavern/content-pack-plan';
+import { AGENT_TOOL_MAP } from '../../src/sillytavern/agent-tools';
 import { hashWorldBook, validatePackOrThrow } from '../../src/sillytavern/content-source';
 import type { ContentPack, PackBaseline } from '../../src/sillytavern/types-content';
 import type { WorldBook } from '../../src/sillytavern/types';
@@ -91,6 +92,43 @@ describeIf('pack-install 契约（POEM_PACK_FILE 已设）', () => {
     const plan = planPackInstall(pack, editedLibrary, {}, buildPlaceholderBaseline());
     const conflicts = (plan.sections.worldBooks?.conflicted ?? []) as Array<{ key: string }>;
     expect(conflicts.length).toBeGreaterThan(0);
+  });
+
+  // 🔴 2026-08-08 真机回归：pack 的 agentDefaults 是运行时默认层（pack > 占位），
+  // 装过 pack 的安装里旧 prompt 就来自这里——必须随 pack 一起守门：
+  //   ① memory_summary 不得教模型留空 hiddenLine（空串会被解析器弃掉整条记忆）
+  //   ② 各 agent「可用工具」广告的工具名必须 ∈ 工具白名单（幻影工具会废掉整条工具链）
+  it('agentDefaults 提示词契约：hiddenLine 非空 + 广告工具 ⊆ 白名单', () => {
+    const pack = loadPack();
+    const agents = pack.agentDefaults.agents as Record<
+      string,
+      { systemPrompt?: string }
+    >;
+
+    const ms = agents.memory_summary?.systemPrompt ?? '';
+    expect(ms).toContain('hiddenLine 必须是非空字符串');
+    expect(ms).not.toMatch(/hiddenLine[^\n]{0,12}留空/);
+    expect(ms).not.toContain('必须留空');
+
+    // 工具广告契约（与 tests/agent-tools-prompt-contract.test.ts 同口径）
+    for (const [agentId, entry] of Object.entries(agents)) {
+      const prompt = entry?.systemPrompt ?? '';
+      const start = prompt.indexOf('可用工具');
+      if (start < 0) continue;
+      const rest = prompt.slice(start);
+      const endMatch = rest.match(/\n\s*\n|\n#/);
+      const section = endMatch ? rest.slice(0, endMatch.index) : rest;
+      const whitelist = AGENT_TOOL_MAP[agentId] ?? [];
+      const advertised = new Set<string>();
+      for (const m of section.matchAll(/(?<!<)\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/g)) {
+        advertised.add(m[0]);
+      }
+      for (const name of advertised) {
+        expect(whitelist, `pack agentDefaults.${agentId} 广告了白名单外工具 ${name}`).toContain(
+          name,
+        );
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## 问题（真机 fated-poem-debug-a0edbbd2-1786152292165）

char_gen 生成达伦时**一个工具都没调**：模型声称「call_item_gen 工具当前不可用」，随后手编全部随机值——性格编码 `code="WoAgy(F)"` 不符合 wOaGz(A) 五维格式（应来自 random_personality），发色/瞳色/五维全靠编。

## 根因

旧版 char_gen systemPrompt 把 `call_item_gen` 列为可用工具，但 `AGENT_TOOL_MAP.char_gen` 白名单里**没有它**（agent-tools.ts:585）。模型一调就收到「未知工具: call_item_gen」，随即放弃**全部**工具。

## 修复

1. **未知工具报错可行动**（agent-tools.ts default 分支）：明确告知「未注册/不在白名单 + 需求应写进 `<skill_requests>/<equipment_requests>/<item_requests>` XML 区块」。模型读到后继续调用 random_personality 等真实工具，而不是放弃整条工具链。
2. **契约闸门** `tests/agent-tools-prompt-contract.test.ts`：默认 prompt「可用工具」小节广告的每个工具名都必须 ∈ AGENT_TOOL_MAP 白名单——防止默认提示词再把不存在的工具写回去。
3. 私有内容仓旧版 char_gen prompt 的 7 处 call_item_gen 已清除（另仓直推）。

## 备注

- 当前默认 prompt 本身已无 call_item_gen；旧版 prompt 在用户 localStorage 里（覆写层优先），已改的可行动报错让旧提示词用户无需重置也能恢复工具调用；重置「角色生成」Agent 配置可拿最新 prompt。
- 性格编码格式：解析器只取描述文本、code 属性仅作兜底——幻觉编码不落库，但会污染 AI 对性格的认知一致性，修工具链是从根上解决。

验证：agent-tools 33 + 契约 3 全绿，typecheck/lint 干净。
