### PR TITLE
fix(vite): 写入口 chunk 编码 bug —— 中文被切成 U+FFFD

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,11 +99,16 @@ export default defineConfig({
             if (req.method !== 'PUT' && req.method !== 'POST') return next();
             const id = (req.url || '').replace(/^\//, '').replace(/\.json$/, '');
             if (!id || id.includes('..')) return next();
-            let body = '';
+            const chunks: Buffer[] = [];
             req.on('data', (chunk: Buffer) => {
-              body += chunk.toString();
+              // 🔴 攒 Buffer 最后统一 toString（2026-08-08 真机）：HTTP 把请求体拆成
+              //    多个 chunk 时，多字节中文可能恰被切成两半——每块各自 toString() 会
+              //    在切分处产生 U+FFFD 替换字符（"展示"曾被切成"展[替换符][替换符]示"、
+              //    顿号丢失），就是 chunk 边界切碎了 UTF-8。
+              chunks.push(chunk);
             });
             req.on('end', () => {
+              const body = Buffer.concat(chunks).toString('utf8');
               try {
                 const worldbooksDir = resolve(dataDir, 'worldbooks');
                 const filePath = resolve(worldbooksDir, `${id}.json`);
@@ -136,11 +141,14 @@ export default defineConfig({
             const rawUrl = (req.url || '').replace(/^\//, '').replace(/\.json$/, '');
             const fileName = rawUrl || 'agent-config';
             if (fileName.includes('..')) return next();
-            let body = '';
+            const chunks: Buffer[] = [];
             req.on('data', (chunk: Buffer) => {
-              body += chunk.toString();
+              // 🔴 攒 Buffer 最后统一 toString（2026-08-08 真机）：同 /api/worldbooks，
+              //    chunk 边界切碎多字节中文时每块各自 toString() 会产 U+FFFD。
+              chunks.push(chunk);
             });
             req.on('end', () => {
+              const body = Buffer.concat(chunks).toString('utf8');
               try {
                 const defaultsDir = resolve(dataDir, 'defaults');
                 if (!fs.existsSync(defaultsDir)) fs.mkdirSync(defaultsDir, { recursive: true });


### PR DESCRIPTION
## 背景

真机复现（2026-08-08）：内容仓 agent-config.json「保存为默认」后出现 5 个 U+FFFD（「展示」→「展[替换符][替换符]示」、顿号丢失）。

## 根因

`vite.config.ts` 两个写入口（`/api/worldbooks` 与 `/api/defaults`）都有：

```js
req.on('data', (chunk) => { body += chunk.toString(); });
```

HTTP 把请求体拆成多个 chunk 时，多字节中文（如「展」=3 字节）可能恰被切在两块之间，每块各自 `toString()` 会在切分处产生 U+FFFD。agent-config.json 约 300KB 中文，命中概率高。

## 修复

攒 `Buffer[]`，`end` 时 `Buffer.concat(chunks).toString('utf8')` 统一解码。

## 验证

- 模拟随机切碎中文 chunk：修复前 U+FFFD>0，修复后 0、内容完好、JSON 可解析
- 全量 7325 tests 通过 · typecheck · lint · prettier 干净
- 已修复内容仓被损坏的 2 处（「后穴、肉棒」顿号、「展示」字），内容仓已推送
