### PR TITLE
fix(ui): expand combat report on short screens

### DIFF
--- a/src/ui/components/game/combat/CombatPanel.vue
+++ b/src/ui/components/game/combat/CombatPanel.vue
@@ -544,6 +544,16 @@ const collapsed = ref(false);
   }
 }
 
+@media (max-height: 720px) and (min-width: 961px) {
+  .combat-command-table {
+    grid-template-rows: minmax(6.5rem, auto) minmax(9rem, 1fr) minmax(6.5rem, auto);
+  }
+
+  .combat-unit-row {
+    padding-block: var(--theme-spacing-xs);
+  }
+}
+
 @media (max-width: 960px) {
   .combat-overlay {
     padding: 0;


### PR DESCRIPTION
## Summary

- compact the combat roster tracks only on short desktop viewports
- give the existing battle report substantially more vertical space
- preserve all combat actions, roster data, scrolling, and narrow-screen behavior

## Root cause

At 1280×720, each roster was held by a 7.5rem minimum track plus 12px vertical row padding. Together with the command dock, those fixed costs left the battle report only 190px tall.

## Impact

This is a UI-only facelift adjustment. It changes no combat mechanics, state, commands, or feature behavior. At the reported viewport, the report grows from 190px to 222px while each roster contracts from 128px to 112px.

## Validation

- live visual QA at 1280×720 and 760×720
- 21 focused combat component/projection tests
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- encoding and `git diff --check` clean