### PR TITLE
Polish Crimson panel coverage and tab motion

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -67,6 +67,7 @@ Flexibility: materials and ornament may vary; frame ownership may not
 ### Crimson rose window
 
 - The established tab treatment uses a continuous stone base and one separate active cap.
+- Motion is interaction-triggered only; do not use ambient or continuously looping theme animation. Crimson tab strips use one shared active cap that slides horizontally between fixed button positions.
 - Blood glass is reserved for the chat text treatment unless the user explicitly expands its scope.
 - Backpack and character modals use asset-free, gold-framed neutral liquid glass; fixed-size blood-control artwork must not be stretched across their panels or sub-elements.
 

--- a/src/ui/components/shared/AppTabs.vue
+++ b/src/ui/components/shared/AppTabs.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts" generic="T extends string">
-defineProps<{
+import { computed } from 'vue';
+
+const props = defineProps<{
   tabs: { key: T; label: string; badge?: number }[];
   active: T;
 }>();
@@ -7,6 +9,19 @@ defineProps<{
 const emit = defineEmits<{
   select: [key: T];
 }>();
+
+const selectionStyle = computed(() => {
+  const count = Math.max(1, props.tabs.length);
+  const activeIndex = Math.max(
+    0,
+    props.tabs.findIndex((tab) => tab.key === props.active),
+  );
+
+  return {
+    '--tab-selection-offset': `${activeIndex * 100}%`,
+    '--tab-selection-width': `${100 / count}%`,
+  };
+});
 </script>
 
 <template>
@@ -22,6 +37,7 @@ const emit = defineEmits<{
         <span class="tab-label">{{ tab.label }}</span>
         <span v-if="tab.badge !== undefined" class="tab-badge">{{ tab.badge }}</span>
       </button>
+      <span class="tab-selection" :style="selectionStyle" aria-hidden="true"></span>
     </div>
   </div>
 </template>
@@ -37,6 +53,10 @@ const emit = defineEmits<{
   scrollbar-width: none;
 }
 .tab-list::-webkit-scrollbar {
+  display: none;
+}
+
+.tab-selection {
   display: none;
 }
 

--- a/src/ui/themes/crimson.css
+++ b/src/ui/themes/crimson.css
@@ -677,6 +677,29 @@
   height: 100%;
 }
 
+:root[data-theme='crimson'] body .game-page-layout .scene-panel > .tab-bar .tab-selection,
+:root[data-theme='crimson'] body .game-page-layout .hold-body > .tab-bar .tab-selection {
+  display: block;
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  left: 0;
+  width: var(--tab-selection-width);
+  height: 100%;
+  pointer-events: none;
+  background-color: transparent;
+  background-image: var(--crimson-tab-cap);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 100% 100%;
+  opacity: 1;
+  clip-path: none;
+  border-radius: 0;
+  box-shadow: none;
+  transform: translateX(var(--tab-selection-offset));
+  transition: transform 180ms ease;
+}
+
 :root[data-theme='crimson'] body .game-page-layout .scene-panel > .tab-bar .tab-item {
   position: relative;
   z-index: 1;
@@ -727,24 +750,6 @@
   transform: none !important;
   filter: none;
   text-shadow: 0 0 7px rgba(151, 43, 57, 0.34);
-}
-
-:root[data-theme='crimson'] body .game-page-layout .scene-panel > .tab-bar .tab-active::before {
-  content: '';
-  position: absolute;
-  z-index: 1;
-  inset: 0;
-  pointer-events: none;
-  background-color: transparent;
-  background-image: var(--crimson-tab-cap);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 100% 100%;
-  opacity: 1;
-  filter: brightness(1.18) contrast(1.08) saturate(1.04) drop-shadow(0 3px 2px rgba(0, 0, 0, 0.74))
-    drop-shadow(0 1px 2px rgba(177, 28, 49, 0.52));
-  clip-path: none;
-  box-shadow: none;
 }
 
 :root[data-theme='crimson'] body .game-page-layout .scene-panel > .tab-bar .tab-active::after {
@@ -1073,24 +1078,6 @@
   transform: none !important;
   filter: none;
   text-shadow: 0 0 7px rgba(151, 43, 57, 0.34);
-}
-
-:root[data-theme='crimson'] body .game-page-layout .hold-body > .tab-bar .tab-active::before {
-  content: '';
-  position: absolute;
-  z-index: 1;
-  inset: 0;
-  pointer-events: none;
-  background-color: transparent;
-  background-image: var(--crimson-tab-cap);
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 100% 100%;
-  opacity: 1;
-  filter: brightness(1.18) contrast(1.08) saturate(1.04) drop-shadow(0 3px 2px rgba(0, 0, 0, 0.74))
-    drop-shadow(0 1px 2px rgba(177, 28, 49, 0.52));
-  clip-path: none;
-  box-shadow: none;
 }
 
 :root[data-theme='crimson'] body .game-page-layout .hold-body > .tab-bar .tab-active::after {
@@ -1446,11 +1433,63 @@
   width: 100%;
   height: 100%;
   background-image: var(--crimson-right-panel);
-  background-size: auto max(100%, 62rem);
+  background-size: cover;
   background-position: right bottom;
   mix-blend-mode: normal;
   opacity: 0.62;
   transform: none;
+}
+
+/* Interaction-only pilot: hover reveals an inlay on the stationary strip. */
+:root[data-theme='crimson']
+  body
+  .game-page-layout
+  .hold-body
+  > .tab-bar
+  .tab-item:not(.tab-active)::after {
+  display: block;
+  content: '';
+  position: absolute;
+  z-index: 2;
+  right: 20%;
+  bottom: 5px;
+  left: 20%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgb(var(--crimson-inlay-gold-rgb) / 82%),
+    transparent
+  );
+  opacity: 0;
+  transform: scaleX(0.35);
+  transition:
+    opacity 180ms ease-out,
+    transform 180ms ease-out;
+  pointer-events: none;
+}
+
+:root[data-theme='crimson']
+  body
+  .game-page-layout
+  .hold-body
+  > .tab-bar
+  .tab-item:not(.tab-active):is(:hover, :focus-visible) {
+  color: var(--theme-text-primary);
+  outline: none;
+  text-shadow:
+    0 0 7px color-mix(in srgb, var(--theme-primary) 42%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.82);
+}
+
+:root[data-theme='crimson']
+  body
+  .game-page-layout
+  .hold-body
+  > .tab-bar
+  .tab-item:not(.tab-active):is(:hover, :focus-visible)::after {
+  opacity: 0.82;
+  transform: scaleX(1);
 }
 
 /* Stats, effects, and inventory share one neutral liquid-glass body. Their
@@ -1677,8 +1716,8 @@
   filter: brightness(1.32) contrast(1.06) saturate(0.94) drop-shadow(0 2px 2px rgba(0, 0, 0, 0.72));
 }
 
-:root[data-theme='crimson'] body .game-page-layout .scene-panel > .tab-bar .tab-active::before,
-:root[data-theme='crimson'] body .game-page-layout .hold-body > .tab-bar .tab-active::before {
+:root[data-theme='crimson'] body .game-page-layout .scene-panel > .tab-bar .tab-selection,
+:root[data-theme='crimson'] body .game-page-layout .hold-body > .tab-bar .tab-selection {
   filter: brightness(1.28) contrast(1.06) saturate(1.04) drop-shadow(0 3px 2px rgba(0, 0, 0, 0.7))
     drop-shadow(0 1px 2px rgba(177, 28, 49, 0.48));
 }

--- a/tests/theme-surface-ownership.test.ts
+++ b/tests/theme-surface-ownership.test.ts
@@ -25,6 +25,16 @@ function readRule(css: string, selector: string): string {
   return css.slice(start, end + 1);
 }
 
+function readLastRule(css: string, selector: string): string {
+  const start = css.lastIndexOf(selector);
+  const end = css.indexOf('}', start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  return css.slice(start, end + 1);
+}
+
 describe('play-area theme surface ownership', () => {
   it('does not bake responsive panel frames into fixed 16:9 viewport plates', () => {
     const integrationCss = readFileSync(
@@ -80,5 +90,38 @@ describe('play-area theme surface ownership', () => {
 
     expect(rule).toContain('gilded-orrery-field-v2.webp');
     expect(rule).toMatch(/background-size:\s*100% 100%,\s*cover;/);
+  });
+
+  it('keeps the Crimson right-panel artwork covered at wide viewports', () => {
+    const crimsonCss = readFileSync(join(UI_ROOT, 'themes', 'crimson.css'), 'utf8');
+    const rule = readLastRule(
+      crimsonCss,
+      ":root[data-theme='crimson'] body .game-page-layout .status-hud::after",
+    );
+
+    expect(rule).toContain('background-image: var(--crimson-right-panel);');
+    expect(rule).toContain('background-size: cover;');
+    expect(rule).toContain('background-position: right bottom;');
+  });
+
+  it('slides one shared Crimson cap between stationary tab buttons', () => {
+    const crimsonCss = readFileSync(join(UI_ROOT, 'themes', 'crimson.css'), 'utf8');
+    const appTabs = readFileSync(join(UI_ROOT, 'components', 'shared', 'AppTabs.vue'), 'utf8');
+    const activeTabRule = readLastRule(
+      crimsonCss,
+      ":root[data-theme='crimson'] body .game-page-layout .hold-body > .tab-bar .tab-active {",
+    );
+
+    expect(appTabs).toContain('class="tab-selection"');
+    expect(appTabs).toContain("'--tab-selection-offset': `${activeIndex * 100}%`");
+    expect(appTabs).toContain("'--tab-selection-width': `${100 / count}%`");
+    expect(crimsonCss).toContain('background-image: var(--crimson-tab-cap);');
+    expect(crimsonCss).toContain('transform: translateX(var(--tab-selection-offset));');
+    expect(crimsonCss).toContain('transition: transform 180ms ease;');
+    expect(activeTabRule).toContain('transform: none !important;');
+    expect(crimsonCss).not.toContain('translateY(3px)');
+    expect(crimsonCss).not.toContain('.tab-active::before');
+    expect(crimsonCss).not.toContain('animation:');
+    expect(crimsonCss).not.toContain('@keyframes');
   });
 });


### PR DESCRIPTION
## What changed

- make the Crimson right-panel artwork cover wide and 4K layouts without black edges
- replace per-tab active artwork with one shared stone cap that slides horizontally between fixed tab buttons
- keep motion interaction-only and document the approved behavior
- add focused regression coverage for panel ownership and tab motion

## Why

The right-panel artwork previously used a height-driven size that could leave uncovered space on wide 16:9 displays. The tab experiment also moved individual buttons instead of moving a shared selection indicator. This change assigns the background to `cover` and moves only the shared active cap.

## Validation

- `npm run test -- --run tests/theme-surface-ownership.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test -- --run --maxWorkers=1` (286 files, 7,338 passed, 9 skipped)
- live Crimson game-page verification at 1280x720; both tab strips aligned and browser console reported no errors
