### PR TITLE
fix(game): 记忆面板 UX —— 放大弹窗 + MEM 编号 + 卡片间距

### DIFF
--- a/src/ui/components/game/GamePage.vue
+++ b/src/ui/components/game/GamePage.vue
@@ -330,7 +330,7 @@ function onModalOpenChange(v: boolean) {
     <AppModal
       title="记忆"
       :open="game.activeModal === 'memory'"
-      size="lg"
+      size="xxl"
       closable
       @close="game.closeModal()"
       @update:open="onModalOpenChange"

--- a/src/ui/components/game/MemoryPanel.vue
+++ b/src/ui/components/game/MemoryPanel.vue
@@ -187,9 +187,12 @@ async function removeSelected() {
           :aria-label="`查看记忆 ${mem.id}`"
           @click="openDetail(mem.id)"
         >
-          <span class="card-star" :class="starClass(mem.importance)">{{
-            '★'.repeat(mem.importance)
-          }}</span>
+          <span class="card-topline">
+            <span class="card-star" :class="starClass(mem.importance)">{{
+              '★'.repeat(mem.importance)
+            }}</span>
+            <span class="card-id">{{ mem.id }}</span>
+          </span>
           <span class="card-content">{{ mem.content }}</span>
           <span class="card-meta">
             <span v-if="mem.keywords?.length" class="card-keywords">
@@ -246,6 +249,7 @@ async function removeSelected() {
   gap: 8px;
   align-items: center;
   flex-shrink: 0;
+  margin-bottom: 4px;
 }
 .search-input {
   flex: 1;
@@ -276,8 +280,9 @@ async function removeSelected() {
   overflow-y: auto;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
-  gap: 8px;
+  gap: 10px;
   align-content: start;
+  padding-top: 2px;
 }
 .memory-card {
   display: flex;
@@ -302,8 +307,20 @@ async function removeSelected() {
   outline: 2px solid var(--theme-primary);
   outline-offset: 1px;
 }
+.card-topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 6px;
+}
 .card-star {
   font-size: 0.6875rem;
+}
+.card-id {
+  font-size: 0.625rem;
+  color: var(--theme-text-muted);
+  font-family: monospace;
+  white-space: nowrap;
 }
 .star-high {
   color: #f59e0b;


### PR DESCRIPTION
## 改动（按主人反馈）

1. **弹窗放大**：记忆弹窗 \lg → xxl\，与背包（ItemsPanel）同尺寸（GamePage.vue:333）
2. **卡片加 MEM 编号**：卡片顶行左星标、右 \MEM000xxx\ 编号（monospace），一眼定位
3. **卡片与搜索栏拉开间距**：工具条 \margin-bottom\ + 网格 gap 加大，卡片不再顶到搜索栏

全量 7041 tests 通过 · typecheck · prettier 干净