### PR TITLE
polish(ui): facelift combat command table

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -55,6 +55,25 @@ Flexibility: materials and ornament may vary; frame ownership may not
 - Validate 1920 x 1080, 2560 x 1440, and 3840 x 2160, plus one taller and one
   wider stress viewport before handoff.
 
+### Combat command table
+
+Status: owner-approved structural direction
+Scope: the active combat overlay across all themes
+Flexibility: materials and ornament may vary by theme; the feature and interaction contract may not
+
+- Build the combat overlay entirely from live HTML and CSS. Do not add runtime
+  artwork for its frame, side plaques, initiative rail, ledger, or controls.
+- Preserve the composition order: header and existing initiative projection,
+  enemy roster, scrollable battle ledger, ally roster, then command dock.
+- Retain the ready gate, collapse and reopen affordance, unit details, buffs,
+  morale, structured commands, free-text commands, end turn, skip, and restart.
+- The UI may reorganize existing `CombatView` data but must not add a
+  `CombatCommand`, engine state, or combat mechanic.
+- Use each theme's semantic surfaces and colors, with the primary accent limited
+  to seams, active states, and restrained hierarchy cues.
+- Reflow the command dock and keep the battlefield scrollable on narrow
+  viewports; do not remove or merge existing actions to make them fit.
+
 ## Theme-specific decisions
 
 ### Qinghua porcelain

--- a/src/ui/components/game/combat/CombatActionBar.vue
+++ b/src/ui/components/game/combat/CombatActionBar.vue
@@ -325,7 +325,7 @@ function handleKeydown(e: KeyboardEvent) {
       <div class="section-label">快捷拼装</div>
 
       <!-- 步骤 1：我方单位 -->
-      <div class="step-row">
+      <div class="step-row step-unit">
         <label class="step-label">单位</label>
         <select
           v-model="selectedUnitId"
@@ -358,7 +358,7 @@ function handleKeydown(e: KeyboardEvent) {
       </div>
 
       <!-- 步骤 3：技能/道具选择（仅 skill/item 显示） -->
-      <div v-if="activeTab?.needsDetail" class="step-row">
+      <div v-if="activeTab?.needsDetail" class="step-row step-detail">
         <label class="step-label">{{ selectedAction === 'skill' ? '技能' : '道具' }}</label>
         <select
           v-model="selectedDetail"
@@ -382,7 +382,11 @@ function handleKeydown(e: KeyboardEvent) {
       </div>
 
       <!-- 步骤 4：目标选择（普攻必选；攻击型技能可选） -->
-      <div v-if="activeTab?.needsTarget" class="step-row">
+      <div
+        v-if="activeTab?.needsTarget"
+        class="step-row step-target"
+        :class="{ 'without-detail': !activeTab.needsDetail }"
+      >
         <label class="step-label">目标</label>
         <select
           v-model="selectedTargetId"
@@ -405,42 +409,55 @@ function handleKeydown(e: KeyboardEvent) {
 
     <!-- ═══ 自由文本框 + 发送 + 结束回合 ═══ -->
     <div class="input-section">
-      <textarea
-        v-model="inputText"
-        class="combat-textarea"
-        :class="{ 'is-locked': isLocked }"
-        :disabled="isLocked"
-        placeholder="描述我方行动…（可点上方拼装直接执行，也可手打如“攻击骷髅兵”；“结束回合”放弃当前单位剩余行动）"
-        rows="2"
-        @keydown="handleKeydown"
-      />
-      <button
-        class="end-turn-btn"
-        :class="{ 'is-disabled': isLocked }"
-        :disabled="isLocked"
-        @click="handleEndTurn"
-      >
-        结束回合
-      </button>
-      <button
-        class="send-btn"
-        :class="{ 'is-disabled': !canSend }"
-        :disabled="!canSend"
-        @click="handleSend"
-      >
-        发送
-      </button>
+      <div class="section-label input-section-label">
+        行动指令 <span>可输入自定义指令 · Ctrl / ⌘ + Enter 发送</span>
+      </div>
+      <div class="input-controls">
+        <textarea
+          v-model="inputText"
+          class="combat-textarea"
+          :class="{ 'is-locked': isLocked }"
+          :disabled="isLocked"
+          placeholder="描述我方行动…（可点左侧拼装直接执行，也可手打如“攻击骷髅兵”）"
+          rows="2"
+          @keydown="handleKeydown"
+        />
+        <div class="input-actions">
+          <button
+            class="end-turn-btn"
+            :class="{ 'is-disabled': isLocked }"
+            :disabled="isLocked"
+            @click="handleEndTurn"
+          >
+            结束回合
+          </button>
+          <button
+            class="send-btn"
+            :class="{ 'is-disabled': !canSend }"
+            :disabled="!canSend"
+            @click="handleSend"
+          >
+            发送
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <style scoped>
 .combat-action-bar {
-  display: flex;
-  flex-direction: column;
-  gap: var(--theme-spacing-sm);
-  padding: var(--theme-spacing-md);
-  background: var(--theme-bg-secondary, var(--theme-card-bg));
+  display: grid;
+  grid-template-columns: minmax(34rem, 1.15fr) minmax(24rem, 0.85fr);
+  gap: var(--theme-spacing-md);
+  padding: var(--theme-spacing-md) var(--theme-spacing-lg);
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--theme-primary) 4%, transparent),
+      transparent 45%
+    ),
+    var(--theme-surface-muted);
   border-top: 1px solid var(--theme-card-border);
   position: relative;
 }
@@ -459,6 +476,7 @@ function handleKeydown(e: KeyboardEvent) {
   justify-content: center;
   z-index: 2;
   pointer-events: none;
+  background: color-mix(in srgb, var(--theme-content-bg) 48%, transparent);
 }
 
 .lock-hint {
@@ -468,37 +486,82 @@ function handleKeydown(e: KeyboardEvent) {
   background: var(--theme-card-bg);
   padding: var(--theme-spacing-sm) var(--theme-spacing-lg);
   border-radius: var(--theme-radius-sm);
-  border: 1px solid var(--theme-card-border);
+  border: 1px solid color-mix(in srgb, var(--theme-primary) 28%, var(--theme-card-border));
   letter-spacing: 0.05em;
 }
 
 /* ═══ 快捷拼装区 ═══ */
 .assemble-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--theme-spacing-xs);
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(8rem, 0.8fr) minmax(16rem, 1.35fr) minmax(10rem, 1fr) auto;
+  grid-template-rows: auto auto auto;
+  gap: var(--theme-spacing-sm);
+  padding: var(--theme-spacing-sm);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  background: color-mix(in srgb, var(--theme-card-bg) 82%, var(--theme-content-bg));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--theme-text-primary) 4%, transparent);
 }
 
 .section-label {
-  font-size: 0.8rem;
-  color: var(--theme-text-muted);
-  font-weight: 500;
-  margin-bottom: var(--theme-spacing-xs);
-}
-
-.step-row {
+  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   gap: var(--theme-spacing-sm);
+  font-family: var(--theme-font-title);
+  font-size: 0.75rem;
+  color: var(--theme-text-muted);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.section-label::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(to right, var(--theme-card-border), transparent);
+}
+
+.step-row {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--theme-spacing-xs);
   min-height: 36px; /* 触摸目标 ≥ 36px */
 }
 
