### PR TITLE
fix(beautifier): 装包后预设规则只剩占位 —— boot 竞态收敛保险

### DIFF
--- a/src/ui/stores/beautifier-store.test.ts
+++ b/src/ui/stores/beautifier-store.test.ts
@@ -242,7 +242,7 @@ describe('beautifier-store', () => {
       expect(store.presetRules.map((r) => r.id)).toEqual(['builtin-pack-a', 'builtin-pack-b']);
     });
     // 不污染用户表 / 不写回 settings
-    expect((await getDatabase().beautifierRules.toArray())).toHaveLength(0);
+    expect(await getDatabase().beautifierRules.toArray()).toHaveLength(0);
     setPackRulesProvider(null);
   });
 });

--- a/src/ui/stores/beautifier-store.test.ts
+++ b/src/ui/stores/beautifier-store.test.ts
@@ -12,8 +12,10 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
+import { nextTick } from 'vue';
 import type { BeautifierRule } from '@engine/types';
 import { getDatabase } from '@engine/database';
+import { setPackRulesProvider } from '@engine/content-source';
 
 const presetPayload = vi.hoisted(() => ({ value: [] as unknown[] }));
 vi.mock('@engine/beautifier', async (importOriginal) => {
@@ -22,6 +24,7 @@ vi.mock('@engine/beautifier', async (importOriginal) => {
 });
 
 import { useBeautifierStore } from './beautifier-store';
+import { useContentStore } from './content-store';
 import { useSettingsStore } from './settings-store';
 import { LEGACY_RULES_KEY, LEGACY_PRESET_CACHE_KEY } from './beautifier-migration';
 
@@ -215,5 +218,31 @@ describe('beautifier-store', () => {
     expect(store.presetRules[0].locked).toBe(true);
     // locked 是算出来的，仍然不许落进任何存储
     expectSettingsFreeOfRules();
+  });
+
+  it('boot 竞态收敛: pack provider 注册 + activePackVersion 变化后 presetRules 自动重算', async () => {
+    // 模拟 App.vue beautifier.init 先跑（provider 未注册 → 占位态）
+    setPackRulesProvider(null);
+    presetPayload.value = [];
+    const store = useBeautifierStore();
+    await store.init();
+    expect(store.presetRules).toHaveLength(0);
+
+    // 模拟 hydratePackState：注册 pack provider + 设置 activePackVersion
+    const packRules = [
+      makeRule('builtin-pack-a', { isBuiltin: true }),
+      makeRule('builtin-pack-b', { isBuiltin: true }),
+    ];
+    setPackRulesProvider(() => packRules as unknown as readonly BeautifierRule[]);
+    useContentStore().activePackVersion = '9.9.9';
+
+    // watch 异步触发 refreshPresetRules → 收敛到 pack 规则
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(store.presetRules.map((r) => r.id)).toEqual(['builtin-pack-a', 'builtin-pack-b']);
+    });
+    // 不污染用户表 / 不写回 settings
+    expect((await getDatabase().beautifierRules.toArray())).toHaveLength(0);
+    setPackRulesProvider(null);
   });
 });

--- a/src/ui/stores/beautifier-store.ts
+++ b/src/ui/stores/beautifier-store.ts
@@ -16,7 +16,7 @@
  *    设置对象序列化进 localStorage，写回去等于把刚搬出来的容量又塞回配额里。
  */
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import { getDatabase } from '@engine/database';
 import { loadPresetRules, mergeRules, normalizeRuleRuntime } from '@engine/beautifier';
 import { getPackRules } from '@engine/content-source';
@@ -26,6 +26,7 @@ import {
   pruneLegacyBuiltinOverrides,
   type BeautifierMigrationOutcome,
 } from './beautifier-migration';
+import { useContentStore } from './content-store';
 import { useSettingsStore } from './settings-store';
 import { detach, omit } from './db-write';
 
