### PR TITLE
feat(game): 记忆面板改版 —— 卡片墙 + 搜索/筛选/排序/分页 + 详情视图

### DIFF
--- a/src/ui/components/game/MemoryPanel.test.ts
+++ b/src/ui/components/game/MemoryPanel.test.ts
@@ -1,0 +1,217 @@
+/**
+ * MemoryPanel.test.ts — 记忆面板卡片墙 + 详情视图的界面性质
+ *
+ * 1. **规模可控** —— 超过一页（24 条）时分页出现，翻页能翻出后面的记忆。
+ * 2. **找得到** —— 搜索过滤 content+keywords、重要度筛选、排序切换即时生效。
+ * 3. **看得清** —— 卡片显示 ★/摘要/关键词/游戏时间；点卡进详情，全文不截断、
+ *    关联角色解析成名字；返回回到卡片墙。
+ * 4. **删除** —— 从详情删除调 deleteMemory 且从 store 移除、回到列表。
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { reactive, nextTick } from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+import type { MemoryRecord, CharacterState } from '@engine/types';
+import { createDefaultCharacterState } from '@engine/types';
+
+// ── 假 store ──
+
+const deleteMemoryMock = vi.hoisted(() => vi.fn(async () => {}));
+const recentMemories: MemoryRecord[] = reactive([]);
+let mockGame: {
+  recentMemories: MemoryRecord[];
+  characters: CharacterState[];
+};
+
+vi.mock('../../stores/game-store', () => ({ useGameStore: () => mockGame }));
+vi.mock('@engine/database', () => ({ deleteMemory: deleteMemoryMock }));
+
+import MemoryPanel from './MemoryPanel.vue';
+
+function mem(id: string, over: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id,
+    saveId: 's1',
+    createdAt: 100,
+    realTimestamp: 100,
+    timeRange: { start: '复兴纪元488年3月5日', end: '复兴纪元488年3月8日' },
+    content: `记忆${id}的正文，这是一个足够长以展示摘要截断行为的记忆内容，里面提到了铁蹄与血誓。`,
+    hiddenLine: '',
+    keywords: ['铁蹄', '血誓', '军粮'],
+    relatedCharacterIds: [],
+    importance: 5,
+    ...over,
+  };
+}
+
+function char(id: string, name: string): CharacterState {
+  return createDefaultCharacterState({ id, type: 'npc', name, race: '人' });
+}
+
+beforeEach(() => {
+  recentMemories.length = 0;
+  mockGame = {
+    recentMemories,
+    characters: [char('player', '主角'), char('npc_001', '苏婉')],
+  };
+});
+
+afterEach(() => {
+  deleteMemoryMock.mockClear();
+});
+
+async function mountPanel() {
+  const wrapper = mount(MemoryPanel, { attachTo: document.body });
+  await nextTick();
+  return wrapper;
+}
+
+describe('MemoryPanel 卡片墙', () => {
+  it('按时间倒序渲染卡片墙，点卡进入详情、返回回到列表', async () => {
+    recentMemories.push(mem('MEM000001', { createdAt: 1 }), mem('MEM000002', { createdAt: 2 }));
+
+    const wrapper = await mountPanel();
+
+    const cards = wrapper.findAll('.memory-card');
+    expect(cards).toHaveLength(2);
+    // 时间倒序：新（2）在前
+    expect(cards[0]!.text()).toContain('MEM000002');
+    expect(cards[1]!.text()).toContain('MEM000001');
+
+    await cards[0]!.trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('.memory-detail').exists()).toBe(true);
+    expect(wrapper.find('.detail-content').text()).toContain('记忆MEM000002的正文');
+
+    await wrapper.find('.back-btn').trigger('click');
+    await nextTick();
+    expect(wrapper.find('.memory-detail').exists()).toBe(false);
+    expect(wrapper.findAll('.memory-card')).toHaveLength(2);
+  });
+
+  it('超过一页时显示分页，翻页能看到后面的记忆', async () => {
+    for (let i = 1; i <= 30; i++)
+      recentMemories.push(mem(`MEM${String(i).padStart(6, '0')}`, { createdAt: i }));
+
+    const wrapper = await mountPanel();
+
+    expect(wrapper.findAll('.memory-card')).toHaveLength(24);
+    expect(wrapper.find('.pagination').exists()).toBe(true);
+    expect(wrapper.find('.page-info').text()).toContain('第 1 / 2 页');
+
+    await wrapper.find('.page-btn:last-child').trigger('click');
+    await nextTick();
+    expect(wrapper.findAll('.memory-card')).toHaveLength(6);
+    expect(wrapper.find('.page-info').text()).toContain('第 2 / 2 页');
+  });
+
+  it('搜索即时过滤内容与关键词，无匹配时显示空态', async () => {
+    recentMemories.push(
+      mem('MEM000001', { content: '王城外的第一场雨', keywords: ['雨水'] }),
+      mem('MEM000002', { content: '铁蹄踏过平原', keywords: ['军马'] }),
+    );
+
+    const wrapper = await mountPanel();
+    await wrapper.find('.search-input').setValue('铁蹄');
+
+    expect(wrapper.findAll('.memory-card')).toHaveLength(1);
+    expect(wrapper.find('.memory-card').text()).toContain('铁蹄踏过平原');
+
+    await wrapper.find('.search-input').setValue('不存在的词');
+    expect(wrapper.findAll('.memory-card')).toHaveLength(0);
+    expect(wrapper.find('.empty').text()).toContain('无匹配记忆');
+  });
+
+  it('重要度筛选只保留对应区间', async () => {
+    recentMemories.push(
+      mem('MEM000001', { importance: 9, content: '高重要度记忆内容' }),
+      mem('MEM000002', { importance: 5, content: '中重要度记忆内容' }),
+      mem('MEM000003', { importance: 2, content: '低重要度记忆内容' }),
+    );
+
+    const wrapper = await mountPanel();
+    await wrapper.findAll('.sort-select')[1]!.setValue('high');
+    expect(wrapper.findAll('.memory-card')).toHaveLength(1);
+    expect(wrapper.find('.memory-card').text()).toContain('高重要度记忆内容');
+
+    await wrapper.findAll('.sort-select')[1]!.setValue('low');
+    expect(wrapper.findAll('.memory-card')).toHaveLength(1);
+    expect(wrapper.find('.memory-card').text()).toContain('低重要度记忆内容');
+  });
+
+  it('排序切换：按重要度降序', async () => {
+    recentMemories.push(
+      mem('MEM000001', { createdAt: 3, importance: 3, content: '低重要度内容' }),
+      mem('MEM000002', { createdAt: 2, importance: 9, content: '高重要度内容' }),
+      mem('MEM000003', { createdAt: 1, importance: 6, content: '中重要度内容' }),
+    );
+
+    const wrapper = await mountPanel();
+    await wrapper.findAll('.sort-select')[0]!.setValue('importance');
+
+    const cards = wrapper.findAll('.memory-card');
+    expect(cards[0]!.text()).toContain('高重要度内容');
+    expect(cards[1]!.text()).toContain('中重要度内容');
+  });
+});
+
+describe('MemoryPanel 详情', () => {
+  it('显示全文（不截断）、全部关键词、关联角色名、ID 与真实时间', async () => {
+    const longContent = '长'.repeat(300);
+    recentMemories.push(
+      mem('MEM000001', {
+        content: longContent,
+        keywords: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+        relatedCharacterIds: ['npc_001', 'player'],
+        realTimestamp: 1700000000000,
+      }),
+    );
+
+    const wrapper = await mountPanel();
+    await wrapper.find('.memory-card').trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('.detail-content').text()).toBe(longContent);
+    expect(wrapper.findAll('.keyword')).toHaveLength(8);
+    expect(wrapper.find('.detail-chars').text()).toContain('苏婉');
+    expect(wrapper.find('.detail-chars').text()).toContain('主角');
+    expect(wrapper.find('.detail-id').text()).toContain('MEM000001');
+  });
+
+  it('删除调 deleteMemory 并从 store 移除、回到卡片墙', async () => {
+    recentMemories.push(mem('MEM000001'));
+
+    const wrapper = await mountPanel();
+    await wrapper.find('.memory-card').trigger('click');
+    await nextTick();
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    await wrapper.find('.detail-actions .btn-danger').trigger('click');
+    await flushPromises();
+
+    expect(deleteMemoryMock).toHaveBeenCalledWith('MEM000001');
+    expect(recentMemories).toHaveLength(0);
+    expect(wrapper.find('.memory-detail').exists()).toBe(false);
+    expect(wrapper.findAll('.memory-card')).toHaveLength(0);
+    vi.restoreAllMocks();
+  });
+
+  it('复制内容调用 clipboard', async () => {
+    recentMemories.push(mem('MEM000001', { content: '要复制的话' }));
+
+    const wrapper = await mountPanel();
+    await wrapper.find('.memory-card').trigger('click');
+    await nextTick();
+
+    const writeText = vi.fn(async () => {});
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    await wrapper.find('.detail-actions .btn-secondary').trigger('click');
+
+    expect(writeText).toHaveBeenCalledWith('要复制的话');
+  });
+});

--- a/src/ui/components/game/MemoryPanel.vue
+++ b/src/ui/components/game/MemoryPanel.vue
@@ -1,32 +1,234 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { ref, computed } from 'vue';
 import { useGameStore } from '../../stores/game-store';
+import { deleteMemory } from '@engine/database';
+import type { MemoryRecord } from '@engine/types';
+import AppButton from '../shared/AppButton.vue';
 
 const game = useGameStore();
 
-const memories = computed(() => {
-  return [...(game.recentMemories || [])].sort((a, b) => b.createdAt - a.createdAt);
+// ===== 列表态 =====
+const searchQuery = ref('');
+const sortMode = ref<'time-desc' | 'time-asc' | 'importance'>('time-desc');
+const importanceFilter = ref<'all' | 'high' | 'mid' | 'low'>('all');
+const pageSize = 24;
+const currentPage = ref(1);
+
+// ===== 详情态 =====
+const selectedId = ref<string | null>(null);
+
+const allMemories = computed(() => [...(game.recentMemories || [])]);
+
+const filtered = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase();
+  return allMemories.value.filter((mem) => {
+    if (importanceFilter.value === 'high' && mem.importance < 7) return false;
+    if (importanceFilter.value === 'mid' && (mem.importance < 4 || mem.importance > 6))
+      return false;
+    if (importanceFilter.value === 'low' && mem.importance > 3) return false;
+    if (!q) return true;
+    const haystack = `${mem.content} ${(mem.keywords || []).join(' ')}`.toLowerCase();
+    return haystack.includes(q);
+  });
 });
+
+const sorted = computed(() => {
+  const arr = [...filtered.value];
+  if (sortMode.value === 'time-asc') {
+    arr.sort((a, b) => a.createdAt - b.createdAt);
+  } else if (sortMode.value === 'importance') {
+    arr.sort((a, b) => b.importance - a.importance || b.createdAt - a.createdAt);
+  } else {
+    arr.sort((a, b) => b.createdAt - a.createdAt);
+  }
+  return arr;
+});
+
+const totalPages = computed(() => Math.max(1, Math.ceil(sorted.value.length / pageSize)));
+
+const paged = computed(() => {
+  const start = (currentPage.value - 1) * pageSize;
+  return sorted.value.slice(start, start + pageSize);
+});
+
+const selected = computed<MemoryRecord | null>(() => {
+  if (!selectedId.value) return null;
+  return allMemories.value.find((m) => m.id === selectedId.value) ?? null;
+});
+
+const characterNames = computed(() => {
+  const map = new Map<string, string>();
+  for (const c of game.characters || []) map.set(c.id, c.name);
+  return map;
+});
+
+function characterNameOf(id: string): string {
+  return characterNames.value.get(id) ?? id;
+}
+
+function timeText(ts: number): string {
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+function starClass(importance: number): string {
+  if (importance >= 8) return 'star-high';
+  if (importance >= 5) return 'star-mid';
+  return 'star-low';
+}
+
+function starText(importance: number): string {
+  return '★'.repeat(importance) + '☆'.repeat(Math.max(0, 10 - importance));
+}
+
+function onFilterChange() {
+  currentPage.value = 1;
+}
+
+function openDetail(id: string) {
+  selectedId.value = id;
+}
+
+function backToList() {
+  selectedId.value = null;
+}
+
+async function copyContent() {
+  if (!selected.value) return;
+  try {
+    await navigator.clipboard.writeText(selected.value.content);
+  } catch (e) {
+    console.warn('[MemoryPanel] 复制失败:', e);
+  }
+}
+
+async function removeSelected() {
+  const mem = selected.value;
+  if (!mem) return;
+  const ok = window.confirm(`删除记忆「${mem.id}」？删除后不可恢复。`);
+  if (!ok) return;
+  try {
+    await deleteMemory(mem.id);
+    const idx = game.recentMemories?.findIndex((m) => m.id === mem.id) ?? -1;
+    if (idx >= 0 && game.recentMemories) {
+      game.recentMemories.splice(idx, 1);
+    }
+    selectedId.value = null;
+  } catch (e) {
+    console.warn('[MemoryPanel] 删除记忆失败:', e);
+  }
+}
 </script>
 
 <template>
   <div class="memory-panel">
-    <div class="panel-title">记忆列表 ({{ memories.length }})</div>
-    <div v-if="memories.length > 0" class="memory-list">
-      <div v-for="mem in memories" :key="mem.id" class="memory-card">
-        <div class="memory-header">
-          <span class="memory-id">{{ mem.id }}</span>
-          <span class="memory-importance">★{{ mem.importance || 0 }}</span>
-        </div>
-        <div class="memory-content">
-          {{ mem.content?.slice(0, 200) }}{{ (mem.content?.length || 0) > 200 ? '...' : '' }}
-        </div>
-        <div v-if="mem.keywords?.length" class="memory-keywords">
-          <span v-for="kw in mem.keywords.slice(0, 5)" :key="kw" class="keyword">{{ kw }}</span>
-        </div>
+    <!-- ========== 详情视图 ========== -->
+    <div v-if="selected" class="memory-detail">
+      <div class="detail-toolbar">
+        <button class="back-btn" aria-label="返回列表" @click="backToList">← 返回</button>
+        <span class="detail-title">记忆详情</span>
+        <span class="detail-star" :class="starClass(selected.importance)">
+          {{ starText(selected.importance) }}
+        </span>
+      </div>
+      <div class="detail-meta">
+        <span v-if="selected.timeRange" class="detail-time">
+          {{ selected.timeRange.start }} → {{ selected.timeRange.end }}
+        </span>
+        <span v-if="selected.relatedCharacterIds?.length" class="detail-chars">
+          {{ selected.relatedCharacterIds.map(characterNameOf).join(' · ') }}
+        </span>
+      </div>
+      <div class="detail-content">{{ selected.content }}</div>
+      <div v-if="selected.keywords?.length" class="detail-keywords">
+        <span v-for="kw in selected.keywords" :key="kw" class="keyword">{{ kw }}</span>
+      </div>
+      <div class="detail-foot">
+        <span class="detail-id">ID: {{ selected.id }}</span>
+        <span class="detail-real">存档于 {{ timeText(selected.realTimestamp) }}</span>
+      </div>
+      <div class="detail-actions">
+        <AppButton variant="secondary" size="sm" @click="copyContent">复制内容</AppButton>
+        <AppButton variant="danger" size="sm" @click="removeSelected">删除这条</AppButton>
       </div>
     </div>
-    <div v-else class="empty">暂无记忆</div>
+
+    <!-- ========== 卡片墙视图 ========== -->
+    <div v-else class="memory-wall">
+      <div class="wall-toolbar">
+        <input
+          v-model="searchQuery"
+          class="search-input"
+          type="text"
+          placeholder="搜索记忆内容 / 关键词…"
+          @input="onFilterChange"
+        />
+        <select v-model="sortMode" class="sort-select" @change="onFilterChange">
+          <option value="time-desc">最新在前</option>
+          <option value="time-asc">最早在前</option>
+          <option value="importance">按重要度</option>
+        </select>
+        <select v-model="importanceFilter" class="sort-select" @change="onFilterChange">
+          <option value="all">全部重要度</option>
+          <option value="high">重要度 ≥7</option>
+          <option value="mid">重要度 4-6</option>
+          <option value="low">重要度 ≤3</option>
+        </select>
+      </div>
+
+      <div v-if="paged.length > 0" class="card-grid">
+        <button
+          v-for="mem in paged"
+          :key="mem.id"
+          class="memory-card"
+          :aria-label="`查看记忆 ${mem.id}`"
+          @click="openDetail(mem.id)"
+        >
+          <span class="card-star" :class="starClass(mem.importance)">{{
+            '★'.repeat(mem.importance)
+          }}</span>
+          <span class="card-content">{{ mem.content }}</span>
+          <span class="card-meta">
+            <span v-if="mem.keywords?.length" class="card-keywords">
+              {{ mem.keywords.slice(0, 3).join(' · ') }}
+            </span>
+            <span v-if="mem.timeRange?.start" class="card-time">{{ mem.timeRange.start }}</span>
+          </span>
+        </button>
+      </div>
+      <div v-else class="empty">
+        {{
+          filtered.length === 0 && (searchQuery || importanceFilter !== 'all')
+            ? '无匹配记忆'
+            : '暂无记忆'
+        }}
+      </div>
+
+      <div v-if="totalPages > 1" class="pagination">
+        <button
+          class="page-btn"
+          :disabled="currentPage <= 1"
+          aria-label="上一页"
+          @click="currentPage--"
+        >
+          ‹ 上一页
+        </button>
+        <span class="page-info"
+          >第 {{ currentPage }} / {{ totalPages }} 页 · 共 {{ sorted.length }} 条</span
+        >
+        <button
+          class="page-btn"
+          :disabled="currentPage >= totalPages"
+          aria-label="下一页"
+          @click="currentPage++"
+        >
+          下一页 ›
+        </button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -36,51 +238,193 @@ const memories = computed(() => {
   flex-direction: column;
   height: 100%;
   padding: 8px;
+  gap: 8px;
 }
-.panel-title {
+/* ===== 卡片墙 ===== */
+.wall-toolbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.search-input {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 10px;
   font-size: 0.8125rem;
-  font-weight: 600;
+  font-family: inherit;
   color: var(--theme-text-primary);
-  margin-bottom: 8px;
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-sm, 4px);
 }