+.step-unit {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.step-actions {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.step-detail {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.step-target {
+  grid-column: 3;
+  grid-row: 3;
+}
+
+.step-target.without-detail {
+  grid-row: 2;
+}
+
 .step-label {
-  flex-shrink: 0;
-  width: 3em;
-  font-size: 0.85rem;
-  color: var(--theme-text-secondary, var(--theme-text-muted));
-  text-align: right;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--theme-text-muted);
+  text-align: left;
+  letter-spacing: 0.04em;
 }
 
 .step-select {
@@ -509,7 +572,7 @@ function handleKeydown(e: KeyboardEvent) {
   background: var(--theme-card-bg);
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-sm);
-  color: var(--theme-text);
+  color: var(--theme-text-primary);
   font-size: 0.88rem;
   font-family: var(--theme-font-body);
   cursor: pointer;
@@ -520,9 +583,10 @@ function handleKeydown(e: KeyboardEvent) {
   border-color: var(--theme-primary);
 }
 
-.step-select:focus {
+.step-select:focus-visible {
   outline: none;
   border-color: var(--theme-primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-primary) 18%, transparent);
 }
 
 .step-select:disabled {
@@ -532,12 +596,12 @@ function handleKeydown(e: KeyboardEvent) {
 
 /* ── 行动 Tab ── */
 .step-actions {
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 .action-tabs {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3.5rem, 1fr));
   gap: var(--theme-spacing-xs);
 }
 
@@ -548,7 +612,7 @@ function handleKeydown(e: KeyboardEvent) {
   background: var(--theme-card-bg);
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-sm);
-  color: var(--theme-text-secondary, var(--theme-text));
+  color: var(--theme-text-secondary);
   font-size: 0.85rem;
   font-family: var(--theme-font-body);
   cursor: pointer;
@@ -561,6 +625,11 @@ function handleKeydown(e: KeyboardEvent) {
 .action-tab:hover:not(:disabled) {
   border-color: var(--theme-primary);
   color: var(--theme-primary);
+}
+
+.action-tab:focus-visible {
+  outline: 2px solid var(--theme-primary);
+  outline-offset: 2px;
 }
 
 /* selected 态：primary 8% 染底（design §4.2） */
@@ -578,21 +647,34 @@ function handleKeydown(e: KeyboardEvent) {
 
 /* ── 注入按钮 ── */
 .inject-btn {
-  align-self: flex-end;
-  min-height: 36px;
+  grid-column: 4;
+  grid-row: 2;
+  align-self: end;
+  min-height: 44px;
   padding: var(--theme-spacing-xs) var(--theme-spacing-lg);
   background: var(--theme-primary);
-  border: none;
+  border: 1px solid var(--theme-primary);
   border-radius: var(--theme-radius-sm);
-  color: var(--theme-btn-text, #fff);
+  color: var(--theme-primary-text);
   font-size: 0.85rem;
   font-family: var(--theme-font-body);
+  font-weight: 700;
+  white-space: nowrap;
   cursor: pointer;
-  transition: opacity var(--theme-transition-fast);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--theme-primary) 12%, transparent);
+  transition:
+    filter var(--theme-transition-fast),
+    box-shadow var(--theme-transition-fast);
 }
 
 .inject-btn:hover:not(:disabled) {
-  opacity: 0.85;
+  filter: brightness(1.08);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--theme-primary) 22%, transparent);
+}
+
+.inject-btn:focus-visible {
+  outline: 2px solid var(--theme-primary);
+  outline-offset: 2px;
 }
 
 .inject-btn:disabled {
@@ -602,29 +684,54 @@ function handleKeydown(e: KeyboardEvent) {
 
 /* ═══ 文本框 + 发送 ═══ */
 .input-section {
+  min-width: 0;
   display: flex;
+  flex-direction: column;
   gap: var(--theme-spacing-sm);
-  align-items: flex-end;
+  padding: var(--theme-spacing-sm);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  background: color-mix(in srgb, var(--theme-card-bg) 82%, var(--theme-content-bg));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--theme-text-primary) 4%, transparent);
+}
+
+.input-section-label span {
+  color: var(--theme-text-muted);
+  font-family: var(--theme-font-body);
+  font-size: 0.6875rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  opacity: 0.75;
+}
+
+.input-controls {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--theme-spacing-sm);
+  align-items: stretch;
 }
 
 .combat-textarea {
-  flex: 1;
-  min-height: 56px;
+  width: 100%;
+  min-height: 5rem;
+  max-height: 8rem;
   resize: vertical;
   padding: var(--theme-spacing-sm);
   background: var(--theme-card-bg);
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-sm);
-  color: var(--theme-text);
+  color: var(--theme-text-primary);
   font-size: 0.9rem;
   font-family: var(--theme-font-body);
   line-height: 1.5;
   transition: border-color var(--theme-transition-fast);
 }
 
-.combat-textarea:focus {
+.combat-textarea:focus-visible {
   outline: none;
   border-color: var(--theme-primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-primary) 18%, transparent);
 }
 
 .combat-textarea::placeholder {
@@ -632,11 +739,17 @@ function handleKeydown(e: KeyboardEvent) {
   opacity: 0.7;
 }
 
+.input-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(5.5rem, 1fr));
+  gap: var(--theme-spacing-sm);
+}
+
 /* ── 结束回合按钮（secondary 变体：design §4.1）──
    与「发送」（primary 实心）区分主次：结束回合是放弃语义，用描边次级样式 */
 .end-turn-btn {
   flex-shrink: 0;
-  min-height: 36px;
+  min-height: 44px;
   min-width: 64px;
   padding: var(--theme-spacing-sm) var(--theme-spacing-lg);
   background: var(--theme-card-bg);
@@ -651,8 +764,13 @@ function handleKeydown(e: KeyboardEvent) {
     border-color var(--theme-transition-fast);
 }
 
+.end-turn-btn:focus-visible {
+  outline: 2px solid var(--theme-primary);
+  outline-offset: 2px;
+}
+
 .end-turn-btn:hover:not(:disabled) {
-  background: var(--theme-surface-muted, var(--theme-card-bg));
+  background: var(--theme-surface-muted);
   border-color: var(--theme-primary);
 }
 
@@ -663,28 +781,96 @@ function handleKeydown(e: KeyboardEvent) {
 
 .send-btn {
   flex-shrink: 0;
-  min-height: 36px;
+  min-height: 44px;
   min-width: 64px;
   padding: var(--theme-spacing-sm) var(--theme-spacing-lg);
   background: var(--theme-primary);
-  border: none;
+  border: 1px solid var(--theme-primary);
   border-radius: var(--theme-radius-sm);
-  color: var(--theme-btn-text, #fff);
+  color: var(--theme-primary-text);
   font-size: 0.9rem;
   font-family: var(--theme-font-body);
   font-weight: 600;
   cursor: pointer;
-  transition: opacity var(--theme-transition-fast);
+  transition: filter var(--theme-transition-fast);
 }
 
 .send-btn:hover:not(:disabled) {
-  opacity: 0.85;
+  filter: brightness(1.08);
+}
+
+.send-btn:focus-visible {
+  outline: 2px solid var(--theme-primary);
+  outline-offset: 2px;
 }
 
 /* 用 .is-disabled 类避开全局 .disabled 陷阱（CLAUDE.md 编码模式） */
 .send-btn.is-disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .lock-overlay {
+    background: var(--theme-content-bg);
+  }
+}
+
+@media (max-width: 1200px) {
+  .combat-action-bar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .combat-textarea {
+    min-height: 4.5rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .combat-action-bar {
+    padding: var(--theme-spacing-sm);
+  }
+
+  .assemble-section {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto;
+  }
+
+  .step-unit,
+  .step-actions,
+  .step-detail,
+  .step-target,
+  .step-target.without-detail,
+  .inject-btn {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .action-tabs {
+    grid-template-columns: repeat(3, minmax(4rem, 1fr));
+  }
+
+  .input-controls {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .input-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .input-section-label span {
+    display: none;
+  }
+}
+
+@media (max-height: 720px) and (min-width: 1201px) {
+  .combat-action-bar {
+    padding-block: var(--theme-spacing-sm);
+  }
+
+  .combat-textarea {
+    min-height: 4rem;
+  }
 }
 
 /* ── prefers-reduced-motion（design §6.3）── */

--- a/src/ui/components/game/combat/CombatActionCard.vue
+++ b/src/ui/components/game/combat/CombatActionCard.vue
@@ -144,6 +144,9 @@ const ratingColor = computed((): string => {
 /** 工具名 → 中文标签映射 */
 const toolLabel = computed((): string => {
   const map: Record<string, string> = {
+    attack: '攻击',
+    cost: '消耗',
+    flee: '逃跑',
     combat_attack: '攻击',
     combat_use_skill: '技能',
     combat_use_item: '道具',
@@ -363,11 +366,12 @@ const fullResult = computed((): CombatActionResult | null => {
 <style scoped>
 /* ════════ 卡片骨架 ════════ */
 .combat-action-card {
-  border: 1px solid var(--theme-card-border);
-  border-radius: var(--theme-radius-md, 6px);
+  border: 1px solid transparent;
+  border-bottom-color: var(--theme-card-border);
+  border-radius: 0;
   overflow: hidden;
-  background: var(--theme-card-bg);
-  box-shadow: var(--paper-stack, 0 2px 8px rgba(0, 0, 0, 0.15));
+  background: transparent;
+  box-shadow: none;
 }
 
 /* ════════ 折叠态头部 ════════ */
@@ -375,15 +379,17 @@ const fullResult = computed((): CombatActionResult | null => {
   display: flex;
   align-items: center;
   gap: var(--theme-spacing-sm, 8px);
-  padding: 8px var(--theme-spacing-md, 12px);
+  padding: var(--theme-spacing-sm) var(--theme-spacing-md);
   min-height: 36px; /* design §8: 触摸目标 ≥ 36px */
   cursor: pointer;
   user-select: none;
-  background: var(--theme-surface-muted);
-  transition: background 0.15s ease;
+  background: transparent;
+  transition:
+    background var(--theme-transition-fast),
+    border-color var(--theme-transition-fast);
 }
 .cac-header:hover {
-  background: var(--theme-surface-hover, var(--theme-card-bg));
+  background: color-mix(in srgb, var(--theme-primary) 5%, var(--theme-card-bg));
 }
 .cac-header:focus-visible {
   outline: 2px solid var(--theme-primary);
@@ -403,7 +409,7 @@ const fullResult = computed((): CombatActionResult | null => {
   color: var(--theme-text-muted);
   background: var(--theme-card-bg);
   padding: 1px 6px;
-  border-radius: var(--theme-radius-sm, 4px);
+  border-radius: var(--theme-radius-sm);
   border: 1px solid var(--theme-card-border);
 }
 
@@ -501,12 +507,14 @@ const fullResult = computed((): CombatActionResult | null => {
 
 /* ════════ 展开态内容 ════════ */
 .cac-body {
-  padding: var(--theme-spacing-md, 12px) var(--theme-spacing-md, 12px);
+  padding: var(--theme-spacing-md);
   display: flex;
   flex-direction: column;
   gap: var(--theme-spacing-sm, 8px);
   font-size: 0.75rem; /* 12px 管线步 */
   color: var(--theme-text-primary);
+  background: color-mix(in srgb, var(--theme-card-bg) 76%, var(--theme-content-bg));
+  border-top: 1px solid var(--theme-card-border);
 }
 
 .cac-body--fallback {

--- a/src/ui/components/game/combat/CombatHeader.test.ts
+++ b/src/ui/components/game/combat/CombatHeader.test.ts
@@ -1,0 +1,62 @@
+/**
+ * CombatHeader.test.ts — Command Table 行动轴投影。
+ *
+ * 行动轴只可视化 CombatView 已有的 initiativeOrder / units / 当前行动者，
+ * 不创建新战斗状态或控制入口。
+ *
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+import { mount } from '@vue/test-utils';
+
+let mockGame: Record<string, unknown>;
+
+vi.mock('../../../stores/game-store', () => ({ useGameStore: () => mockGame }));
+
+import CombatHeader from './CombatHeader.vue';
+
+beforeEach(() => {
+  mockGame = reactive({
+    v3ActiveCombat: {
+      round: 2,
+      initiativeOrder: ['莱恩', '灰刃', '紫岚'],
+      units: {
+        莱恩: { id: '莱恩', name: '莱恩', side: 'player' },
+        灰刃: { id: '灰刃', name: '灰刃·科尔', side: 'enemy' },
+        紫岚: { id: '紫岚', name: '紫岚', side: 'player' },
+      },
+    },
+    combatCurrentUnitId: '灰刃',
+    combatAwaitingInput: null,
+  });
+});
+
+describe('CombatHeader — existing initiative projection', () => {
+  it('renders the existing initiative order and marks the current unit without changing geometry', () => {
+    const wrapper = mount(CombatHeader);
+    const entries = wrapper.findAll('.initiative-entry');
+
+    expect(entries.map((entry) => entry.find('.initiative-name').text())).toEqual([
+      '莱恩',
+      '灰刃·科尔',
+      '紫岚',
+    ]);
+    expect(entries[1].classes()).toContain('is-active');
+    expect(entries[1].classes()).toContain('is-enemy');
+    expect(entries[1].attributes('aria-current')).toBe('step');
+    expect(wrapper.find('.combat-round').text()).toBe('第 2 回合');
+  });
+
+  it('uses the existing awaiting-player unit when no turn event is active', () => {
+    mockGame.combatCurrentUnitId = null;
+    mockGame.combatAwaitingInput = { unitId: '紫岚' };
+
+    const wrapper = mount(CombatHeader);
+    const entries = wrapper.findAll('.initiative-entry');
+
+    expect(entries[2].classes()).toContain('is-active');
+    expect(entries[2].classes()).toContain('is-player');
+    expect(wrapper.find('.combat-your-turn').text()).toBe('轮到你了');
+  });
+});

--- a/src/ui/components/game/combat/CombatHeader.vue
+++ b/src/ui/components/game/combat/CombatHeader.vue
@@ -1,11 +1,22 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useGameStore } from '../../../stores/game-store';
 
 const game = useGameStore();
+
+const initiative = computed(() => {
+  const combat = game.v3ActiveCombat;
+  if (!combat) return [];
+  return combat.initiativeOrder.map((id) => ({ id, unit: combat.units[id] }));
+});
+
+const activeUnitId = computed(
+  () => game.combatCurrentUnitId ?? game.combatAwaitingInput?.unitId ?? null,
+);
 </script>
 
 <template>
-  <div class="combat-header">
+  <header class="combat-header">
     <div class="combat-title">
       <i class="fa-solid fa-hand-fist combat-title-icon" />
       <!-- v3 CombatView 无 combatType / environment 字段（开战 bundle 不投影），
@@ -13,52 +24,219 @@ const game = useGameStore();
       <span class="combat-type">战斗</span>
       <span class="combat-round">第 {{ game.v3ActiveCombat?.round ?? 1 }} 回合</span>
     </div>
+
+    <ol v-if="initiative.length" class="combat-initiative" aria-label="本回合行动顺序">
+      <li
+        v-for="(entry, index) in initiative"
+        :key="entry.id"
+        class="initiative-entry"
+        :class="{
+          'is-active': entry.id === activeUnitId,
+          'is-enemy': entry.unit?.side === 'enemy',
+          'is-player': entry.unit?.side === 'player',
+        }"
+        :aria-current="entry.id === activeUnitId ? 'step' : undefined"
+      >
+        <span class="initiative-marker" aria-hidden="true">
+          <span>{{ index + 1 }}</span>
+        </span>
+        <span class="initiative-name">{{ entry.unit?.name ?? entry.id }}</span>
+      </li>
+    </ol>
+
     <div class="combat-status">
       <span v-if="game.combatAwaitingInput" class="combat-your-turn">轮到你了</span>
       <span v-else class="combat-thinking">敌方行动中…</span>
     </div>
-  </div>
+  </header>
 </template>
 
 <style scoped>
 .combat-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
   align-items: center;
-  justify-content: space-between;
-  padding: var(--theme-spacing-md) var(--theme-spacing-lg);
+  gap: var(--theme-spacing-xl);
+  padding: var(--theme-spacing-md) calc(36px + var(--theme-spacing-xl)) var(--theme-spacing-md)
+    var(--theme-spacing-lg);
   border-bottom: 1px solid var(--theme-card-border);
-  background: var(--theme-card-bg);
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--theme-primary) 5%, transparent),
+      transparent 28%,
+      transparent 72%,
+      color-mix(in srgb, var(--theme-primary) 4%, transparent)
+    ),
+    var(--theme-title-bar-bg);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--theme-primary) 18%, transparent);
 }
 .combat-title {
   display: flex;
   align-items: center;
   gap: var(--theme-spacing-sm);
   font-family: var(--theme-font-title);
-  font-size: 0.9375rem;
+  font-size: 1.125rem;
   color: var(--theme-text-primary);
+  white-space: nowrap;
 }
 .combat-title-icon {
   color: var(--theme-primary);
-  font-size: 0.875rem;
+  font-size: 1rem;
 }
 .combat-round {
-  font-size: 0.75rem;
-  color: var(--theme-text-muted);
-  font-family: system-ui, sans-serif;
+  margin-left: var(--theme-spacing-sm);
+  font-size: 0.8125rem;
+  color: var(--theme-text-secondary);
+  font-family: var(--theme-font-body);
+  font-weight: 500;
 }
+
+.combat-initiative {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: flex-start;
+  list-style: none;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.initiative-entry {
+  position: relative;
+  isolation: isolate;
+  flex: 1 0 78px;
+  min-width: 0;
+  display: grid;
+  justify-items: center;
+  gap: var(--theme-spacing-xs);
+  color: var(--theme-text-muted);
+  font-family: var(--theme-font-body);
+  font-size: 0.6875rem;
+}
+
+.initiative-entry::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  top: 8px;
+  left: calc(50% + 13px);
+  width: calc(100% - 26px);
+  height: 1px;
+  background: color-mix(in srgb, var(--theme-primary) 28%, var(--theme-card-border));
+}
+
+.initiative-entry:last-child::after {
+  display: none;
+}
+
+.initiative-marker {
+  width: 16px;
+  height: 16px;
+  display: grid;
+  place-items: center;
+  transform: rotate(45deg);
+  border: 1px solid var(--theme-card-border);
+  background: var(--theme-card-bg);
+  color: var(--theme-text-muted);
+  box-shadow: 0 0 0 2px var(--theme-title-bar-bg);
+  transition:
+    background var(--theme-transition-fast),
+    border-color var(--theme-transition-fast),
+    box-shadow var(--theme-transition-fast),
+    color var(--theme-transition-fast);
+}
+
+.initiative-marker > span {
+  transform: rotate(-45deg);
+  font-size: 0.5625rem;
+  line-height: 1;
+}
+
+.initiative-entry.is-enemy .initiative-marker {
+  border-color: color-mix(in srgb, var(--theme-error) 65%, var(--theme-card-border));
+}
+
+.initiative-entry.is-player .initiative-marker {
+  border-color: color-mix(in srgb, var(--theme-primary) 65%, var(--theme-card-border));
+}
+
+.initiative-entry.is-active {
+  color: var(--theme-primary);
+  font-weight: 600;
+}
+
+.initiative-entry.is-active .initiative-marker {
+  color: var(--theme-primary-text);
+  border-color: var(--theme-primary);
+  background: var(--theme-primary);
+  box-shadow:
+    0 0 0 2px var(--theme-title-bar-bg),
+    0 0 12px color-mix(in srgb, var(--theme-primary) 52%, transparent);
+}
+
+.initiative-name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .combat-status {
   font-size: 0.75rem;
-  font-family: system-ui, sans-serif;
+  font-family: var(--theme-font-body);
+  text-align: right;
+  white-space: nowrap;
 }
 .combat-your-turn {
   color: var(--theme-primary);
   font-weight: 600;
-  padding: 3px var(--theme-spacing-sm);
+  padding: var(--theme-spacing-xs) var(--theme-spacing-md);
   border-radius: var(--theme-radius-sm);
-  background: color-mix(in srgb, var(--theme-primary) 12%, transparent);
+  background: color-mix(in srgb, var(--theme-primary) 10%, var(--theme-card-bg));
+  border: 1px solid color-mix(in srgb, var(--theme-primary) 28%, var(--theme-card-border));
 }
 .combat-thinking {
   color: var(--theme-text-muted);
   font-style: italic;
+}
+
+@media (max-width: 960px) {
+  .combat-header {
+    grid-template-columns: 1fr max-content;
+    gap: var(--theme-spacing-sm) var(--theme-spacing-lg);
+  }
+
+  .combat-initiative {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}
+
+@media (max-width: 600px) {
+  .combat-header {
+    padding: var(--theme-spacing-sm) calc(36px + var(--theme-spacing-lg)) var(--theme-spacing-sm)
+      var(--theme-spacing-md);
+  }
+
+  .combat-title {
+    font-size: 1rem;
+  }
+
+  .combat-round {
+    margin-left: 0;
+    font-size: 0.75rem;
+  }
+
+  .initiative-entry {
+    flex-basis: 68px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .initiative-marker {
+    transition: none;
+  }
 }
 </style>

--- a/src/ui/components/game/combat/CombatMessageFlow.vue
+++ b/src/ui/components/game/combat/CombatMessageFlow.vue
@@ -79,15 +79,24 @@ watch(
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--theme-primary) 2%, transparent),
+      transparent 30%
+    ),
+    var(--theme-content-bg);
 }
 
 .combat-messages {
   flex: 1;
   overflow-y: auto;
-  padding: var(--theme-spacing-lg, 20px) 20px 28px;
+  padding: var(--theme-spacing-md) var(--theme-spacing-xl);
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: var(--theme-spacing-sm);
+  scrollbar-width: thin;
+  scrollbar-color: var(--theme-card-border) transparent;
 }
 
 /* ===== 空态（design.md §5.2） ===== */
@@ -112,12 +121,12 @@ watch(
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  padding: 4px 0;
+  gap: var(--theme-spacing-md);
+  padding: var(--theme-spacing-xs) 0;
   font-size: 0.75rem;
   letter-spacing: 0.05em;
   color: var(--theme-text-muted);
-  font-family: var(--theme-font-title, 'Noto Serif SC', serif);
+  font-family: var(--theme-font-title);
   position: relative;
 }
 /* 两侧渐变线（::before 左 / ::after 右） */
@@ -170,17 +179,16 @@ watch(
 /* 叙事行 + 动作行均居中 */
 .bubble-row-narrative,
 .bubble-row-action {
-  justify-content: center;
+  justify-content: stretch;
 }
 
 /* ===== 叙事气泡（参考 ChatFlow .bubble-narrative-full） ===== */
 .bubble {
   width: 100%;
-  max-width: 70ch;
-  padding: 4px 8px;
-  border-radius: var(--theme-radius-md, 8px);
-  font-size: 0.9375rem;
-  line-height: 1.8;
+  padding: var(--theme-spacing-xs) var(--theme-spacing-sm);
+  border-radius: var(--theme-radius-md);
+  font-size: 0.875rem;
+  line-height: 1.7;
   text-align: left;
 }
 .bubble-narrative-full {
@@ -191,7 +199,9 @@ watch(
 
 /* 叙事正文段落（design.md §2.5 首行缩进） */
 .narrative-body {
-  font-family: var(--theme-font-title, 'Noto Serif SC', serif);
+  max-width: 90ch;
+  margin-inline: auto;
+  font-family: var(--theme-font-title);
   color: var(--theme-text-primary);
   line-height: 1.8;
   text-wrap: pretty;
@@ -210,6 +220,22 @@ watch(
 
 /* ===== 动作卡片行 ===== */
 .bubble-row-action {
-  /* CombatActionCard 自身控制宽度（max-width 72ch 级别） */
+  width: 100%;
+  position: relative;
+  padding-left: var(--theme-spacing-lg);
+}
+
+.bubble-row-action::before {
+  content: '◇';
+  position: absolute;
+  left: 0;
+  top: var(--theme-spacing-sm);
+  color: var(--theme-primary);
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
+.bubble-row-action :deep(.combat-action-card) {
+  width: 100%;
 }
 </style>

--- a/src/ui/components/game/combat/CombatPanel.test.ts
+++ b/src/ui/components/game/combat/CombatPanel.test.ts
@@ -163,5 +163,6 @@ describe('CombatPanel F2 就绪态', () => {
     expect(wrapper.find('.combat-ready').exists()).toBe(false);
     expect(wrapper.find('.combat-header').exists()).toBe(true); // 开打态视图
     expect(wrapper.find('.combat-action-bar').exists()).toBe(true);
+    expect(wrapper.text()).toContain('100 / 100');
   });
 });

--- a/src/ui/components/game/combat/CombatPanel.vue
+++ b/src/ui/components/game/combat/CombatPanel.vue
@@ -63,7 +63,7 @@ const collapsed = ref(false);
           >
         </div>
 
-        <div v-else class="combat-panel">
+        <div v-else class="combat-panel" :class="{ 'is-ready': ready }">
           <button
             class="combat-collapse-btn"
             title="收起面板"
@@ -112,36 +112,58 @@ const collapsed = ref(false);
           <template v-else>
             <CombatHeader />
 
-            <div v-if="enemies.length" class="combat-units combat-enemies">
-              <span class="combat-side-label">【敌方】</span>
-              <div class="combat-unit-row">
-                <CombatUnitCard
-                  v-for="p in enemies"
-                  :key="p.id"
-                  :unit="p"
-                  :is-current-turn="game.combatCurrentUnitId === p.id"
-                />
-              </div>
-            </div>
+            <main class="combat-command-table">
+              <section
+                v-if="enemies.length"
+                class="combat-roster combat-roster-enemy"
+                aria-labelledby="combat-enemy-label"
+              >
+                <div class="combat-side-plaque combat-side-plaque-enemy">
+                  <span id="combat-enemy-label">敌方</span>
+                  <span class="combat-side-emblem" aria-hidden="true">◇</span>
+                </div>
+                <div class="combat-unit-row">
+                  <CombatUnitCard
+                    v-for="p in enemies"
+                    :key="p.id"
+                    :unit="p"
+                    :is-current-turn="game.combatCurrentUnitId === p.id"
+                  />
+                </div>
+              </section>
 
-            <CombatMessageFlow :entries="game.combatLog" class="combat-flow" />
+              <section class="combat-ledger" aria-labelledby="combat-ledger-label">
+                <div class="combat-ledger-heading">
+                  <span id="combat-ledger-label">战斗记录</span>
+                </div>
+                <CombatMessageFlow :entries="game.combatLog" class="combat-flow" />
+              </section>
 
-            <div v-if="allies.length" class="combat-units combat-allies">
-              <span class="combat-side-label">【我方】</span>
-              <div class="combat-unit-row">
-                <CombatUnitCard
-                  v-for="p in allies"
-                  :key="p.id"
-                  :unit="p"
-                  :is-current-turn="game.combatCurrentUnitId === p.id"
-                />
-              </div>
-            </div>
+              <section
+                v-if="allies.length"
+                class="combat-roster combat-roster-allies"
+                aria-labelledby="combat-ally-label"
+              >
+                <div class="combat-side-plaque combat-side-plaque-allies">
+                  <span id="combat-ally-label">我方</span>
+                  <span class="combat-side-emblem" aria-hidden="true">◇</span>
+                </div>
+                <div class="combat-unit-row">
+                  <CombatUnitCard
+                    v-for="p in allies"
+                    :key="p.id"
+                    :unit="p"
+                    :is-current-turn="game.combatCurrentUnitId === p.id"
+                  />
+                </div>
+              </section>
+            </main>
 
             <CombatActionBar />
 
             <!-- T16 §3.5：跳过 / 重开战斗（战斗内任何时候可用，不受敌方回合锁影响） -->
             <div class="combat-panel-actions">
+              <span class="combat-panel-actions-label">战斗控制</span>
               <AppButton variant="ghost" size="sm" @click="skipOpen = true">跳过战斗</AppButton>
               <AppButton variant="ghost" size="sm" @click="restartOpen = true">重开战斗</AppButton>
             </div>
@@ -175,24 +197,58 @@ const collapsed = ref(false);
   position: fixed;
   inset: 0;
   z-index: 1000;
-  background: var(--theme-overlay-bg, rgba(0, 0, 0, 0.7));
+  background: var(--theme-overlay-bg);
   backdrop-filter: blur(4px);
   display: flex;
-  align-items: stretch;
+  align-items: center;
   justify-content: center;
-  padding: var(--theme-spacing-lg);
+  padding: var(--theme-spacing-md);
 }
 .combat-panel {
-  width: 100%;
-  max-width: 1100px;
-  background: var(--theme-content-bg);
-  border: 1px solid var(--theme-card-border);
-  border-radius: var(--theme-radius-xl);
+  --combat-inlay: color-mix(in srgb, var(--theme-primary) 38%, var(--theme-card-border));
+  width: min(100%, 100rem);
+  height: min(60rem, calc(100dvh - var(--theme-spacing-md) - var(--theme-spacing-md)));
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--theme-primary) 5%, transparent),
+      transparent 18%
+    ),
+    var(--theme-content-bg);
+  border: 1px solid var(--combat-inlay);
+  border-radius: var(--theme-radius-md);
   box-shadow: var(--theme-shadow-lg);
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
   overflow: hidden;
   position: relative;
+  isolation: isolate;
+}
+.combat-panel::before,
+.combat-panel::after {
+  content: '';
+  position: absolute;
+  z-index: 6;
+  width: var(--theme-spacing-xl);
+  height: var(--theme-spacing-xl);
+  pointer-events: none;
+}
+.combat-panel::before {
+  top: var(--theme-spacing-xs);
+  left: var(--theme-spacing-xs);
+  border-top: 1px solid var(--theme-primary);
+  border-left: 1px solid var(--theme-primary);
+}
+.combat-panel::after {
+  right: var(--theme-spacing-xs);
+  bottom: var(--theme-spacing-xs);
+  border-right: 1px solid var(--theme-primary);
+  border-bottom: 1px solid var(--theme-primary);
+}
+.combat-panel.is-ready {
+  display: flex;
+  height: auto;
+  min-height: min(36rem, calc(100dvh - var(--theme-spacing-md) - var(--theme-spacing-md)));
 }
 
 /* ── 折叠按钮（右上角；就绪态与开打态共用）── */
@@ -200,14 +256,14 @@ const collapsed = ref(false);
   position: absolute;
   top: var(--theme-spacing-sm);
   right: var(--theme-spacing-sm);
-  z-index: 5;
-  width: 28px;
-  height: 28px;
+  z-index: 7;
+  width: 36px;
+  height: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: transparent;
-  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--theme-card-bg) 88%, transparent);
+  border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-sm);
   color: var(--theme-text-muted);
   font-size: 0.875rem;
@@ -219,9 +275,13 @@ const collapsed = ref(false);
     color var(--theme-transition-fast);
 }
 .combat-collapse-btn:hover {
-  background: var(--theme-surface-hover, rgba(128, 128, 128, 0.15));
-  border-color: var(--theme-card-border);
-  color: var(--theme-text-primary);
+  background: color-mix(in srgb, var(--theme-primary) 8%, var(--theme-card-bg));
+  border-color: var(--theme-primary);
+  color: var(--theme-primary);
+}
+.combat-collapse-btn:focus-visible {
+  outline: 2px solid var(--theme-primary);
+  outline-offset: 2px;
 }
 
 /* ── 折叠小条（收起时游戏仍锁定，重新展开的入口）── */
@@ -236,7 +296,7 @@ const collapsed = ref(false);
   padding: var(--theme-spacing-sm) var(--theme-spacing-lg);
   background: var(--theme-content-bg);
   border: 1px solid var(--theme-card-border);
-  border-radius: var(--theme-radius-lg);
+  border-radius: var(--theme-radius-md);
   box-shadow: var(--theme-shadow-lg);
   z-index: 1001;
 }
@@ -248,34 +308,40 @@ const collapsed = ref(false);
 
 /* ── F2 就绪态面板 ── */
 .combat-ready {
-  display: flex;
-  flex-direction: column;
+  width: min(48rem, 100%);
+  margin: auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--theme-spacing-md);
-  padding: var(--theme-spacing-xl);
+  padding: var(--theme-spacing-2xl);
 }
 .combat-ready-title {
+  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   gap: var(--theme-spacing-sm);
   font-family: var(--theme-font-title);
-  font-size: 1.125rem;
+  font-size: 1.35rem;
   font-weight: 700;
   color: var(--theme-text-primary);
+  padding-bottom: var(--theme-spacing-md);
+  border-bottom: 1px solid var(--combat-inlay);
 }
 .combat-title-icon {
   color: var(--theme-primary);
   font-size: 1rem;
 }
 .combat-ready-meta {
+  grid-column: 1 / -1;
   display: flex;
   flex-wrap: wrap;
   gap: var(--theme-spacing-sm);
 }
 .combat-ready-meta-item {
   font-size: 0.8125rem;
-  color: var(--theme-text-secondary, var(--theme-text));
+  color: var(--theme-text-secondary);
   padding: var(--theme-spacing-xs) var(--theme-spacing-sm);
-  background: var(--theme-card-bg);
+  background: var(--theme-surface-muted);
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-sm);
 }
@@ -283,10 +349,11 @@ const collapsed = ref(false);
   display: flex;
   flex-direction: column;
   gap: var(--theme-spacing-xs);
-  padding: var(--theme-spacing-sm) var(--theme-spacing-md);
+  padding: var(--theme-spacing-md);
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-md);
   background: var(--theme-card-bg);
+  box-shadow: var(--paper-stack);
 }
 .combat-ready-names {
   font-size: 0.8125rem;
@@ -294,52 +361,151 @@ const collapsed = ref(false);
   line-height: 1.6;
 }
 .combat-ready-brief {
+  grid-column: 1 / -1;
   font-size: 0.8125rem;
-  color: var(--theme-text-secondary, var(--theme-text));
+  color: var(--theme-text-secondary);
   line-height: 1.7;
-  border-left: 0; /* 禁侧边条（design 绝对禁令）：用整圈边框 + 染底 */
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-md);
-  padding: var(--theme-spacing-sm) var(--theme-spacing-md);
+  padding: var(--theme-spacing-md);
   background: color-mix(in srgb, var(--theme-primary) 4%, var(--theme-card-bg));
 }
-.combat-units {
-  padding: var(--theme-spacing-sm) var(--theme-spacing-lg);
-  border-bottom: 1px solid var(--theme-card-border);
-  display: flex;
-  flex-direction: column;
-  gap: var(--theme-spacing-xs);
-  flex-shrink: 0;
+.combat-ready .combat-panel-actions {
+  grid-column: 1 / -1;
 }
 .combat-side-label {
   font-size: 0.75rem;
   color: var(--theme-text-muted);
   font-weight: 600;
-  font-family: system-ui, sans-serif;
+  font-family: var(--theme-font-body);
+}
+
+/* ── Command Table 主体：敌方 / 日志 / 我方 ── */
+.combat-command-table {
+  min-height: 0;
+  padding: var(--theme-spacing-sm);
+  display: grid;
+  grid-template-rows: minmax(7.5rem, auto) minmax(9rem, 1fr) minmax(7.5rem, auto);
+  gap: var(--theme-spacing-xs);
+  overflow: auto;
+  background: color-mix(in srgb, var(--theme-window-bg) 74%, var(--theme-content-bg));
+}
+
+.combat-roster {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 6.75rem minmax(0, 1fr);
+  border: 1px solid var(--combat-inlay);
+  background: color-mix(in srgb, var(--theme-card-bg) 74%, var(--theme-content-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--theme-card-border) 50%, transparent);
+}
+
+.combat-side-plaque {
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: var(--theme-spacing-sm);
+  border: 1px solid var(--theme-card-border);
+  margin: var(--theme-spacing-xs);
+  font-family: var(--theme-font-title);
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.combat-side-plaque-enemy {
+  color: var(--theme-error);
+  background: color-mix(in srgb, var(--theme-error) 8%, var(--theme-surface-muted));
+  border-color: color-mix(in srgb, var(--theme-error) 42%, var(--theme-card-border));
+}
+
+.combat-side-plaque-allies {
+  color: var(--theme-primary);
+  background: color-mix(in srgb, var(--theme-primary) 7%, var(--theme-surface-muted));
+  border-color: color-mix(in srgb, var(--theme-primary) 42%, var(--theme-card-border));
+}
+
+.combat-side-emblem {
+  color: currentColor;
+  font-size: 1rem;
+  opacity: 0.35;
 }
 .combat-unit-row {
   display: flex;
+  align-items: stretch;
   gap: var(--theme-spacing-sm);
+  padding: var(--theme-spacing-md);
   overflow-x: auto;
+  scrollbar-width: thin;
 }
 .combat-unit-row > * {
-  flex: 1 1 220px;
-  min-width: 220px;
+  flex: 0 1 21rem;
+  min-width: 18rem;
+}
+
+.combat-ledger {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  border: 1px solid var(--combat-inlay);
+  background: color-mix(in srgb, var(--theme-content-bg) 88%, var(--theme-card-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--theme-card-border) 50%, transparent);
+}
+
+.combat-ledger-heading {
+  display: flex;
+  align-items: center;
+  gap: var(--theme-spacing-md);
+  padding: var(--theme-spacing-sm) var(--theme-spacing-lg);
+  font-family: var(--theme-font-title);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--theme-primary);
+  letter-spacing: 0.08em;
+}
+
+.combat-ledger-heading::before,
+.combat-ledger-heading::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in srgb, var(--theme-primary) 35%, var(--theme-card-border))
+  );
+}
+
+.combat-ledger-heading::after {
+  background: linear-gradient(
+    to left,
+    transparent,
+    color-mix(in srgb, var(--theme-primary) 35%, var(--theme-card-border))
+  );
 }
 .combat-flow {
-  flex: 1;
   min-height: 0;
+  border-top: 1px solid var(--theme-card-border);
 }
 
 /* T16 §3.5：面板底部操作行（跳过/重开战斗） */
 .combat-panel-actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: var(--theme-spacing-sm);
   padding: var(--theme-spacing-xs) var(--theme-spacing-lg);
   border-top: 1px solid var(--theme-card-border);
-  background: var(--theme-bg-secondary, var(--theme-card-bg));
+  background: var(--theme-title-bar-bg);
   flex-shrink: 0;
+}
+
+.combat-panel-actions-label {
+  margin-right: auto;
+  color: var(--theme-text-muted);
+  font-family: var(--theme-font-body);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
 }
 
 .combat-confirm-text {
@@ -366,11 +532,102 @@ const collapsed = ref(false);
 .combat-overlay-leave-to .combat-panel {
   transform: scale(0.97);
 }
+
+@media (prefers-reduced-transparency: reduce) {
+  .combat-overlay {
+    backdrop-filter: none;
+  }
+
+  .combat-panel,
+  .combat-collapse-btn {
+    background: var(--theme-content-bg);
+  }
+}
+
+@media (max-width: 960px) {
+  .combat-overlay {
+    padding: 0;
+  }
+
+  .combat-panel,
+  .combat-panel.is-ready {
+    width: 100%;
+    height: 100dvh;
+    max-height: none;
+    border-radius: 0;
+    border-top: 0;
+    border-bottom: 0;
+  }
+
+  .combat-command-table {
+    padding: var(--theme-spacing-xs);
+  }
+
+  .combat-roster {
+    grid-template-columns: 5rem minmax(0, 1fr);
+  }
+
+  .combat-side-plaque {
+    font-size: 0.9375rem;
+  }
+
+  .combat-unit-row {
+    padding: var(--theme-spacing-sm);
+  }
+
+  .combat-unit-row > * {
+    flex-basis: 19rem;
+    min-width: 17rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .combat-ready {
+    grid-template-columns: 1fr;
+    padding: var(--theme-spacing-xl) var(--theme-spacing-lg);
+  }
+
+  .combat-ready-title,
+  .combat-ready-meta,
+  .combat-ready-brief {
+    grid-column: 1;
+  }
+
+  .combat-command-table {
+    grid-template-rows: auto minmax(12rem, 1fr) auto;
+  }
+
+  .combat-roster {
+    grid-template-columns: 1fr;
+  }
+
+  .combat-side-plaque {
+    min-height: 2.5rem;
+    grid-auto-flow: column;
+    place-content: center;
+    gap: var(--theme-spacing-sm);
+    margin-bottom: 0;
+  }
+
+  .combat-unit-row > * {
+    min-width: 15rem;
+  }
+
+  .combat-ledger-heading {
+    padding: var(--theme-spacing-xs) var(--theme-spacing-md);
+  }
+
+  .combat-panel-actions-label {
+    display: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .combat-overlay-enter-active,
   .combat-overlay-leave-active,
   .combat-overlay-enter-active .combat-panel,
-  .combat-overlay-leave-active .combat-panel {
+  .combat-overlay-leave-active .combat-panel,
+  .combat-collapse-btn {
     transition: none;
   }
 }

--- a/src/ui/components/game/combat/CombatUnitCard.vue
+++ b/src/ui/components/game/combat/CombatUnitCard.vue
@@ -113,6 +113,7 @@ const buffChips = computed(() =>
       'is-dead': isDead,
       'is-incapacitated': isIncapacitated,
     }"
+    :aria-current="isCurrentTurn ? 'step' : undefined"
   >
     <!-- ── 名字行 ── -->
     <div class="unit-header">
@@ -131,7 +132,12 @@ const buffChips = computed(() =>
         <span v-if="isLowHp" class="mark mark-low-hp">⚠ 低血</span>
         <span v-if="isDead" class="mark mark-dead">已倒下</span>
         <span v-else-if="isIncapacitated" class="mark mark-incapacitated">无法行动</span>
-        <button class="detail-toggle" type="button" @click="expanded = !expanded">
+        <button
+          class="detail-toggle"
+          type="button"
+          :aria-expanded="expanded"
+          @click="expanded = !expanded"
+        >
           {{ expanded ? '收起' : '详情' }}
         </button>
       </div>
@@ -139,9 +145,27 @@ const buffChips = computed(() =>
 
     <!-- ── HP / MP / SP 资源条 ── -->
     <div class="unit-resources" :class="{ 'hp-flashing': isLowHp }">
-      <ResourceBar label="HP" :current="unit.hp" :max="unit.maxHp" color="var(--theme-hp)" />
-      <ResourceBar label="MP" :current="unit.mp" :max="unit.maxMp" color="var(--theme-mp)" />
-      <ResourceBar label="SP" :current="unit.sp" :max="unit.maxSp" color="var(--theme-sp)" />
+      <ResourceBar
+        label="HP"
+        :current="unit.hp"
+        :max="unit.maxHp"
+        color="var(--theme-hp)"
+        show-values
+      />
+      <ResourceBar
+        label="MP"
+        :current="unit.mp"
+        :max="unit.maxMp"
+        color="var(--theme-mp)"
+        show-values
+      />
+      <ResourceBar
+        label="SP"
+        :current="unit.sp"
+        :max="unit.maxSp"
+        color="var(--theme-sp)"
+        show-values
+      />
     </div>
 
     <!-- ── Buff chips（每个 buff 和它的剩余回合小标成组渲染） ── -->
@@ -184,18 +208,31 @@ const buffChips = computed(() =>
 <style scoped>
 .combat-unit-card {
   position: relative;
-  background: var(--theme-card-bg);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--theme-primary) 3%, transparent),
+      transparent 42%
+    ),
+    var(--theme-card-bg);
   border: 1px solid var(--theme-card-border);
-  border-radius: var(--theme-radius-md);
-  padding: var(--theme-spacing-md);
+  border-radius: var(--theme-radius-sm);
+  padding: var(--theme-spacing-sm) var(--theme-spacing-md);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--theme-text-primary) 5%, transparent);
   transition:
+    background var(--theme-transition-fast),
+    border-color var(--theme-transition-fast),
     box-shadow 0.15s ease,
     opacity 0.2s ease;
 }
 
 /* 当前行动者：环绕光晕（design §4.2 选中态） */
 .combat-unit-card.is-current-turn {
-  box-shadow: 0 0 0 1px var(--theme-primary);
+  background: color-mix(in srgb, var(--theme-primary) 7%, var(--theme-card-bg));
+  border-color: var(--theme-primary);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--theme-primary) 45%, transparent),
+    0 0 14px color-mix(in srgb, var(--theme-primary) 18%, transparent);
 }
 
 /* 无法行动（非死亡）：降低存在感 */
@@ -214,7 +251,7 @@ const buffChips = computed(() =>
   align-items: center;
   justify-content: space-between;
   gap: var(--theme-spacing-sm);
-  margin-bottom: var(--theme-spacing-sm);
+  margin-bottom: var(--theme-spacing-xs);
 }
 
 .unit-name-row {
@@ -235,7 +272,7 @@ const buffChips = computed(() =>
 .unit-name {
   font-family: var(--theme-font-title);
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.875rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -258,7 +295,7 @@ const buffChips = computed(() =>
 .unit-marks {
   display: flex;
   align-items: center;
-  gap: var(--theme-spacing-xs);
+  gap: 2px;
   flex-shrink: 0;
 }
 
@@ -277,8 +314,8 @@ const buffChips = computed(() =>
 }
 
 .mark-dead {
-  color: #fff;
-  background: color-mix(in srgb, var(--theme-error) 70%, transparent);
+  color: var(--theme-error);
+  background: color-mix(in srgb, var(--theme-error) 16%, transparent);
   border: 1px solid var(--theme-error);
 }
 
@@ -297,28 +334,37 @@ const buffChips = computed(() =>
 
 /* 详情展开开关（触摸目标 ≥ 36px） */
 .detail-toggle {
-  min-height: 22px;
-  padding: 0 8px;
+  min-height: 36px;
+  padding: 0 var(--theme-spacing-sm);
   font-size: 0.7rem;
   font-weight: 600;
-  font-family: system-ui, sans-serif;
+  font-family: var(--theme-font-body);
   color: var(--theme-primary);
   background: color-mix(in srgb, var(--theme-primary) 8%, transparent);
   border: 1px solid color-mix(in srgb, var(--theme-primary) 30%, transparent);
   border-radius: var(--theme-radius-full);
   cursor: pointer;
-  transition: opacity var(--theme-transition-fast);
+  transition:
+    background var(--theme-transition-fast),
+    border-color var(--theme-transition-fast),
+    color var(--theme-transition-fast);
 }
 
 .detail-toggle:hover {
-  opacity: 0.8;
+  background: color-mix(in srgb, var(--theme-primary) 14%, transparent);
+  border-color: var(--theme-primary);
+}
+
+.detail-toggle:focus-visible {
+  outline: 2px solid var(--theme-primary);
+  outline-offset: 2px;
 }
 
 /* ── 详情展开区（设计 §3.3：五维 + 技能 + Lv）── */
 .unit-detail {
   margin-top: var(--theme-spacing-sm);
   padding-top: var(--theme-spacing-sm);
-  border-top: 1px dashed var(--theme-card-border);
+  border-top: 1px solid var(--theme-card-border);
   display: flex;
   flex-direction: column;
   gap: var(--theme-spacing-xs);
@@ -367,7 +413,7 @@ const buffChips = computed(() =>
   padding: 1px 8px;
   font-size: 0.7rem;
   color: var(--theme-text-secondary, var(--theme-text-muted));
-  background: var(--theme-bg-secondary, var(--theme-card-bg));
+  background: var(--theme-surface-muted);
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-full);
 }
@@ -382,7 +428,7 @@ const buffChips = computed(() =>
 .unit-resources {
   display: flex;
   flex-direction: column;
-  gap: var(--theme-spacing-xs);
+  gap: calc(var(--theme-spacing-xs) / 2);
 }
 
 /* 低血时 HP 条闪烁动画 */
@@ -406,14 +452,14 @@ const buffChips = computed(() =>
   flex-wrap: wrap;
   align-items: center;
   gap: var(--theme-spacing-xs);
-  margin-top: var(--theme-spacing-sm);
+  margin-top: var(--theme-spacing-xs);
 }
 
 /* BuffChip + 剩余回合小标 成组紧挨（不换行） */
 .buff-group {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: calc(var(--theme-spacing-xs) / 2);
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## What changed

- Reframed the active combat overlay as a code-only command table with an initiative rail, enemy and ally rosters, a scrollable battle ledger, and a responsive command dock.
- Restyled unit resource bars, status details, action cards, controls, focus states, reduced-motion handling, and narrow layouts using the existing theme tokens.
- Preserved the ready gate, collapse/reopen flow, all five structured actions, skill/item/target selectors, free-text commands, end turn, skip, restart, morale, buffs, and unit details.
- Added focused initiative-order and resource-value regression coverage.
- Recorded the owner-approved cross-theme combat command-table contract in `DESIGN.md`.

## Why

The existing combat UI had weak hierarchy and did not communicate the current round, action order, sides, log, and command controls as one coherent combat surface. This applies the selected Command Table direction without changing the combat feature set.

## Impact

UI-only facelift. No new combat mechanics, `CombatCommand` variants, engine state, runtime artwork, dependencies, or persistence changes.

## Validation

- Live browser QA at 1280×720, 760×720, and 600×720, including non-destructive interaction checks
- `npm run test -- --run` — 294 files passed; 7,509 tests passed; 9 skipped
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- UTF-8 replacement/control-character checks and `git diff --check`