### PR TITLE
feat(plot): 大纲生成流式化 + 实时字数/速率/剩余时间统计 + 取消

### DIFF
--- a/src/sillytavern/agent-client.ts
+++ b/src/sillytavern/agent-client.ts
@@ -68,6 +68,8 @@ const STREAM_TIMEOUT_MULTIPLIER = 3;
 export interface StreamCallbacks {
   /** 增量文本块（delta），isComplete 在最后一块为 true */
   onChunk: (text: string, isComplete: boolean) => void;
+  /** 思维链增量（delta.reasoning_content）——实时字数统计用；可选，不传则只在 onComplete 拿最终值 */
+  onReasoning?: (text: string) => void;
   /** 工具调用增量（name + 当前已累积的 arguments JSON 字符串） */
   onToolCall?: (toolCall: { id: string; name: string; arguments: string }) => void;
   /** 流式完成，携带最终累积状态 */
@@ -481,6 +483,7 @@ export class AgentClient {
 
           if (delta.reasoning_content) {
             fullReasoning += delta.reasoning_content;
+            callbacks.onReasoning?.(delta.reasoning_content);
           }
 
           if (delta.tool_calls) {

--- a/src/ui/components/create/CreateStepPlot.vue
+++ b/src/ui/components/create/CreateStepPlot.vue
@@ -250,8 +250,10 @@ const DIFFICULTY_OPTIONS = [
         :outline="store.plotOutline"
         :chapters="store.plotOutlineChapters"
         :is-generating="store.isPlotGenerating"
+        :stream-stats="store.plotStreamStats"
         :revealed="store.plotOutlineRevealed"
         @reveal="store.plotOutlineRevealed = true"
+        @abort="store.abortPlotGeneration()"
       />
     </section>
 

--- a/src/ui/components/create/PlotOutlinePreview.vue
+++ b/src/ui/components/create/PlotOutlinePreview.vue
@@ -7,8 +7,19 @@ const props = defineProps<{
   chapters: any[];
   isGenerating: boolean;
   revealed: boolean;
+  /** 流式生成实时统计（null = 非生成中） */
+  streamStats?: {
+    phase: 'connecting' | 'streaming';
+    round: number;
+    chars: number;
+    reasoningChars: number;
+    charsPerSec: number;
+    estimatedTotal: number;
+    estimatedRemainingSec: number | null;
+    elapsedSec: number;
+  } | null;
 }>();
-defineEmits<{ reveal: []; regenerate: [] }>();
+defineEmits<{ reveal: []; regenerate: []; abort: [] }>();
 
 const expandedChapters = ref<Set<number>>(new Set());
 
@@ -35,6 +46,17 @@ function formatTimeRange(tr: { start?: string; end?: string } | undefined): stri
   if (!tr.end || tr.end === tr.start) return formatOutlineTime(tr.start);
   return `${formatOutlineTime(tr.start)} ~ ${formatOutlineTime(tr.end)}`;
 }
+
+/** 秒 → 可读剩余时长（不足 1 分钟显秒，否则「X分Y秒」，≥60 分钟显「约 X 小时」） */
+function formatRemaining(sec: number): string {
+  if (sec < 60) return `${sec} 秒`;
+  if (sec < 3600) {
+    const m = Math.floor(sec / 60);
+    const s = sec % 60;
+    return s > 0 ? `${m} 分 ${s} 秒` : `${m} 分钟`;
+  }
+  return `约 ${Math.round(sec / 3600)} 小时`;
+}
 </script>
 
 <template>
@@ -45,7 +67,34 @@ function formatTimeRange(tr: { start?: string; end?: string } | undefined): stri
     <!-- 生成中 -->
     <div v-if="isGenerating" class="outline-loading">
       <div class="shimmer" />
-      <p>AI 正在生成剧情大纲，请耐心等待…</p>
+      <div v-if="streamStats" class="stream-stats">
+        <template v-if="streamStats.phase === 'connecting'">
+          <p class="stream-line">正在连接模型，请稍候…（首次响应可能需数十秒）</p>
+        </template>
+        <template v-else>
+          <p class="stream-line">
+            第 {{ streamStats.round }} 轮 · 正文 {{ streamStats.chars.toLocaleString() }} 字 ·
+            思维链 {{ streamStats.reasoningChars.toLocaleString() }} 字 ·
+            {{ streamStats.charsPerSec }} 字/秒
+            <span v-if="streamStats.estimatedRemainingSec !== null">
+              · 预计剩余 {{ formatRemaining(streamStats.estimatedRemainingSec) }}
+            </span>
+          </p>
+          <div
+            class="stream-progress"
+            :style="{
+              width:
+                streamStats.estimatedTotal > 0
+                  ? Math.min(100, (streamStats.chars / streamStats.estimatedTotal) * 100) + '%'
+                  : '0%',
+            }"
+          />
+        </template>
+        <AppButton size="sm" variant="danger" class="stream-abort" @click="$emit('abort')">
+          取消生成
+        </AppButton>
+      </div>
+      <p v-else>AI 正在生成剧情大纲，请耐心等待…</p>
     </div>
 
     <!-- 已生成：模糊遮罩 -->
@@ -150,6 +199,27 @@ function formatTimeRange(tr: { start?: string; end?: string } | undefined): stri
   text-align: center;
   color: var(--theme-text-muted);
   font-size: 0.8rem;
+}
+.stream-stats {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0 2px;
+}
+.stream-line {
+  margin: 0;
+  font-size: 0.72rem;
+}
+.stream-progress {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--theme-accent);
+  transition: width 0.3s ease;
+  max-width: 100%;
+}
+.stream-abort {
+  margin-top: 2px;
 }
 .shimmer {
   width: 100%;

--- a/src/ui/stores/create-store.test.ts
+++ b/src/ui/stores/create-store.test.ts
@@ -133,6 +133,27 @@ vi.mock('@engine/agent-client', () => ({
     chat(...args: any[]) {
       return chatMock(...args);
     }
+    async chatStream(_req: any, callbacks: any, _signal?: any) {
+      // 流式路径同样走 chatMock 队列；同步补一次 onChunk 模拟最小流式，再收尾
+      const result = await chatMock(_req);
+      if (result.error) {
+        callbacks.onError(result.error);
+      } else {
+        const raw = result.rawResponse || '';
+        if (raw) callbacks.onChunk?.(raw, false);
+        callbacks.onComplete({
+          fullText: raw,
+          toolCalls: [],
+          reasoning: result.reasoning || '',
+          tokensUsed: result.tokensUsed || 0,
+          cacheHit: false,
+          cacheHitTokens: 0,
+          cacheMissTokens: 0,
+          completionTokens: 0,
+          duration: result.duration || 0,
+        });
+      }
+    }
   },
 }));
 
