### PR TITLE
fix(game): 记忆弹窗与背包等高 —— min-height 37.5rem

### DIFF
--- a/src/ui/components/game/MemoryPanel.vue
+++ b/src/ui/components/game/MemoryPanel.vue
@@ -240,6 +240,7 @@ async function removeSelected() {
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 37.5rem;
   padding: 8px;
   gap: 8px;
 }


### PR DESCRIPTION
## 问题

上一轮只把记忆弹窗从 \lg\ 放大到 \xxl\（宽 1600px），但 \.modal-content\ 高度由内容撑开，面板没有 min-height → 变成一条矮扁的宽框。背包弹窗用 \min-height: 37.5rem\（600px）撑高，两者并排时记忆那条又宽又矮很难看。

## 修复

MemoryPanel 根容器加 \min-height: 37.5rem\（与 ItemsPanel 一致），弹窗与背包等宽等高。

全量 7041 tests 通过 · typecheck · prettier 干净