@@ -76,6 +77,30 @@ export const useBeautifierStore = defineStore('beautifier', () => {
     await refreshPresetRules();
     ready.value = true;
   }
+
+  // 🔴 收敛保险（2026-08-08 真机复现）：App.vue 的 `beautifier.init()` 先于 boot 的
+  //    `hydratePackState()` 时，doInit 的 `refreshPresetRules()` 会在 pack provider 挂载前
+  //    跑完（回落占位文件）；若 hydratePackState 里那次重算又因时序未生效，presetRules
+  //    会一直是占位规则（症状：Dexie 装着 pack 且 getPackRules()=22，但 presetRules=5）。
+  //    监听 activePackVersion：boot hydrate / 装包把它从 null 变成版本号时重算，
+  //    让所有时序最终收敛到 pack 规则。
+  // 🔴 守卫：仅当 pack 规则确实可读（provider 已注册）才重算 —— 否则走 loadPresetRules()
+  //    会 fetch 占位文件并把 contentStatus 上报成 error（测试与卸载路径的污染源）。
+  watch(
+    () => {
+      try {
+        return useContentStore().activePackVersion;
+      } catch {
+        // Pinia 未激活（极少见的早调用）→ 保持 null，不抛
+        return null;
+      }
+    },
+    (v) => {
+      if (v === null || v === undefined) return;
+      if (getPackRules() === undefined) return;
+      void refreshPresetRules();
+    },
+  );
 
   /** 从 Dexie 读全表填 ref */
   async function hydrate(): Promise<void> {
@@ -134,8 +159,10 @@ export const useBeautifierStore = defineStore('beautifier', () => {
         activeCharacterNames,
       );
       presetRules.value = merged.filter((r) => r.isBuiltin);
-    } catch {
-      // 加载失败静默（设置页打开时会兜底重算）
+    } catch (err) {
+      // 加载失败不阻断渲染（设置页打开时会兜底重算），但留痕便于诊断：
+      // 2026-08-08 美化规则「只剩占位」真机复现后，这条曾全程静默。
+      console.warn('[beautifier-store] refreshPresetRules 失败，presetRules 可能不完整:', err);
     }
   }
 

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -754,8 +754,10 @@ export const useContentStore = defineStore('content', () => {
         try {
           const { useBeautifierStore } = await import('./beautifier-store');
           await useBeautifierStore().refreshPresetRules();
-        } catch {
-          /* Pinia 未就绪时静默；消费端各自兜底 */
+        } catch (err) {
+          // Pinia 未就绪时静默；消费端各自兜底。但留痕便于诊断 ——
+          // beautifier-store 侧另有 watch contentStatus 收敛保险（2026-08-08）。
+          console.warn('[content-store] hydratePackState 重算 presetRules 失败:', err);
         }
       } catch {
         // Dexie 不可用 → 缓存保持现状，不阻断（boot 兜底）


### PR DESCRIPTION
## 问题

真机复现（2026-08-08）：装 pack-1.4.1 后刷新，**输出美化只剩占位规则**。诊断脚本确认：

- \contentStatus='pack'\ ✅、\ctivePackVersion='1.4.1'\ ✅、\getPackRules()=22\ ✅
- 但 \presetRules=5\（全是 \placeholder-*\ 占位）❌

根因是 #51 修过的 boot 竞态的残余形态：App.vue 的 \eautifier.init()\ 先于 boot 的 \hydratePackState()\ 时，doInit 的 \efreshPresetRules()\ 在 pack provider 挂载前跑完（回落占位文件）；hydratePackState 里补的那次重算若又因时序未生效，就没人再刷新 → 占位规则一直生效。

## 修复

- **beautifier-store 监听 \content-store.activePackVersion\**（boot hydrate / 装包把它从 null 变成版本号），变化时自动重算 \presetRules\ → 所有时序最终收敛到 pack 的 22 条
- **守卫**：仅当 \getPackRules()\ 可读到 pack 规则才重算——否则走 \loadPresetRules()\ 会 fetch 占位文件并污染 \contentStatus\（卸载路径的污染源）
- hydratePackState / refreshPresetRules 的静默 catch 加 \console.warn\ 留痕
- 新增收敛回归测试：provider 注册 + activePackVersion 变化后 presetRules 自动收敛

## 验证
- 全量 7033 tests 通过（含新增收敛测试）
- typecheck / lint 干净