@@ -1366,6 +1387,25 @@ describe('generatePlotOutline 大纲生成', () => {
     expect(store.plotOutline).toBeNull();
     expect(store.plotGenerationError).toContain('HTTP 500');
     expect(store.isPlotGenerating).toBe(false);
+  });
+
+  it('用户取消（Request aborted）→ 提示已取消而非报错', async () => {
+    chatMock.mockResolvedValueOnce({ error: 'Request aborted', rawResponse: '' });
+    const store = setupPlotStore();
+    const ok = await store.generatePlotOutline();
+    expect(ok).toBe(false);
+    expect(store.plotGenerationError).toContain('已取消');
+    expect(store.plotGenerationError).not.toContain('Request aborted');
+    expect(store.isPlotGenerating).toBe(false);
+    expect(store.plotStreamStats).toBeNull();
+  });
+
+  it('成功后流式统计清空（plotStreamStats 回 null）', async () => {
+    chatMock.mockResolvedValueOnce(okResult(outlineJson(8)));
+    const store = setupPlotStore();
+    const ok = await store.generatePlotOutline();
+    expect(ok).toBe(true);
+    expect(store.plotStreamStats).toBeNull();
   });
 
   it('输出解析失败时应设置错误状态', async () => {

--- a/src/ui/stores/create-store.ts
+++ b/src/ui/stores/create-store.ts
@@ -875,6 +875,42 @@ export const useCreateStore = defineStore('create', () => {
   /** 大纲预览是否已揭示（防剧透遮罩，捏人页本地状态） */
   const plotOutlineRevealed = ref(false);
   const plotGenerationError = ref<string | null>(null);
+
+  /** 流式生成实时统计（捏人页统计条用；null = 非生成中） */
+  const plotStreamStats = ref<{
+    phase: 'connecting' | 'streaming';
+    round: number;
+    chars: number;
+    reasoningChars: number;
+    charsPerSec: number;
+    estimatedTotal: number;
+    estimatedRemainingSec: number | null;
+    elapsedSec: number;
+  } | null>(null);
+  /** 当前生成轮的 AbortController（取消按钮用） */
+  let plotAbortController: AbortController | null = null;
+
+  /**
+   * 预计大纲总字数 —— 三档：上轮 raw 实际长度最准 → 历史版 content 膨胀 → 公式兜底。
+   * 公式：章节数 × 每章事件数 × 每事件 220 字 × XML 膨胀 1.8 + 固定开销 1800；
+   * 思维链 ≈ 正文 × 0.5（deepseek 类推理模型经验值）。
+   */
+  function estimateOutlineChars(): number {
+    const lastRaw = lastPlotGenerationMeta.value?.rawResponse?.length;
+    if (lastRaw && lastRaw > 0) return lastRaw;
+    const hist = outlineHistory.value[outlineHistory.value.length - 1];
+    if (hist?.content?.length) return Math.round(hist.content.length * 1.6);
+    const ps = plotSettings.value;
+    const chapters = ps.main?.chapterCount || 3;
+    const eventsPerCh = ps.main?.eventsPerChapter || 3;
+    const body = chapters * eventsPerCh * 220 * 1.8 + 1800;
+    return Math.round(body + body * 0.5);
+  }
+
+  /** 取消当前大纲生成（用户主动中止） */
+  function abortPlotGeneration(): void {
+    plotAbortController?.abort();
+  }
   /** 最近一次大纲生成的完整 AI 数据（供导出） */
   const lastPlotGenerationMeta = ref<{
     messages: Array<{ role: string; content: string }>;
@@ -1125,6 +1161,113 @@ export const useCreateStore = defineStore('create', () => {
     }
   }
 
+  /**
+   * 流式调用 chatStream，一边实时更新 plotStreamStats（字数/速率/剩余估算），
+   * 一边把流聚合回 Promise 结果。用户取消（abort）与真实错误用 `cancelled` 区分。
+   */
+  function streamOutlineChat(
+    client: AgentClient,
+    request: {
+      model: string;
+      temperature: number;
+      maxTokens: number;
+      topP: number;
+      messages: Array<{ role: string; content: string }>;
+    },
+    round: number,
+  ): Promise<{
+    rawResponse: string;
+    reasoning?: string;
+    finishReason?: string;
+    completionTokens?: number;
+    error?: string;
+    cancelled?: boolean;
+  }> {
+    return new Promise((resolve) => {
+      const controller = new AbortController();
+      plotAbortController = controller;
+      const startedAt = Date.now();
+      let fullText = '';
+      let fullReasoning = '';
+      plotStreamStats.value = {
+        phase: 'connecting',
+        round,
+        chars: 0,
+        reasoningChars: 0,
+        charsPerSec: 0,
+        estimatedTotal: estimateOutlineChars(),
+        estimatedRemainingSec: null,
+        elapsedSec: 0,
+      };
+      // 速率滑动窗口（近 10s 平均；开头数据少不估算）
+      const window_: Array<{ ts: number; chars: number }> = [];
+
+      const finishStats = () => {
+        if (!plotStreamStats.value) return;
+        plotStreamStats.value.chars = fullText.length;
+        plotStreamStats.value.reasoningChars = fullReasoning.length;
+        plotStreamStats.value.elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+      };
+
+      void client.chatStream(
+        request,
+        {
+          onChunk(text, _isComplete) {
+            fullText += text;
+            const now = Date.now();
+            window_.push({ ts: now, chars: fullText.length });
+            const cutoff = now - 10000;
+            while (window_.length > 0 && window_[0].ts < cutoff) window_.shift();
+            const first = window_[0];
+            const last = window_[window_.length - 1];
+            const span = last.ts - first.ts;
+            const delta = last.chars - first.chars;
+            const cps = span > 0 ? (delta * 1000) / span : 0;
+            const st = plotStreamStats.value;
+            if (!st) return;
+            st.phase = 'streaming';
+            st.chars = fullText.length;
+            st.charsPerSec = Math.round(cps);
+            st.elapsedSec = Math.round((now - startedAt) / 1000);
+            // 数据足够（≥500 字）才给剩余估算；宁偏大不偏小（×1.15 缓冲）
+            if (fullText.length >= 500 && cps > 0) {
+              const remaining = Math.max(0, st.estimatedTotal - fullText.length);
+              st.estimatedRemainingSec = Math.round((remaining / cps) * 1.15);
+            } else {
+              st.estimatedRemainingSec = null;
+            }
+          },
+          onReasoning(text) {
+            fullReasoning += text;
+            const st = plotStreamStats.value;
+            if (st) st.reasoningChars = fullReasoning.length;
+          },
+          onComplete(result) {
+            fullText = result.fullText;
+            fullReasoning = result.reasoning || '';
+            finishStats();
+            resolve({
+              rawResponse: result.fullText,
+              reasoning: result.reasoning || undefined,
+              completionTokens: result.completionTokens,
+            });
+          },
+          onError(err) {
+            finishStats();
+            const cancelled = err === 'Request aborted';
+            resolve({
+              rawResponse: fullText,
+              reasoning: fullReasoning || undefined,
+              error: cancelled ? undefined : err,
+              cancelled,
+            });
+          },
+        },
+        controller.signal,
+      );
+    });
+  }
+
   /** 核心生成循环: 通过模板系统 buildAgentMessagesAsync 构建上下文，selfCritique.score < 6 时重试（最多 2 次调用） */
   async function runOutlineGeneration(initialUserMessage: string): Promise<boolean> {
     plotGenerationError.value = null;
@@ -1218,10 +1361,17 @@ export const useCreateStore = defineStore('create', () => {
         } else {
           messages.push({ role: 'user', content: userMessage });
         }
-        const result = await client.chat({ ...llmParams, messages });
+
+        const result = await streamOutlineChat(client, { ...llmParams, messages }, attempt + 1);
+        if (result.cancelled) {
+          plotGenerationError.value = '大纲生成已取消';
+          plotStreamStats.value = null;
+          return false;
+        }
         if (result.error || !result.rawResponse) {
           if (best) break;
           plotGenerationError.value = `大纲生成失败: ${result.error ?? 'AI 返回为空'}`;
+          plotStreamStats.value = null;
           return false;
         }
         const parsed = tryParseOutline(result.rawResponse);
@@ -1247,14 +1397,15 @@ export const useCreateStore = defineStore('create', () => {
           lastPlotGenerationMeta.value = {
             messages: messages.map((m) => ({ ...m })),
             rawResponse: raw,
-            reasoning: (result as any).reasoning ?? undefined,
+            reasoning: result.reasoning ?? undefined,
             model: llmParams.model,
             finishReason: result.finishReason,
             timestamp: Date.now(),
           };
           plotGenerationError.value = truncated
-            ? '大纲输出被截断（finish_reason=length，输出未完整闭合），请减少章节/事件数量后重试，或检查 API 输出上限'
+            ? '大纲输出被截断（输出未完整闭合），请减少章节/事件数量后重试，或检查 API 输出上限'
             : '大纲输出解析失败，请重试（失败详情已写入控制台，可导出 AI 调试数据）';
+          plotStreamStats.value = null;
           return false;
         }
         best = { parsed, raw: result.rawResponse };
@@ -1262,7 +1413,7 @@ export const useCreateStore = defineStore('create', () => {
         lastPlotGenerationMeta.value = {
           messages: messages.map((m) => ({ ...m })),
           rawResponse: best.raw,
-          reasoning: (result as any).reasoning ?? undefined,
+          reasoning: result.reasoning ?? undefined,
           finishReason: result.finishReason,
           model: llmParams.model,
           timestamp: Date.now(),
@@ -1287,6 +1438,7 @@ export const useCreateStore = defineStore('create', () => {
         plotGenerationError.value = '大纲生成失败';
         return false;
       }
+      plotStreamStats.value = null;
 
       const outline = createOutlineFromAgent(
         '',
@@ -2068,6 +2220,8 @@ export const useCreateStore = defineStore('create', () => {
     plotOutline,
     plotOutlineChapters,
     isPlotGenerating,
+    plotStreamStats,
+    abortPlotGeneration,
     plotOutlineRevealed,
     plotGenerationError,
     outlineHistory,


### PR DESCRIPTION
## 改动

**流式生成**：\unOutlineGeneration\ 从非流式 \chat()\ 改为 \chatStream()\，边生成边出结果。

**实时统计条**（生成中显示，防剧透——只显示统计不显示内容）：
- 正文 X 字 + 思维链 Y 字（reasoning 实时累计）
- 速率（近 10s 滑动窗口）+ 预计剩余时间
- 进度条（已生成/预计总字数）
- 首字节等待期显示「正在连接模型…」

**预计总字数三档估算**：
1. 上轮 raw 实际长度（最准，重 roll 时）
2. 历史版 content × 1.6（有历史无上轮 raw）
3. 公式兜底：章节×每章事件×220字×XML膨胀1.8 + 固定1800；思维链≈正文×0.5

**取消**：AbortController，\Request aborted\ 时提示「大纲生成已取消」而非报错。

**agent-client**：\StreamCallbacks\ 新增可选 \onReasoning\（\delta.reasoning_content\ 实时增量），向后兼容（现有调用方不受影响）。

## 验证
- 串行全量 7032 tests 通过；相关文件 lint/prettier 干净；typecheck 通过
- 并发全量偶发 1 个既有 flaky（content-store-registry pack 优先，与本次无关，串行稳定全绿）