-.memory-list {
+.search-input:focus {
+  outline: none;
+  border-color: var(--theme-primary);
+}
+.sort-select {
+  padding: 6px 8px;
+  font-size: 0.75rem;
+  font-family: inherit;
+  color: var(--theme-text-secondary);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-sm, 4px);
+}
+.card-grid {
   flex: 1;
   overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 8px;
+  align-content: start;
+}
+.memory-card {
   display: flex;
   flex-direction: column;
   gap: 6px;
-}
-.memory-card {
+  padding: 10px;
+  text-align: left;
   background: var(--theme-card-bg);
-  padding: 8px;
-  border-radius: var(--theme-radius-sm, 4px);
   border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-sm, 4px);
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    border-color var(--theme-transition-fast),
+    transform var(--theme-transition-fast);
 }
-.memory-header {
+.memory-card:hover {
+  border-color: var(--theme-primary);
+  transform: translateY(-1px);
+}
+.memory-card:focus-visible {
+  outline: 2px solid var(--theme-primary);
+  outline-offset: 1px;
+}
+.card-star {
+  font-size: 0.6875rem;
+}
+.star-high {
+  color: #f59e0b;
+}
+.star-mid {
+  color: #94a3b8;
+}
+.star-low {
+  color: #64748b;
+}
+.card-content {
+  font-size: 0.75rem;
+  color: var(--theme-text-secondary);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.card-meta {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 4px;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: auto;
 }
-.memory-id {
+.card-keywords {
+  font-size: 0.625rem;
+  color: var(--theme-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.card-time {
   font-size: 0.625rem;
   color: var(--theme-text-muted);
   font-family: monospace;
 }
-.memory-importance {
-  font-size: 0.6875rem;
-  color: #f59e0b;
+/* ===== 分页 ===== */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 6px 0 2px;
+  flex-shrink: 0;
 }
-.memory-content {
+.page-btn {
+  padding: 4px 10px;
   font-size: 0.75rem;
+  font-family: inherit;
   color: var(--theme-text-secondary);
-  line-height: 1.5;
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-sm, 4px);
+  cursor: pointer;
 }
-.memory-keywords {
+.page-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.page-info {
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+}
+/* ===== 详情视图 ===== */
+.memory-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+  padding: 4px;
+}
+.detail-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+.back-btn {
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-family: inherit;
+  color: var(--theme-text-secondary);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-sm, 4px);
+  cursor: pointer;
+}
+.detail-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--theme-text-primary);
+}
+.detail-star {
+  font-size: 0.75rem;
+  margin-left: auto;
+}
+.detail-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+}
+.detail-content {
+  flex: 1;
+  overflow-y: auto;
+  font-size: 0.8125rem;
+  color: var(--theme-text-primary);
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 10px;
+  background: var(--theme-surface-muted);
+  border-radius: var(--theme-radius-sm, 4px);
+}
+.detail-keywords {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
-  margin-top: 6px;
+  flex-shrink: 0;
 }
 .keyword {
   font-size: 0.625rem;
@@ -89,9 +433,23 @@ const memories = computed(() => {
   color: var(--theme-text-muted);
   border-radius: 3px;
 }
+.detail-foot {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.625rem;
+  color: var(--theme-text-muted);
+  font-family: monospace;
+}
+.detail-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
 .empty {
-  padding: 24px;
-  text-align: center;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--theme-text-muted);
   font-size: 0.8125rem;
 }


### PR DESCRIPTION
## 背景

记忆面板之前是扁平列表，只有 id/重要度/前200字/前5关键词。500 条时 DOM 卡顿、找一条记忆无从下手。本次按主人的设计方向重做：Windows 资源管理器式卡片墙 + 通栏搜索 + 分页 + 点卡进详情。

## 改动

**卡片墙视图**
- 自适应网格（\grid auto-fill\，每卡约 170px），资源管理器大图标式铺满
- 通栏工具条：全文搜索（content+keywords 即时过滤）+ 排序（最新/最早/重要度）+ 重要度区间筛选（≥7 / 4-6 / ≤3）
- 分页：每页 24 张 + 上一页/下一页 + 页码统计 —— 500 条 DOM 无压力
- 每卡：重要度星 + 摘要 3 行截断 + 关键词徽章 + 游戏时间

**详情视图**
- 面板内状态切换（非嵌套弹窗 —— 嵌套会跟 AppModal 的滚动锁/escape/关闭叉打架），点卡进入、返回回列表
- 全文不截断、全部关键词、关联角色名（解析 characters 表）、游戏时间跨度、真实时间、ID
- 复制内容（clipboard）/ 删除这条（\deleteMemory\ + 从 store 移除）

## 验证
- 新增 8 个界面级测试（分页/搜索/筛选/排序/详情/删除/复制）全绿
- 全量 7041 tests 通过 · typecheck · lint · prettier 干净