### PR TITLE
feat(ui): 角色查看器弹窗（通栏画像 + 6 页签）

### DIFF
--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -23,6 +23,9 @@ src/ui/                              ← Vue 3 + Pinia + Vite 前端（单 URL �
 │   ├── useMapMarkers.ts             ← 地图标记 CRUD + Overlay 同步
 │   ├── useHoverPopup.ts             ← 悬停浮层唯一实现（读 settings.hoverDelayMs）
 │   ├── useAssetImage.ts             ← [素材] 渲染缝：(name,type?) → {url,isVideo,row}，世代号守卫 + 引用计数索引
+│   │                                   `options.variant` 指定表情/差分（与 name/type 同属"要解析什么"，
+│   │                                   故收 getter）—— 位置参数已被注入缝占了，在 options 包**后面**
+│   │                                   再挂位置参数是读者陷阱
 │   ├── usePlayerPortrait.ts         ← [Q-25] 玩家画像位：立牌链渲染 + 定点导入 + 裁剪台开关
 │   │                                   （文案一律出自 game/portrait-messages.ts，本层只决定"做什么"）
 │   ├── useSceneImageUrls.ts         ← [图像 v1] 插画字节 → object URL（正文与 CG 图鉴共用一份缓存）
@@ -218,9 +221,16 @@ src/ui/                              ← Vue 3 + Pinia + Vite 前端（单 URL �
 ├── components/
 │   ├── shared/                      ← 通用组件
 │   │   ├── AppButton / AppModal / AppCard / AppTabs / ResourceBar / QualityBadge / BuffChip
+│   │   │     AppModal 的 `size` 多一档 `full`（通栏两栏版式：**定死高度**而不是给
+│   │   │     max-height，里面"左栏铺满 + 右栏自己滚"要一个能百分比化的高度），
+│   │   │     另有 `bare`：不画页头、body 不留内边距，**Esc 与点遮罩照旧生效**
+│   │   │     （🔴 别写成 `closable: false` —— 那会顺手废掉 design.md §4.5 要求的 Esc）
 │   │   ├── AvatarPanel.vue          ← 头像（4 尺寸 × circle/square + video prop）
-│   │   ├── AssetMedia.vue           ← [素材] 命中铺满/没命中交回插槽兜底
+│   │   ├── AssetMedia.vue           ← [素材] 命中铺满/没命中交回插槽兜底；`variant` 可指定表情/差分
+│   │   │                               （⚠️ 不是精确寻址：该变体缺席会退回主图、再退类型链下一档）
 │   │   ├── CharacterPortrait.vue    ← [素材] 顶对齐大画像位（纯呈现组件，不碰 store）
+│   │   │                               `fill` 档把**尺寸**交回外层容器（撤掉 4:5 与 24rem 上限），
+│   │   │                               取景夹逼与焦点缩放两条铁律不变；`overflow:hidden` 必须留
 │   │   ├── PortraitSettingsDialog.vue ← [素材] 画像唯一调节面（取景三滑块 + 换图）
 │   │   ├── AssetCropEditor.vue      ← [素材] 裁剪台（一张源图烘出立绘+头像两份真字节）
 │   │   ├── WorkshopEnableList.vue   ← [工坊] 项目粒度启用列表（捏人页与游戏页共用）
@@ -378,6 +388,25 @@ src/ui/                              ← Vue 3 + Pinia + Vite 前端（单 URL �
 │   │   │                                  一个能开始花钱的入口，是「关掉了但没完全关掉」那类最招人烦的 bug
 │   │   │                               锚点是 anchorKind:'message-end'，不做选中文本锚定（原文一改就丢）
 │   │   ├── StatusHUD.vue / StatusOverview.vue / ItemsPanel.vue / CharacterListPanel.vue
+│   │   ├── CharacterViewerModal.vue ← 非玩家角色的**通栏档案**（左画像 + 右信息面 6 页签：
+│   │   │                               档案/状态/装备/技能/背包/相册）。入口是场景栏「在场」那一行
+│   │   │                               🔴 分工按**角色归属**不按内容：StatusOverview 是**玩家自己的**面，
+│   │   │                                  本弹窗是**别人的**面。字段重叠但变更理由不同，不共用组件
+│   │   │                               🔴 画像位只认 `立绘bg → 立绘`，**刻意不复用**共享的两条链 ——
+│   │   │                                  那两条都以 `头像` 收尾，而一整栏高的位置上，一张 1:1 证件照
+│   │   │                                  拉满看起来像 bug；这一位宁可空着走首字母兜底
+│   │   │                               🔴 收的是**名字**不是角色对象：每次从 store 回查（M4 起名字唯一），
+│   │   │                                  否则提交换掉整份 characters 后弹窗停在提交前的数值
+│   │   │                               🔴 不占 `game.activeModal`（那是页面级弹窗的单选位），
+│   │   │                                  它是场景栏自己的一层
+│   │   │                               🔴 `.viewer-body` 的 `min-height: 0` 不是洁癖: 少了它窄屏那一档
+│   │   │                                  （竖向叠栏）内部滚动作废，弹窗底部内容被切掉且滚不到
+│   │   ├── character-viewer.ts       ← 上者的展示层判定（纯函数，不 mount 可测）：副标题分段 /
+│   │   │                               好感度视图 / 档案四行 / 登神三轨 / 装备背包分家 / 相册分组
+│   │   │                               🔴 层级名由 `tier` 反查 TIER_CONFIGS，`tierName` 只当兜底 ——
+│   │   │                                  两者会不一致（真机上一位 T5 贤者自称「普通」）
+│   │   │                               🔴 登神三字段自 Phase 9 是数组，存量存档可能仍是 Record：
+│   │   │                                  统一先摊平，不摊的表现不是少一行而是白屏
 │   │   ├── portrait-messages.ts     ← [Q-25] 画像导入路径的文案层（纯函数，零副作用，不 mount 可测）
 │   │   ├── QuestsPanel.vue / PlotPanel.vue / MemoryPanel.vue / SnapshotPanel.vue / MiniPlayer.vue
 │   │   ├── SceneImageSegment.vue    ← [图像 v1] 正文里一格插画的六种样子。**不判定**该显示什么

--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -401,12 +401,33 @@ src/ui/                              ← Vue 3 + Pinia + Vite 前端（单 URL �
 │   │   │                                  它是场景栏自己的一层
 │   │   │                               🔴 `.viewer-body` 的 `min-height: 0` 不是洁癖: 少了它窄屏那一档
 │   │   │                                  （竖向叠栏）内部滚动作废，弹窗底部内容被切掉且滚不到
+│   │   │                                  （jsdom 测不到，靠 `?raw` 源码断言钉住）
+│   │   │                               🔴 两栏**都不设 background**：铺一层不透明底会盖掉主题给
+│   │   │                                  `.modal-content` 的处理（indigo 的 frosted+blur、sakura 的
+│   │   │                                  漆器底纹）。画像栏的底由画框自己给；先例是 `.char-panel`
+│   │   │                                  （crimson 在那个前提上做了 `:has()` 液态玻璃）
+│   │   │                               🔴 `.viewer-scroll` 要 `tabindex="0"`：它是弹窗唯一的滚动容器，
+│   │   │                                  而某些页签下里面一个可聚焦元素都没有 —— 那时长背景故事
+│   │   │                                  **只有鼠标读得到**
+│   │   │                               🔴 状态效果的时长/层数一律 `== null` 判空: 存量行整键缺
+│   │   │                                  `remainingTime` / `stacks`，严格判 `null` 会把
+│   │   │                                  **「undefined小时」**印到界面上
 │   │   ├── character-viewer.ts       ← 上者的展示层判定（纯函数，不 mount 可测）：副标题分段 /
 │   │   │                               好感度视图 / 档案四行 / 登神三轨 / 装备背包分家 / 相册分组
 │   │   │                               🔴 层级名由 `tier` 反查 TIER_CONFIGS，`tierName` 只当兜底 ——
 │   │   │                                  两者会不一致（真机上一位 T5 贤者自称「普通」）
 │   │   │                               🔴 登神三字段自 Phase 9 是数组，存量存档可能仍是 Record：
-│   │   │                                  统一先摊平，不摊的表现不是少一行而是白屏
+│   │   │                                  统一先摊平，不摊的表现不是少一行而是白屏；**裸字符串条目
+│   │   │                                  要收下**（AI 写得出 `elements: ['空间']`，丢掉就是
+│   │   │                                  「明明有两个要素却显示 0/3」）
+│   │   │                               🔴 `identity`/`occupation`/`personality`/`appearance`/`outfit`
+│   │   │                                  **一律先过收敛器**（`joinLoose`/`textLoose`）：它们经
+│   │   │                                  `update_character` 的裸 `Object.assign` 落库、零校验，
+│   │   │                                  `??` 兜不住一个字符串 —— `.join`/`.trim` 会从 mount 里抛穿，
+│   │   │                                  整个弹窗打不开
+│   │   │                               🔴 相册**一个 (类型,变体) 只出一格**：格子按行 id 做 key、图按
+│   │   │                                  三元组解析，而索引对同一个位只认一个胜出行。不去重就是
+│   │   │                                  两格标题与图都一样、界面上无从区分
 │   │   ├── portrait-messages.ts     ← [Q-25] 画像导入路径的文案层（纯函数，零副作用，不 mount 可测）
 │   │   ├── QuestsPanel.vue / PlotPanel.vue / MemoryPanel.vue / SnapshotPanel.vue / MiniPlayer.vue
 │   │   ├── SceneImageSegment.vue    ← [图像 v1] 正文里一格插画的六种样子。**不判定**该显示什么

--- a/src/ui/components/game/CharacterViewerModal.test.ts
+++ b/src/ui/components/game/CharacterViewerModal.test.ts
@@ -17,6 +17,9 @@ import { reactive } from 'vue';
 import { createDefaultCharacterState } from '@engine/types';
 import type { AssetMetaRecord, AssetType, CharacterState } from '@engine/types';
 import CharacterViewerModal from './CharacterViewerModal.vue';
+// 源码断言用（jsdom 不算布局，某些 CSS 不变式只能这么钉）——
+// 同 ApiSection.image-endpoint.test.ts 的 `?raw` 先例
+import viewerSource from '@ui/components/game/CharacterViewerModal.vue?raw';
 
 let mockGame: any;
 let mockAssets: any;
@@ -119,6 +122,18 @@ describe('CharacterViewerModal — 开合', () => {
     const w = viewer();
     await flushPromises();
     (document.querySelector('.head-close') as HTMLElement).click();
+    expect(w.emitted('close')).toHaveLength(1);
+  });
+
+  /**
+   * ★ 本弹窗走 AppModal 的 `bare` 档（不画页头），而 `bare` **不该**顺手废掉 Esc ——
+   * design.md §4.5 要求必须支持。这里从查看器这一端把整条链钉住
+   * （AppModal 那一端另有 AppModal.test.ts）。
+   */
+  it('★ Esc 关闭（bare 档不许把 Esc 一起关掉）', async () => {
+    const w = viewer();
+    await flushPromises();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     expect(w.emitted('close')).toHaveLength(1);
   });
 });
@@ -283,6 +298,34 @@ describe('CharacterViewerModal — 页签', () => {
     expect(document.querySelector('.fx-detail')?.textContent).toContain('受法则庇护');
   });
 
+  /**
+   * ★ 遗留状态效果整键缺 `remainingTime` / `stacks`（state-manager 自己有一句注释
+   * 点名这种行存在）。严格判 `null` 时它会掉进模板串，界面上写的是「undefined小时」。
+   */
+  it('★ remainingTime / stacks 缺席 → 不许把 undefined 印到界面上', async () => {
+    await open('状态', {
+      statusEffects: [
+        {
+          name: '古旧诅咒',
+          description: '来历不明',
+          category: '减益',
+          timeUnit: '小时',
+          source: '',
+          effects: {},
+        } as never,
+      ],
+    });
+    expect(document.querySelector('.fx-time')?.textContent?.trim()).toBe('永久');
+
+    (document.querySelector('.fx-chip-btn') as HTMLElement).click();
+    await flushPromises();
+    const meta = document.querySelector('.fx-detail-meta')?.textContent ?? '';
+    expect(meta).toContain('层数 1');
+    expect(meta).toContain('剩余 永久');
+    // 整个弹窗里一处都不许出现这个词
+    expect(document.querySelector('.viewer')?.textContent).not.toContain('undefined');
+  });
+
   it('技能页空态用装饰空态文案，不是「暂无数据」', async () => {
     await open('技能');
     expect(document.querySelector('.empty-tab')?.textContent).toContain('未修得一技');
@@ -356,5 +399,76 @@ describe('CharacterViewerModal — 跟着数据走', () => {
     await flushPromises();
     expect(document.querySelector('.purse')).toBeNull();
     expect(document.querySelector('.aff-block')).not.toBeNull();
+  });
+
+  it('切页签时相册的放大格收起（回相册不该有一格还摊着）', async () => {
+    mockAssets.assets = [makeRow('维奥莱塔', '立绘', 'base')];
+    viewer();
+    await flushPromises();
+    const clickTab = async (label: string) => {
+      const b = [...document.querySelectorAll('.viewer .tab-item')].find(
+        (n) => n.textContent?.trim() === label,
+      ) as HTMLElement;
+      b.click();
+      await flushPromises();
+    };
+    await clickTab('相册');
+    (document.querySelector('.album-tile') as HTMLElement).click();
+    await flushPromises();
+    expect(document.querySelector('.album-tile.focused')).not.toBeNull();
+
+    await clickTab('档案');
+    await clickTab('相册');
+    expect(document.querySelector('.album-tile.focused')).toBeNull();
+  });
+});
+
+describe('CharacterViewerModal — 无障碍', () => {
+  /**
+   * ★ `.viewer-scroll` 是弹窗里唯一的滚动容器（外面几层全 `overflow: hidden`），
+   * 而某些页签下它里面一个可聚焦元素都没有（没登神条目、没心里话、只有一段长背景）。
+   * 没有 `tabindex` 的话那段文字只有鼠标读得到。
+   */
+  it('★ 滚动区可聚焦且带 role/label —— 否则键盘用户读不到长背景故事', async () => {
+    mockGame.characters = [makeChar({ background: '边'.repeat(800) })];
+    viewer();
+    await flushPromises();
+    const scroll = document.querySelector('.viewer-scroll') as HTMLElement;
+    expect(scroll.getAttribute('tabindex')).toBe('0');
+    expect(scroll.getAttribute('role')).toBe('region');
+    expect(scroll.getAttribute('aria-label')).toContain('维奥莱塔');
+  });
+
+  it('展开控件报 aria-expanded（登神条目 / 状态效果）', async () => {
+    mockGame.characters = [
+      makeChar({
+        ascension: {
+          enabled: true,
+          elements: [],
+          authority: [],
+          law: [{ name: '秩序', description: 'x', effects: [], costDescription: '' }],
+          deityPosition: '',
+          divineKingdom: { name: '', description: '' },
+        },
+      }),
+    ];
+    viewer();
+    await flushPromises();
+    const head = document.querySelector('.asc-entry-head') as HTMLElement;
+    expect(head.getAttribute('aria-expanded')).toBe('false');
+    head.click();
+    await flushPromises();
+    expect(document.querySelector('.asc-entry-head')?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  /**
+   * ★ jsdom 不算布局，所以这条只能断言源码 —— 但它挡的是一次真机逮到的缺陷:
+   * `.viewer-body` 少了 `min-height: 0` 时，窄屏（竖向叠栏）下本栏会撑到内容的自然
+   * 高度，把 `.viewer-scroll` 的内部滚动整个作废，弹窗底部内容被切掉且滚不到。
+   * 同 ApiSection.image-endpoint.test.ts 的源码断言先例。
+   */
+  it('★ .viewer-body 保留 min-height: 0（窄屏内部滚动的命门，jsdom 测不到）', () => {
+    const rule = viewerSource.slice(viewerSource.indexOf('.viewer-body {'));
+    expect(rule.slice(0, rule.indexOf('}'))).toContain('min-height: 0');
   });
 });

--- a/src/ui/components/game/CharacterViewerModal.test.ts
+++ b/src/ui/components/game/CharacterViewerModal.test.ts
@@ -1,0 +1,360 @@
+/**
+ * CharacterViewerModal — 通栏角色档案
+ *
+ * 覆盖的都是「只有链路测试才证明得了」的那几条:
+ * - 画像位**只认** `立绘bg → 立绘`：只有头像的角色宁可显示首字母（不复用共享链）
+ * - 画像取景真的传到了 CharacterPortrait（framing 断在半路的表现是「这张图偶尔没对齐」）
+ * - 相册按 (名字, 类型, **变体**) 取图 —— 变体寻址是这次给渲染缝新开的能力
+ * - 角色数据换新后弹窗跟着变（不攥旧对象）
+ * - 换人时展开态归零
+ * - `name=null` → 不渲染；名字查不到人 → 说清楚而不是静默空白
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
+import { reactive } from 'vue';
+import { createDefaultCharacterState } from '@engine/types';
+import type { AssetMetaRecord, AssetType, CharacterState } from '@engine/types';
+import CharacterViewerModal from './CharacterViewerModal.vue';
+
+let mockGame: any;
+let mockAssets: any;
+
+vi.mock('../../stores/game-store', () => ({ useGameStore: () => mockGame }));
+vi.mock('../../stores/asset-store', () => ({ useAssetStore: () => mockAssets }));
+
+function makeRow(
+  name: string,
+  type: AssetType,
+  id = 'asset_1',
+  over: Partial<AssetMetaRecord> = {},
+): AssetMetaRecord {
+  return {
+    id,
+    name,
+    type,
+    ext: 'png',
+    mime: 'image/png',
+    bytes: 12,
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  };
+}
+
+function makeChar(over: Partial<CharacterState> = {}): CharacterState {
+  return createDefaultCharacterState({ name: '维奥莱塔', type: 'npc', ...over });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // 🔴 `reactive` 而不是裸对象: 弹窗每次都从 store 回查角色（刻意不攥旧对象），
+  // 而裸对象上的赋值不会让 computed 重算 —— 那会让「跟着数据走」那条断言测的是
+  // 一个从未通电的门
+  mockGame = reactive({
+    characters: [makeChar()] as CharacterState[],
+    saveProfile: { affections: {} as Record<string, number> },
+    getThoughts: vi.fn(() => ''),
+  });
+  mockAssets = reactive({
+    assets: [] as AssetMetaRecord[],
+    assetUrl: vi.fn(async (id: string) => `blob:${id}`),
+    releaseAssetUrl: vi.fn(),
+  });
+});
+
+/**
+ * 弹窗 Teleport 到 body，所以断言一律在 document 上找 —— 也正因为如此，
+ * **必须逐个用例拆干净**: Teleport 的内容不随 wrapper 的 DOM 一起消失，
+ * 留着会让下一个用例的 `querySelector` 命中上一个用例的节点。
+ */
+let wrapper: VueWrapper | null = null;
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = '';
+});
+
+function viewer(name: string | null = '维奥莱塔') {
+  wrapper?.unmount();
+  wrapper = mount(CharacterViewerModal, { props: { name }, attachTo: document.body });
+  return wrapper;
+}
+
+describe('CharacterViewerModal — 开合', () => {
+  it('name=null 时什么都不渲染', async () => {
+    viewer(null);
+    await flushPromises();
+    expect(document.querySelector('.viewer')).toBeNull();
+  });
+
+  it('给了名字 → 渲染名字与副标题', async () => {
+    mockGame.characters = [
+      makeChar({
+        race: '人类',
+        identity: ['帝王'],
+        occupation: ['法则代行者'],
+        tierName: '神话',
+        level: 24,
+      }),
+    ];
+    viewer();
+    await flushPromises();
+    expect(document.querySelector('.head-name')?.textContent).toBe('维奥莱塔');
+    const meta = document.querySelector('.head-meta')?.textContent ?? '';
+    expect(meta).toContain('人类');
+    expect(meta).toContain('法则代行者');
+    expect(meta).toContain('Lv 24');
+  });
+
+  it('★ 名字给了却查不到人（被删 / 改名）→ 说清楚，不是一片空白', async () => {
+    mockGame.characters = [];
+    viewer('无此人');
+    await flushPromises();
+    expect(document.querySelector('.viewer-missing')?.textContent).toContain('不在记载');
+  });
+
+  it('点 × 抛 close（关不关由调用方决定，本组件不自持 open）', async () => {
+    const w = viewer();
+    await flushPromises();
+    (document.querySelector('.head-close') as HTMLElement).click();
+    expect(w.emitted('close')).toHaveLength(1);
+  });
+});
+
+describe('CharacterViewerModal — 画像位', () => {
+  it('有立绘 → 铺进画像栏', async () => {
+    mockAssets.assets = [makeRow('维奥莱塔', '立绘', 'st')];
+    viewer();
+    await flushPromises();
+    const img = document.querySelector('.viewer-portrait img') as HTMLImageElement;
+    expect(img).not.toBeNull();
+    expect(img.getAttribute('src')).toBe('blob:st');
+  });
+
+  it('立绘与立绘bg都有 → 取立绘bg（这一位的链是 立绘bg → 立绘）', async () => {
+    mockAssets.assets = [makeRow('维奥莱塔', '立绘', 'st'), makeRow('维奥莱塔', '立绘bg', 'bg')];
+    viewer();
+    await flushPromises();
+    expect(document.querySelector('.viewer-portrait img')?.getAttribute('src')).toBe('blob:bg');
+  });
+
+  /**
+   * ★ 这一条是本组件与共享链**刻意的分歧**。两条共享链都以 `头像` 收尾，
+   * 复用任何一条都会把一张 1:1 证件照拉满整栏 —— 那看起来像 bug 而不像功能。
+   */
+  it('★ 只有头像 → 画像栏空着走首字母兜底，绝不把头像拉满整栏', async () => {
+    mockAssets.assets = [makeRow('维奥莱塔', '头像', 'av')];
+    viewer();
+    await flushPromises();
+    expect(document.querySelector('.viewer-portrait img')).toBeNull();
+    expect(document.querySelector('.portrait-initials')?.textContent).toBe('维奥');
+  });
+
+  it('★ 取景真的传到画像组件（framing 断在半路 = 这张图偶尔没对齐）', async () => {
+    mockAssets.assets = [
+      makeRow('维奥莱塔', '立绘', 'st', { framing: { x: 20, y: 10, scale: 1.5 } }),
+    ];
+    viewer();
+    await flushPromises();
+    const style = document.querySelector('.viewer-portrait img')?.getAttribute('style') ?? '';
+    expect(style).toContain('20% 10%');
+    expect(style).toContain('scale(1.5)');
+  });
+});
+
+describe('CharacterViewerModal — 档案页', () => {
+  it('好感度：标签 + 数值 + 单边比例', async () => {
+    mockGame.saveProfile = { affections: { 维奥莱塔: -50 } };
+    viewer();
+    await flushPromises();
+    const value = document.querySelector('.aff-value');
+    expect(value?.textContent).toContain('敌意');
+    expect(value?.textContent).toContain('-50');
+    expect(value?.className).toContain('neg');
+    expect(document.querySelector('.aff-fill')?.getAttribute('style')).toContain('scaleX(0.5)');
+  });
+
+  it('登神三档全空 → 三个占位格 + 「尚未踏上长阶」', async () => {
+    viewer();
+    await flushPromises();
+    expect(document.querySelectorAll('.asc-track')).toHaveLength(3);
+    expect(document.querySelectorAll('.asc-track.filled')).toHaveLength(0);
+    expect(document.querySelector('.asc-divine')?.textContent).toContain('尚未踏上长阶');
+  });
+
+  it('拿到法则 → 那一档着重，条目点开才显示描述', async () => {
+    mockGame.characters = [
+      makeChar({
+        ascension: {
+          enabled: true,
+          elements: [],
+          authority: [],
+          law: [
+            {
+              name: '镇压与秩序',
+              description: '以法则镇压异端',
+              effects: ['定身'],
+              costDescription: '25% 最大MP',
+            },
+          ],
+          deityPosition: '',
+          divineKingdom: { name: '', description: '' },
+        },
+      }),
+    ];
+    viewer();
+    await flushPromises();
+    const filled = document.querySelectorAll('.asc-track.filled');
+    expect(filled).toHaveLength(1);
+    expect(document.querySelector('.asc-entry-name')?.textContent).toBe('镇压与秩序');
+    expect(document.querySelector('.asc-entry-body')).toBeNull();
+
+    (document.querySelector('.asc-entry-head') as HTMLElement).click();
+    await flushPromises();
+    const body = document.querySelector('.asc-entry-body');
+    expect(body?.textContent).toContain('以法则镇压异端');
+    expect(body?.textContent).toContain('25% 最大MP');
+  });
+
+  it('心里话走 store.getThoughts（唯一真源），没有就整节不出现', async () => {
+    viewer();
+    await flushPromises();
+    expect(document.querySelector('.thoughts')).toBeNull();
+
+    mockGame.getThoughts = vi.fn(() => '多么完美的艺术品');
+    viewer();
+    await flushPromises();
+    expect(document.querySelector('.thoughts')?.textContent).toContain('多么完美的艺术品');
+  });
+});
+
+describe('CharacterViewerModal — 页签', () => {
+  async function open(tabLabel: string, over: Partial<CharacterState> = {}) {
+    mockGame.characters = [makeChar(over)];
+    const w = viewer();
+    await flushPromises();
+    const tab = [...document.querySelectorAll('.tab-item')].find(
+      (b) => b.textContent?.trim() === tabLabel,
+    ) as HTMLElement;
+    tab.click();
+    await flushPromises();
+    return w;
+  }
+
+  it('装备页只列穿着的，背包页只列背着的（判据是 equippedSlot）', async () => {
+    const inventory = [
+      { name: '双头狮鹫帝冕', quantity: 1, equippedSlot: '头部' },
+      { name: '古代矿石', quantity: 4 },
+    ];
+    await open('装备', { inventory });
+    expect(document.body.textContent).toContain('双头狮鹫帝冕');
+    expect(document.body.textContent).not.toContain('古代矿石');
+
+    await open('背包', { inventory, money: 320 });
+    expect(document.body.textContent).toContain('古代矿石');
+    expect(document.body.textContent).not.toContain('双头狮鹫帝冕');
+    expect(document.querySelector('.purse-value')?.textContent).toContain('320');
+  });
+
+  it('状态页：资源条 + 状态效果，点一条才展开详情', async () => {
+    await open('状态', {
+      statusEffects: [
+        {
+          name: '秩序庇护',
+          description: '受法则庇护',
+          category: '增益',
+          stacks: 2,
+          remainingTime: 3,
+          timeUnit: '小时',
+          source: '[法则]-维奥莱塔',
+          effects: {},
+        },
+      ],
+    });
+    expect(document.querySelectorAll('.res-stack .res-track, .res-stack').length).toBeGreaterThan(
+      0,
+    );
+    expect(document.querySelector('.fx-detail')).toBeNull();
+
+    (document.querySelector('.fx-chip-btn') as HTMLElement).click();
+    await flushPromises();
+    expect(document.querySelector('.fx-detail')?.textContent).toContain('受法则庇护');
+  });
+
+  it('技能页空态用装饰空态文案，不是「暂无数据」', async () => {
+    await open('技能');
+    expect(document.querySelector('.empty-tab')?.textContent).toContain('未修得一技');
+  });
+
+  /** ★ 变体寻址：这是本次给渲染缝新开的能力，没有它相册只能显示每个类型的主图 */
+  it('★ 相册按 (名字, 类型, 变体) 逐格取图', async () => {
+    mockAssets.assets = [
+      makeRow('维奥莱塔', '立绘', 'base'),
+      makeRow('维奥莱塔', '立绘', 'smile', { variant: '微笑' }),
+    ];
+    await open('相册');
+    const captions = [...document.querySelectorAll('.album-caption')].map((n) => n.textContent);
+    expect(captions).toEqual(['立绘', '立绘 · 微笑']);
+    const srcs = [...document.querySelectorAll('.album-tile img')].map((n) =>
+      n.getAttribute('src'),
+    );
+    expect(srcs).toEqual(['blob:base', 'blob:smile']);
+  });
+
+  it('相册点一格放大、再点收回', async () => {
+    mockAssets.assets = [makeRow('维奥莱塔', '立绘', 'base')];
+    await open('相册');
+    const tile = document.querySelector('.album-tile') as HTMLElement;
+    expect(tile.className).not.toContain('focused');
+    tile.click();
+    await flushPromises();
+    expect(document.querySelector('.album-tile')?.className).toContain('focused');
+    (document.querySelector('.album-tile') as HTMLElement).click();
+    await flushPromises();
+    expect(document.querySelector('.album-tile')?.className).not.toContain('focused');
+  });
+
+  it('没有任何素材 → 相册空态', async () => {
+    await open('相册');
+    expect(document.querySelector('.empty-tab')?.textContent).toContain('尚无留影');
+  });
+});
+
+describe('CharacterViewerModal — 跟着数据走', () => {
+  it('★ 角色数组被整份替换后跟着更新（不攥着旧对象）', async () => {
+    mockGame.characters = [makeChar({ hp: 100, maxHp: 100 })];
+    viewer();
+    await flushPromises();
+    const tab = [...document.querySelectorAll('.tab-item')].find(
+      (b) => b.textContent?.trim() === '状态',
+    ) as HTMLElement;
+    tab.click();
+    await flushPromises();
+    expect(document.body.textContent).toContain('100 / 100');
+
+    // 提交一轮状态：整份换掉数组（同 state-manager）。**弹窗没换人**，
+    // 所以这条测的正是"回查"本身，不是换人时的重置
+    mockGame.characters = [makeChar({ hp: 40, maxHp: 100 })];
+    await flushPromises();
+    expect(document.body.textContent).toContain('40 / 100');
+  });
+
+  it('★ 换人时展开态与页签归零（否则新角色身上留着上一位的展开区）', async () => {
+    mockGame.characters = [makeChar({ name: '甲' }), makeChar({ name: '乙' })];
+    const w = viewer('甲');
+    await flushPromises();
+    const tab = [...document.querySelectorAll('.tab-item')].find(
+      (b) => b.textContent?.trim() === '背包',
+    ) as HTMLElement;
+    tab.click();
+    await flushPromises();
+    expect(document.querySelector('.purse')).not.toBeNull();
+
+    await w.setProps({ name: '乙' });
+    await flushPromises();
+    expect(document.querySelector('.purse')).toBeNull();
+    expect(document.querySelector('.aff-block')).not.toBeNull();
+  });
+});

--- a/src/ui/components/game/CharacterViewerModal.vue
+++ b/src/ui/components/game/CharacterViewerModal.vue
@@ -100,6 +100,11 @@ watch(
   },
 );
 
+/** 离开相册页也把放大格收起来 —— 否则回到相册时还有一格摊着，像是没关掉的抽屉 */
+watch(activeTab, () => {
+  focusedTile.value = null;
+});
+
 // ═══ 画像 ═══
 // 解构而不是留着整个对象: 模板里只有**顶层** ref 会自动解包，
 // `portrait.url` 那种写法会把 Ref 对象本身插进 `src`
@@ -141,11 +146,27 @@ function chipType(fx: StatusEffect): 'buff' | 'debuff' | 'special' {
   if (fx.category === '减益') return 'debuff';
   return 'special';
 }
+/**
+ * 🔴 `== null` 而不是 `=== null` —— 这里**必须**把 `undefined` 一起收掉。
+ *
+ * `remainingTime` 名义上是 `number | null`，但存量数据里有整键缺席的行
+ * （state-manager 自己就有一句注释点名「遗留数据 remainingTime === undefined」）。
+ * 严格判 `null` 时 `undefined` 会一路掉到末尾那句模板串，界面上写的是
+ * **「undefined小时」** —— 这条是审查逮到的，而且是**对着邻居退步**:
+ * CharacterListPanel / StatusOverview 用的是 `v-if === null` + `v-else-if < 999`
+ * 且**没有 v-else**，那种写法碰到 undefined 只是不显示，不会把这个词印出来。
+ */
 function durationText(fx: StatusEffect): string {
-  if (fx.remainingTime === null) return '永久';
+  if (fx.remainingTime == null) return '永久';
   // 999 是"实际上不会走完"的约定值（同 CharacterListPanel），照数字显示只会让人以为是 bug
   if (fx.remainingTime >= 999) return '长期';
-  return `${fx.remainingTime}${fx.timeUnit}`;
+  return `${fx.remainingTime}${fx.timeUnit ?? ''}`;
+}
+
+/** 同上一条的同类: `stacks` 缺席的遗留行不该在详情里印出「层数 undefined」 */
+function stacksText(fx: StatusEffect): string {
+  const now = fx.stacks ?? 1;
+  return fx.maxStacks ? `${now}/${fx.maxStacks}` : `${now}`;
 }
 
 // ═══ 相册 ═══
@@ -201,7 +222,16 @@ function toggleTile(tile: AlbumTile) {
 
         <AppTabs :tabs="TABS" :active="activeTab" @select="activeTab = $event" />
 
-        <div class="viewer-scroll">
+        <!-- 🔴 `tabindex="0"` 不是装饰: 这是弹窗里**唯一**的滚动容器（外面几层全是
+             `overflow: hidden`），而某些页签下它里面一个可聚焦元素都没有 —— 比如没有
+             登神条目、没有心里话、只有一段长背景故事的角色。那时键盘用户按 PageDown
+             会往上找祖先，而祖先都不滚，于是那段文字**只有鼠标能读到**。 -->
+        <div
+          class="viewer-scroll"
+          tabindex="0"
+          role="region"
+          :aria-label="`${char.name} 的档案内容`"
+        >
           <!-- ─────── 档案 ─────── -->
           <template v-if="activeTab === 'profile'">
             <!-- 好感度: 中线为 0，正向右生长、负向左生长（同场景栏那一条的口径） -->
@@ -374,10 +404,7 @@ function toggleTile(tile: AlbumTile) {
                     <div class="fx-detail-name">{{ fx.name }}</div>
                     <p v-if="fx.description" class="fx-detail-desc">{{ fx.description }}</p>
                     <div class="fx-detail-meta">
-                      <span
-                        >层数 {{ fx.stacks
-                        }}<template v-if="fx.maxStacks">/{{ fx.maxStacks }}</template></span
-                      >
+                      <span>层数 {{ stacksText(fx) }}</span>
                       <span>剩余 {{ durationText(fx) }}</span>
                       <span v-if="fx.source">来源 {{ fx.source }}</span>
                     </div>
@@ -528,12 +555,17 @@ function toggleTile(tile: AlbumTile) {
   right: var(--theme-spacing-md);
 }
 
-/* 画像栏 —— 42% 是让 4:5 立绘在常见桌面下几乎不被裁；再宽信息面就要折行 */
+/**
+ * 画像栏 —— 42% 是让 4:5 立绘在常见桌面下几乎不被裁；再宽信息面就要折行。
+ *
+ * 同 `.viewer-body`：**不设 background**。画框自己的底
+ * （`CharacterPortrait` 的 `.portrait-frame`，`fill` 档只撤掉边框/圆角/阴影、保留底）
+ * 已经铺满本栏，这里再铺一层是重复，且会盖掉主题给 `.modal-content` 的处理。
+ */
 .viewer-portrait {
   flex: 0 0 42%;
   min-width: 0;
   overflow: hidden;
-  background: var(--theme-surface-muted);
   border-right: 1px solid var(--theme-card-border);
 }
 .portrait-initials {
@@ -561,7 +593,16 @@ function toggleTile(tile: AlbumTile) {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--theme-card-bg);
+  /**
+   * 🔴 **不设 background** —— 让 `.modal-content` 的主题处理透上来。
+   *
+   * 审查逮到的: 铺一层不透明底会把每个主题给 `.modal-content` 的处理整个盖掉
+   * （indigo 的 frosted + `backdrop-filter: blur(20px)`、sakura 的漆器底纹）。
+   * 缺省档下 `.modal-content` 的底本来就是 `--theme-card-bg`，所以撤掉它在无主题
+   * 覆盖时**逐像素等价**，只在有覆盖时才变 —— 而那正是主题想要的样子。
+   * 先例就在隔壁: `.char-panel` 一样不设底，crimson 还在那个前提上做了
+   * `:has(.char-panel)` 的整套液态玻璃。
+   */
 }
 
 .viewer-head {

--- a/src/ui/components/game/CharacterViewerModal.vue
+++ b/src/ui/components/game/CharacterViewerModal.vue
@@ -1,0 +1,1207 @@
+<script setup lang="ts">
+/**
+ * CharacterViewerModal — 非玩家角色的**通栏档案**（左画像 + 右信息面，6 个页签）。
+ *
+ * 从哪来: 场景栏「在场」列表点一位角色。分工是**按角色归属**而不是按内容 ——
+ * 右侧状态栏（StatusOverview）是**玩家自己的**面，本弹窗是**别人的**面。
+ * 两者字段重叠很多，但一个是"我的资源/我的分配点"，另一个是"我对这个人知道什么"，
+ * 变更理由不同，所以不共用一个组件。
+ *
+ * 🔴 **画像位只认 `立绘bg → 立绘`**（{@link VIEWER_PORTRAIT_CHAIN}）。这是刻意**不**
+ * 复用 asset-resolve 那两条共享链的：那两条都以 `头像` 收尾（"构图不对总好过留一个
+ * 洞"），而这一位是一整栏的高度 —— 一张 1:1 证件照拉满整栏看起来像 bug 而不像功能，
+ * 首字母兜底反而更诚实。所以这一位宁可空着。
+ *
+ * 名字**严格 `===`**（D2）: 角色从 `game.characters` 里按名字取（M4 起名字唯一），
+ * 素材也按同一个名字解析。传进来的名字带一个尾随空格就会静默什么都查不到 ——
+ * 那是上游要修的缺陷，本层不做归一化。
+ *
+ * 判定一律在 `character-viewer.ts`（纯函数，不 mount 可测），本文件只负责呈现。
+ */
+import { computed, ref, watch } from 'vue';
+import AppModal from '../shared/AppModal.vue';
+import AppTabs from '../shared/AppTabs.vue';
+import AssetMedia from '../shared/AssetMedia.vue';
+import BuffChip from '../shared/BuffChip.vue';
+import CharacterPortrait from '../shared/CharacterPortrait.vue';
+import ResourceBar from '../shared/ResourceBar.vue';
+import { useAssetImage } from '../../composables/useAssetImage';
+import { useAssetStore } from '../../stores/asset-store';
+import { useGameStore } from '../../stores/game-store';
+import { qualityVar, tierVarByName } from '../../lib/quality-colors';
+import { initialsOf } from '../../utils/name-color';
+import type { AssetType, CharacterState, StatusEffect } from '@engine/types';
+import {
+  buildAffectionView,
+  buildAlbumGroups,
+  buildAscensionTracks,
+  buildProfileFields,
+  buildSubtitleSegments,
+  hasAnyAscension,
+  itemQuality,
+  splitInventory,
+  type AlbumTile,
+} from './character-viewer';
+
+/** 见文件头那条铁律 —— 这一位**没有**第三档兜底 */
+const VIEWER_PORTRAIT_CHAIN: readonly AssetType[] = ['立绘bg', '立绘'];
+
+const props = defineProps<{
+  /** 要看谁；`null` = 弹窗关着（本组件不另存一份 open 状态，避免两处真源） */
+  name: string | null;
+}>();
+
+const emit = defineEmits<{ close: [] }>();
+
+const game = useGameStore();
+const assetStore = useAssetStore();
+
+const open = computed(() => props.name !== null);
+
+/**
+ * 每次都按名字回查，**不把角色对象存成 prop**: 存档提交会整份替换
+ * `game.characters`，攥着旧对象的弹窗会停在提交前那一刻的数值
+ * （血量打完架还是满的，那种缺陷没人会怀疑到弹窗上）。
+ */
+const char = computed<CharacterState | null>(
+  () => (game.characters ?? []).find((c) => c.name === props.name) ?? null,
+);
+
+// ═══ 页签 ═══
+type ViewerTab = 'profile' | 'status' | 'equipment' | 'skills' | 'bag' | 'album';
+const TABS: { key: ViewerTab; label: string }[] = [
+  { key: 'profile', label: '档案' },
+  { key: 'status', label: '状态' },
+  { key: 'equipment', label: '装备' },
+  { key: 'skills', label: '技能' },
+  { key: 'bag', label: '背包' },
+  { key: 'album', label: '相册' },
+];
+const activeTab = ref<ViewerTab>('profile');
+
+/** 展开态 —— 登神条目 / 状态效果 / 相册放大格，都按名字或 id 记单选 */
+const openAscension = ref<string | null>(null);
+const openStatus = ref<string | null>(null);
+const focusedTile = ref<string | null>(null);
+
+/**
+ * 换人 = 一切归零。
+ *
+ * 不这么做的表现很具体: 上一位展开着「镇压与秩序」，切到下一位时那一格仍是展开的，
+ * 而新角色没有同名条目 —— 于是展开区里空着一块，看着像渲染 bug。
+ */
+watch(
+  () => props.name,
+  () => {
+    activeTab.value = 'profile';
+    openAscension.value = null;
+    openStatus.value = null;
+    focusedTile.value = null;
+  },
+);
+
+// ═══ 画像 ═══
+// 解构而不是留着整个对象: 模板里只有**顶层** ref 会自动解包，
+// `portrait.url` 那种写法会把 Ref 对象本身插进 `src`
+const {
+  url: portraitUrl,
+  isVideo: portraitIsVideo,
+  row: portraitRow,
+} = useAssetImage(
+  () => props.name,
+  () => VIEWER_PORTRAIT_CHAIN,
+);
+
+const subtitle = computed(() => (char.value ? buildSubtitleSegments(char.value) : []));
+
+// ═══ 档案页 ═══
+const affection = computed(() =>
+  buildAffectionView(props.name ? game.saveProfile?.affections?.[props.name] : 0),
+);
+const profileFields = computed(() => (char.value ? buildProfileFields(char.value) : []));
+const ascensionTracks = computed(() => (char.value ? buildAscensionTracks(char.value) : []));
+const ascensionUnlocked = computed(() => hasAnyAscension(ascensionTracks.value));
+const thoughts = computed(() => (char.value ? game.getThoughts(char.value) : ''));
+
+const ATTR_ROWS: { key: 'str' | 'dex' | 'con' | 'int' | 'spi'; label: string }[] = [
+  { key: 'str', label: '力量' },
+  { key: 'dex', label: '敏捷' },
+  { key: 'con', label: '体质' },
+  { key: 'int', label: '智力' },
+  { key: 'spi', label: '精神' },
+];
+
+// ═══ 物品 / 技能 ═══
+const inventory = computed(() => splitInventory(char.value?.inventory));
+const skills = computed(() => char.value?.skills ?? []);
+const statusEffects = computed(() => char.value?.statusEffects ?? []);
+
+function chipType(fx: StatusEffect): 'buff' | 'debuff' | 'special' {
+  if (fx.category === '增益') return 'buff';
+  if (fx.category === '减益') return 'debuff';
+  return 'special';
+}
+function durationText(fx: StatusEffect): string {
+  if (fx.remainingTime === null) return '永久';
+  // 999 是"实际上不会走完"的约定值（同 CharacterListPanel），照数字显示只会让人以为是 bug
+  if (fx.remainingTime >= 999) return '长期';
+  return `${fx.remainingTime}${fx.timeUnit}`;
+}
+
+// ═══ 相册 ═══
+const albumGroups = computed(() =>
+  props.name ? buildAlbumGroups(assetStore.assets ?? [], props.name) : [],
+);
+const albumCount = computed(() =>
+  albumGroups.value.reduce((sum, group) => sum + group.tiles.length, 0),
+);
+function toggleTile(tile: AlbumTile) {
+  focusedTile.value = focusedTile.value === tile.id ? null : tile.id;
+}
+</script>
+
+<template>
+  <AppModal :open="open" size="full" bare @update:open="emit('close')">
+    <div v-if="char" class="viewer">
+      <!-- ═══════ 左: 画像（立绘bg → 立绘，没有第三档） ═══════ -->
+      <div class="viewer-portrait">
+        <CharacterPortrait
+          :name="char.name"
+          :src="portraitUrl"
+          :video="portraitIsVideo"
+          :framing="portraitRow?.framing ?? null"
+          fill
+        >
+          <!-- 兜底: 一个巨大的首字母。刻意不是「暂无立绘」四个字 ——
+               这一栏是装饰位，一句报错文案会把它变成一条待办 -->
+          <span class="portrait-initials" aria-hidden="true">{{ initialsOf(char.name) }}</span>
+        </CharacterPortrait>
+      </div>
+
+      <!-- ═══════ 右: 信息面 ═══════ -->
+      <div class="viewer-body">
+        <div class="viewer-head">
+          <div class="head-text">
+            <h2 class="head-name">{{ char.name }}</h2>
+            <div class="head-meta">
+              <template v-for="(seg, i) in subtitle" :key="seg.text + i"
+                ><span v-if="i" class="meta-sep" aria-hidden="true"> · </span
+                ><span
+                  class="meta-seg"
+                  :style="seg.kind === 'tier' ? { color: tierVarByName(seg.text) } : undefined"
+                  >{{ seg.text }}</span
+                ></template
+              >
+            </div>
+          </div>
+          <button class="head-close" type="button" aria-label="关闭" @click="emit('close')">
+            ×
+          </button>
+        </div>
+
+        <AppTabs :tabs="TABS" :active="activeTab" @select="activeTab = $event" />
+
+        <div class="viewer-scroll">
+          <!-- ─────── 档案 ─────── -->
+          <template v-if="activeTab === 'profile'">
+            <!-- 好感度: 中线为 0，正向右生长、负向左生长（同场景栏那一条的口径） -->
+            <div class="aff-block">
+              <div class="aff-head">
+                <span class="aff-title">好感度</span>
+                <span class="aff-value" :class="{ neg: affection.negative }">
+                  <span class="aff-label">{{ affection.label }}</span>
+                  {{ affection.value }}
+                </span>
+              </div>
+              <div class="aff-track">
+                <span
+                  class="aff-fill"
+                  :class="affection.negative ? 'neg' : 'pos'"
+                  :style="{ transform: `scaleX(${affection.ratio})` }"
+                />
+                <span class="aff-zero" aria-hidden="true" />
+              </div>
+              <div class="aff-scale" aria-hidden="true">
+                <span>-100</span><span>0</span><span>+100</span>
+              </div>
+            </div>
+
+            <!-- 档案四行 -->
+            <section class="vw-sec">
+              <h3 class="vw-sec-title">档案</h3>
+              <div v-if="profileFields.length" class="prose-list">
+                <div v-for="f in profileFields" :key="f.label" class="prose-row">
+                  <div class="prose-label">{{ f.label }}</div>
+                  <p class="prose-text">{{ f.text }}</p>
+                </div>
+              </div>
+              <div v-else class="empty-tab">此人来历不详…</div>
+            </section>
+
+            <!-- 属性 -->
+            <section class="vw-sec">
+              <h3 class="vw-sec-title">属性</h3>
+              <div class="attr-grid">
+                <div v-for="a in ATTR_ROWS" :key="a.key" class="attr-cell">
+                  <span class="attr-name">{{ a.label }}</span>
+                  <span class="attr-num">{{ char.attributes?.[a.key] ?? '—' }}</span>
+                </div>
+              </div>
+              <div v-if="char.freeAttrPoints" class="attr-free">
+                未分配自由点 {{ char.freeAttrPoints }}
+              </div>
+            </section>
+
+            <!-- 登神长阶 -->
+            <section class="vw-sec">
+              <h3 class="vw-sec-title">登神长阶</h3>
+              <div class="asc-grid">
+                <div
+                  v-for="track in ascensionTracks"
+                  :key="track.key"
+                  class="asc-track"
+                  :class="{ filled: track.entries.length > 0 }"
+                >
+                  <div class="asc-track-head">
+                    <span class="asc-track-label">{{ track.label }}</span>
+                    <span class="asc-track-count"
+                      >{{ track.entries.length }}<span class="asc-cap">/{{ track.cap }}</span></span
+                    >
+                  </div>
+                  <div v-if="!track.entries.length" class="asc-none">
+                    <span aria-hidden="true">—</span>
+                    <span class="asc-none-hint">{{ track.unlockLevel }} 起</span>
+                  </div>
+                  <div v-else class="asc-entries">
+                    <div v-for="entry in track.entries" :key="entry.name" class="asc-entry">
+                      <button
+                        class="asc-entry-head"
+                        type="button"
+                        :aria-expanded="openAscension === entry.name"
+                        @click="openAscension = openAscension === entry.name ? null : entry.name"
+                      >
+                        <span class="asc-entry-name">{{ entry.name }}</span>
+                        <span class="asc-toggle" aria-hidden="true">{{
+                          openAscension === entry.name ? '−' : '+'
+                        }}</span>
+                      </button>
+                      <Transition name="collapse">
+                        <div v-if="openAscension === entry.name" class="asc-entry-body">
+                          <p v-if="entry.description" class="asc-desc">{{ entry.description }}</p>
+                          <ul v-if="entry.effects.length" class="asc-effects">
+                            <li v-for="(fx, i) in entry.effects" :key="i">{{ fx }}</li>
+                          </ul>
+                          <div v-if="entry.cost" class="asc-cost">消耗 · {{ entry.cost }}</div>
+                        </div>
+                      </Transition>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="asc-divine">
+                <span class="dv-label">神位</span>
+                <span class="dv-value">{{ char.ascension?.deityPosition || '—' }}</span>
+                <span class="dv-label">神国</span>
+                <span class="dv-value">{{ char.ascension?.divineKingdom?.name || '—' }}</span>
+                <span v-if="!ascensionUnlocked" class="dv-hint">尚未踏上长阶</span>
+              </div>
+            </section>
+
+            <!-- 心里话 —— 唯一真源 CharacterState.thoughts（经 store.getThoughts） -->
+            <section v-if="thoughts" class="vw-sec">
+              <h3 class="vw-sec-title">心里话</h3>
+              <blockquote class="thoughts">{{ thoughts }}</blockquote>
+            </section>
+
+            <!-- 背景故事 -->
+            <section v-if="char.background" class="vw-sec">
+              <h3 class="vw-sec-title">背景故事</h3>
+              <p class="story">{{ char.background }}</p>
+            </section>
+          </template>
+
+          <!-- ─────── 状态 ─────── -->
+          <template v-else-if="activeTab === 'status'">
+            <section class="vw-sec">
+              <h3 class="vw-sec-title">资源</h3>
+              <div class="res-stack">
+                <ResourceBar
+                  label="HP"
+                  :current="char.hp"
+                  :max="char.maxHp"
+                  color="color-mix(in srgb, var(--theme-hp) 65%, #000)"
+                  :height="22"
+                  :show-values="true"
+                />
+                <ResourceBar
+                  label="MP"
+                  :current="char.mp"
+                  :max="char.maxMp"
+                  color="color-mix(in srgb, var(--theme-mp) 65%, #000)"
+                  :height="22"
+                  :show-values="true"
+                />
+                <ResourceBar
+                  label="SP"
+                  :current="char.sp"
+                  :max="char.maxSp"
+                  color="color-mix(in srgb, var(--theme-sp) 65%, #000)"
+                  :height="22"
+                  :show-values="true"
+                />
+              </div>
+            </section>
+
+            <section class="vw-sec">
+              <h3 class="vw-sec-title">状态效果</h3>
+              <div v-if="!statusEffects.length" class="empty-tab">身上并无异状…</div>
+              <template v-else>
+                <div class="fx-chips">
+                  <button
+                    v-for="fx in statusEffects"
+                    :key="fx.name"
+                    class="fx-chip-btn"
+                    type="button"
+                    :aria-expanded="openStatus === fx.name"
+                    @click="openStatus = openStatus === fx.name ? null : fx.name"
+                  >
+                    <BuffChip :name="fx.name" :type="chipType(fx)" :stacks="fx.stacks" />
+                    <span class="fx-time">{{ durationText(fx) }}</span>
+                  </button>
+                </div>
+                <template v-for="fx in statusEffects" :key="`d-${fx.name}`">
+                  <div v-if="openStatus === fx.name" class="fx-detail">
+                    <div class="fx-detail-name">{{ fx.name }}</div>
+                    <p v-if="fx.description" class="fx-detail-desc">{{ fx.description }}</p>
+                    <div class="fx-detail-meta">
+                      <span
+                        >层数 {{ fx.stacks
+                        }}<template v-if="fx.maxStacks">/{{ fx.maxStacks }}</template></span
+                      >
+                      <span>剩余 {{ durationText(fx) }}</span>
+                      <span v-if="fx.source">来源 {{ fx.source }}</span>
+                    </div>
+                  </div>
+                </template>
+              </template>
+            </section>
+          </template>
+
+          <!-- ─────── 装备 ─────── -->
+          <template v-else-if="activeTab === 'equipment'">
+            <div v-if="!inventory.equipped.length" class="empty-tab">未着寸铁…</div>
+            <div v-for="eq in inventory.equipped" :key="eq.name" class="thing-card">
+              <div class="thing-head">
+                <span class="q-dot" :style="{ background: qualityVar(itemQuality(eq)) }" />
+                <span class="thing-name" :style="{ color: qualityVar(itemQuality(eq)) }">{{
+                  eq.name
+                }}</span>
+                <span class="thing-tag">{{ eq.equippedSlot }}</span>
+              </div>
+              <p v-if="eq.description" class="thing-desc">{{ eq.description }}</p>
+              <div v-if="eq.effects && Object.keys(eq.effects).length" class="kv-list">
+                <div v-for="(desc, key) in eq.effects" :key="key" class="kv-row">
+                  <span class="kv-k">{{ key }}</span
+                  ><span class="kv-v">{{ desc }}</span>
+                </div>
+              </div>
+              <div v-if="eq.durability !== undefined" class="thing-foot">
+                耐久 {{ eq.durability
+                }}<template v-if="eq.maxDurability">/{{ eq.maxDurability }}</template>
+              </div>
+            </div>
+          </template>
+
+          <!-- ─────── 技能 ─────── -->
+          <template v-else-if="activeTab === 'skills'">
+            <div v-if="!skills.length" class="empty-tab">未修得一技…</div>
+            <div v-for="sk in skills" :key="sk.name" class="thing-card">
+              <div class="thing-head">
+                <span class="thing-name">{{ sk.name }}</span>
+                <span class="thing-tag"
+                  >{{ sk.type === 'active' ? '主动' : '被动'
+                  }}<template v-if="sk.level"> · Lv.{{ sk.level }}</template></span
+                >
+              </div>
+              <div v-if="sk.cost || sk.cooldown" class="thing-cost">
+                <template v-if="sk.cost">{{ sk.cost.amount }} {{ sk.cost.type }}</template>
+                <template v-if="sk.cooldown"> · 冷却 {{ sk.cooldown }} 回合</template>
+              </div>
+              <p v-if="sk.description" class="thing-desc">{{ sk.description }}</p>
+              <div v-if="sk.effects && Object.keys(sk.effects).length" class="kv-list">
+                <div v-for="(desc, key) in sk.effects" :key="key" class="kv-row">
+                  <span class="kv-k">{{ key }}</span
+                  ><span class="kv-v">{{ desc }}</span>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- ─────── 背包 ─────── -->
+          <template v-else-if="activeTab === 'bag'">
+            <div class="purse">
+              <span class="purse-label">随身钱财</span>
+              <span class="purse-value">{{ char.money ?? 0 }} G</span>
+            </div>
+            <div v-if="!inventory.carried.length" class="empty-tab">行囊空空…</div>
+            <div v-for="item in inventory.carried" :key="item.name" class="thing-card">
+              <div class="thing-head">
+                <span class="q-dot" :style="{ background: qualityVar(itemQuality(item)) }" />
+                <span class="thing-name" :style="{ color: qualityVar(itemQuality(item)) }">{{
+                  item.name
+                }}</span>
+                <span v-if="item.quantity > 1" class="thing-tag">×{{ item.quantity }}</span>
+              </div>
+              <p v-if="item.description" class="thing-desc">{{ item.description }}</p>
+              <div v-if="item.effects && Object.keys(item.effects).length" class="kv-list">
+                <div v-for="(desc, key) in item.effects" :key="key" class="kv-row">
+                  <span class="kv-k">{{ key }}</span
+                  ><span class="kv-v">{{ desc }}</span>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- ─────── 相册 ─────── -->
+          <template v-else>
+            <div v-if="!albumCount" class="empty-tab">此人尚无留影…</div>
+            <section v-for="group in albumGroups" :key="group.type" class="vw-sec">
+              <h3 class="vw-sec-title">{{ group.type }}</h3>
+              <div class="album-grid">
+                <button
+                  v-for="tile in group.tiles"
+                  :key="tile.id"
+                  class="album-tile"
+                  :class="{ focused: focusedTile === tile.id }"
+                  type="button"
+                  :aria-pressed="focusedTile === tile.id"
+                  :title="tile.caption"
+                  @click="toggleTile(tile)"
+                >
+                  <span class="album-frame">
+                    <AssetMedia :name="char.name" :type="tile.type" :variant="tile.variant">
+                      <span class="album-missing" aria-hidden="true">—</span>
+                    </AssetMedia>
+                  </span>
+                  <span class="album-caption">{{ tile.caption }}</span>
+                </button>
+              </div>
+            </section>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <!-- 名字给了却查不到人（被删 / 改名）—— 不静默关窗，说清楚发生了什么 -->
+    <div v-else class="viewer viewer-missing">
+      <div class="empty-tab">此人已不在记载之中…</div>
+      <button
+        class="head-close missing-close"
+        type="button"
+        aria-label="关闭"
+        @click="emit('close')"
+      >
+        ×
+      </button>
+    </div>
+  </AppModal>
+</template>
+
+<style scoped>
+/* ═══ 根: 左画像 + 右信息 ═══ */
+.viewer {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  --paper-stack:
+    0 1px 0 0 color-mix(in srgb, var(--theme-card-border) 40%, transparent),
+    0 4px 12px rgba(0, 0, 0, 0.08);
+}
+.viewer-missing {
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+.missing-close {
+  position: absolute;
+  top: var(--theme-spacing-md);
+  right: var(--theme-spacing-md);
+}
+
+/* 画像栏 —— 42% 是让 4:5 立绘在常见桌面下几乎不被裁；再宽信息面就要折行 */
+.viewer-portrait {
+  flex: 0 0 42%;
+  min-width: 0;
+  overflow: hidden;
+  background: var(--theme-surface-muted);
+  border-right: 1px solid var(--theme-card-border);
+}
+.portrait-initials {
+  font-family: var(--theme-font-title);
+  font-size: clamp(6rem, 22vh, 16rem);
+  font-weight: 700;
+  line-height: 1;
+  color: color-mix(in srgb, var(--theme-text-primary) 22%, transparent);
+  user-select: none;
+}
+
+/* ═══ 信息面 ═══ */
+/**
+ * 🔴 `min-width: 0` **和** `min-height: 0` 两个都要，缺一个就有一档版式坏掉。
+ *
+ * flex 子项的默认 `min-*` 是 `auto`（= 不小于内容），所以 `flex: 1` 只给"可以长"，
+ * 不给"可以缩"。少了 `min-height: 0`，窄屏那一档（`flex-direction: column`）里本栏
+ * 会撑到内容的自然高度、把 `.viewer-scroll` 的内部滚动整个作废 —— 表现是**弹窗底部
+ * 的内容被切掉且滚不到**（真机 768 宽走查逮到: 320 + 848 撑出 942 高的弹窗外）。
+ * `min-width: 0` 同理管的是宽屏那一档（长字符串把本栏顶宽）。
+ */
+.viewer-body {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--theme-card-bg);
+}
+
+.viewer-head {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--theme-spacing-md);
+  padding: var(--theme-spacing-lg) var(--theme-spacing-xl) var(--theme-spacing-md);
+}
+.head-text {
+  flex: 1;
+  min-width: 0;
+}
+.head-name {
+  margin: 0;
+  font-family: var(--theme-font-title);
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--theme-text-primary);
+  letter-spacing: 0.02em;
+}
+.head-meta {
+  margin-top: var(--theme-spacing-xs);
+  font-size: 0.75rem;
+  color: var(--theme-text-secondary);
+}
+.meta-sep {
+  color: var(--theme-text-muted);
+}
+.head-close {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.35rem;
+  line-height: 1;
+  color: var(--theme-text-muted);
+  background: none;
+  border: none;
+  border-radius: var(--theme-radius-sm);
+  cursor: pointer;
+  transition: all var(--theme-transition-fast);
+}
+.head-close:hover {
+  color: var(--theme-text-primary);
+  background: var(--theme-tab-hover-bg);
+}
+
+.viewer-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--theme-spacing-lg) var(--theme-spacing-xl) var(--theme-spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--theme-spacing-lg);
+}
+
+/* ═══ Section 外壳（design.md §5.1 装饰线） ═══ */
+.vw-sec {
+  display: flex;
+  flex-direction: column;
+  gap: var(--theme-spacing-sm);
+}
+.vw-sec-title {
+  display: flex;
+  align-items: center;
+  gap: var(--theme-spacing-sm);
+  margin: 0;
+  font-family: var(--theme-font-title);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--theme-text-secondary);
+  letter-spacing: 0.06em;
+}
+.vw-sec-title::before {
+  content: '❖';
+  font-size: 0.6875rem;
+  color: var(--theme-primary);
+}
+.vw-sec-title::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(to right, var(--theme-card-border), transparent);
+}
+
+/* ═══ 好感度 ═══ */
+.aff-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--theme-spacing-xs);
+}
+.aff-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.aff-title {
+  font-family: var(--theme-font-title);
+  font-size: 0.8125rem;
+  color: var(--theme-text-secondary);
+  letter-spacing: 0.06em;
+}
+.aff-value {
+  font-size: 1rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--theme-quality-epic);
+}
+.aff-value.neg {
+  color: var(--theme-error);
+}
+.aff-label {
+  margin-right: var(--theme-spacing-sm);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+.aff-track {
+  position: relative;
+  height: 6px;
+  border-radius: var(--theme-radius-full);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  overflow: hidden;
+}
+/* 中线两侧各占一半：正向从中线往右长，负向往左长 */
+.aff-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  background: var(--theme-quality-epic);
+  transition: transform var(--theme-transition-normal, 0.3s ease-out);
+}
+.aff-fill.pos {
+  left: 50%;
+  transform-origin: left;
+}
+.aff-fill.neg {
+  right: 50%;
+  transform-origin: right;
+  background: var(--theme-error);
+}
+.aff-zero {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: color-mix(in srgb, var(--theme-text-muted) 55%, transparent);
+}
+.aff-scale {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ═══ 档案四行 ═══ */
+.prose-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--theme-spacing-sm);
+}
+.prose-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.prose-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--theme-primary);
+  letter-spacing: 0.04em;
+}
+.prose-text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.7;
+  color: var(--theme-text-primary);
+}
+
+/* ═══ 属性 ═══ */
+.attr-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+  gap: var(--theme-spacing-xs);
+}
+.attr-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: var(--theme-spacing-sm) var(--theme-spacing-md);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  box-shadow: var(--paper-stack);
+}
+.attr-name {
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+  letter-spacing: 0.04em;
+}
+.attr-num {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--theme-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.attr-free {
+  font-size: 0.75rem;
+  color: var(--theme-warning);
+}
+
+/* ═══ 登神长阶 ═══ */
+.asc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: var(--theme-spacing-sm);
+  align-items: start;
+}
+.asc-track {
+  padding: var(--theme-spacing-sm) var(--theme-spacing-md);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  box-shadow: var(--paper-stack);
+}
+/* 拿到了东西的那一档：全边混合边框 + 染底（design.md 的激活态配方，不用侧边条） */
+.asc-track.filled {
+  background: color-mix(in srgb, var(--theme-primary) 8%, var(--theme-card-bg));
+  border-color: color-mix(in srgb, var(--theme-primary) 30%, var(--theme-card-border));
+}
+.asc-track-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--theme-spacing-sm);
+}
+.asc-track-label {
+  font-family: var(--theme-font-title);
+  font-size: 0.8125rem;
+  color: var(--theme-text-secondary);
+}
+.asc-track.filled .asc-track-label {
+  color: var(--theme-text-primary);
+  font-weight: 600;
+}
+.asc-track-count {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--theme-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.asc-cap {
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--theme-text-muted);
+}
+.asc-none {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--theme-spacing-sm);
+  margin-top: var(--theme-spacing-xs);
+  color: var(--theme-text-muted);
+}
+.asc-none-hint {
+  font-size: 0.6875rem;
+  font-style: italic;
+}
+.asc-entries {
+  margin-top: var(--theme-spacing-xs);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.asc-entry-head {
+  width: 100%;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--theme-spacing-sm);
+  padding: var(--theme-spacing-xs) 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--theme-text-primary);
+  font-family: inherit;
+  text-align: left;
+  transition: color var(--theme-transition-fast);
+}
+.asc-entry-head:hover {
+  color: var(--theme-primary);
+}
+.asc-entry-name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+.asc-toggle {
+  flex-shrink: 0;
+  font-size: 0.9375rem;
+  line-height: 1;
+  color: var(--theme-primary);
+}
+.asc-entry-body {
+  padding-bottom: var(--theme-spacing-sm);
+  font-size: 0.75rem;
+  color: var(--theme-text-secondary);
+  line-height: 1.6;
+}
+.asc-desc {
+  margin: 0;
+}
+.asc-effects {
+  margin: var(--theme-spacing-xs) 0 0;
+  padding-left: 1.1em;
+}
+.asc-cost {
+  margin-top: var(--theme-spacing-xs);
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+}
+.asc-divine {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--theme-spacing-xs) var(--theme-spacing-sm);
+  font-size: 0.75rem;
+}
+.dv-label {
+  color: var(--theme-text-muted);
+  letter-spacing: 0.04em;
+}
+.dv-value {
+  color: var(--theme-text-primary);
+  margin-right: var(--theme-spacing-md);
+}
+.dv-hint {
+  color: var(--theme-text-muted);
+  font-style: italic;
+}
+
+/* ═══ 心里话 / 背景 ═══ */
+.thoughts {
+  margin: 0;
+  padding: var(--theme-spacing-md) var(--theme-spacing-lg);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  box-shadow: var(--paper-stack);
+  font-family: var(--theme-font-title);
+  font-size: 0.8125rem;
+  font-style: italic;
+  line-height: 1.7;
+  color: var(--theme-text-secondary);
+}
+.thoughts::before {
+  content: '“';
+}
+.thoughts::after {
+  content: '”';
+}
+.story {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.75;
+  color: var(--theme-text-primary);
+}
+
+/* ═══ 资源 / 状态 ═══ */
+.res-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--theme-spacing-sm);
+}
+.fx-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--theme-spacing-xs);
+}
+.fx-chip-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--theme-spacing-xs);
+  min-height: 36px;
+  padding: 0 var(--theme-spacing-xs);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--theme-radius-sm);
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color var(--theme-transition-fast);
+}
+.fx-chip-btn:hover,
+.fx-chip-btn[aria-expanded='true'] {
+  border-color: var(--theme-card-border);
+}
+.fx-time {
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+}
+.fx-detail {
+  padding: var(--theme-spacing-md);
+  background: color-mix(in srgb, var(--theme-primary) 6%, var(--theme-surface-muted));
+  border: 1px solid color-mix(in srgb, var(--theme-primary) 25%, var(--theme-card-border));
+  border-radius: var(--theme-radius-md);
+}
+.fx-detail-name {
+  font-family: var(--theme-font-title);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--theme-text-primary);
+}
+.fx-detail-desc {
+  margin: var(--theme-spacing-xs) 0 0;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--theme-text-secondary);
+}
+.fx-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--theme-spacing-md);
+  margin-top: var(--theme-spacing-xs);
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+}
+
+/* ═══ 装备 / 技能 / 背包 卡片（design.md §4.2 统一外壳 + 色点着色） ═══ */
+.thing-card {
+  padding: var(--theme-spacing-md);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  box-shadow: var(--paper-stack);
+}
+.thing-card + .thing-card {
+  margin-top: var(--theme-spacing-sm);
+}
+.thing-head {
+  display: flex;
+  align-items: center;
+  gap: var(--theme-spacing-sm);
+}
+.q-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.thing-name {
+  font-family: var(--theme-font-title);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--theme-text-primary);
+}
+.thing-tag {
+  margin-left: auto;
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+  letter-spacing: 0.04em;
+}
+.thing-cost {
+  margin-top: var(--theme-spacing-xs);
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+}
+.thing-desc {
+  margin: var(--theme-spacing-xs) 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--theme-text-secondary);
+}
+.thing-foot {
+  margin-top: var(--theme-spacing-xs);
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+}
+.kv-list {
+  margin-top: var(--theme-spacing-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.kv-row {
+  display: flex;
+  gap: var(--theme-spacing-sm);
+  font-size: 0.75rem;
+}
+.kv-k {
+  min-width: 4rem;
+  flex-shrink: 0;
+  color: var(--theme-text-secondary);
+  font-weight: 500;
+}
+.kv-v {
+  color: var(--theme-text-primary);
+}
+
+/* ═══ 背包钱袋 ═══ */
+.purse {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: var(--theme-spacing-sm) var(--theme-spacing-md);
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  box-shadow: var(--paper-stack);
+}
+.purse-label {
+  font-size: 0.75rem;
+  color: var(--theme-text-muted);
+  letter-spacing: 0.04em;
+}
+.purse-value {
+  font-family: var(--theme-font-title);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--theme-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ═══ 相册 ═══ */
+.album-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+  gap: var(--theme-spacing-sm);
+}
+.album-tile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--theme-spacing-xs);
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: center;
+}
+/* 放大的那一格铺满整行 —— 相册里点一张就是想看清它 */
+.album-tile.focused {
+  grid-column: 1 / -1;
+}
+.album-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+  background: var(--theme-surface-muted);
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-md);
+  box-shadow: var(--paper-stack);
+  color: var(--theme-text-muted);
+  transition: border-color var(--theme-transition-fast);
+}
+.album-tile:hover .album-frame {
+  border-color: color-mix(in srgb, var(--theme-primary) 40%, var(--theme-card-border));
+}
+.album-tile.focused .album-frame {
+  aspect-ratio: auto;
+  height: min(60vh, 34rem);
+  border-color: color-mix(in srgb, var(--theme-primary) 45%, var(--theme-card-border));
+}
+/* 放大态下不要裁切: 这一格的意义就是"整张看清" */
+.album-tile.focused .album-frame :deep(.asset-media) {
+  object-fit: contain;
+}
+.album-missing {
+  font-size: 1.25rem;
+  opacity: 0.4;
+}
+.album-caption {
+  font-size: 0.6875rem;
+  color: var(--theme-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ═══ 空态（design.md §5.2） ═══ */
+.empty-tab {
+  padding: var(--theme-spacing-2xl) 0;
+  text-align: center;
+  color: var(--theme-text-muted);
+  font-size: 0.8125rem;
+  font-style: italic;
+}
+.empty-tab::before {
+  content: '—';
+  display: block;
+  margin-bottom: var(--theme-spacing-sm);
+  font-size: 1.25rem;
+  opacity: 0.3;
+}
+
+/* ═══ 折叠动画 —— 与 StatusOverview 同一份（opacity + 位移，绝不过渡布局属性） ═══ */
+.collapse-enter-active {
+  transition:
+    opacity 0.2s ease-out,
+    transform 0.2s ease-out;
+}
+.collapse-leave-active {
+  transition: opacity 0.12s ease-in;
+}
+.collapse-enter-from {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+.collapse-leave-to {
+  opacity: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .collapse-enter-active,
+  .collapse-leave-active {
+    transition: none;
+  }
+}
+
+/* ═══ 窄屏: 画像转到上方，两栏叠成一栏 ═══ */
+@media (max-width: 900px) {
+  .viewer {
+    flex-direction: column;
+  }
+  .viewer-portrait {
+    flex: 0 0 34%;
+    border-right: none;
+    border-bottom: 1px solid var(--theme-card-border);
+  }
+  .viewer-head,
+  .viewer-scroll {
+    padding-left: var(--theme-spacing-lg);
+    padding-right: var(--theme-spacing-lg);
+  }
+}
+</style>

--- a/src/ui/components/game/ScenePanel.viewer.test.ts
+++ b/src/ui/components/game/ScenePanel.viewer.test.ts
@@ -1,0 +1,89 @@
+/**
+ * ScenePanel — 点在场角色开角色查看器
+ *
+ * 这一条测的是**接线**，不是弹窗内容（那在 CharacterViewerModal.test.ts）:
+ * - 在场那一行点下去，弹窗带着**这个人的名字**开出来
+ * - 传的是名字不是对象（弹窗要靠它回查最新状态）
+ * - 弹窗 close 之后不再渲染
+ * - 🔴 **不经 `game.showModal`**: 那是页面级弹窗的单选位（一次只能开一个），
+ *   查看器是场景栏自己的一层。走那条路会把「角色列表」之类顶掉。
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
+import ScenePanel from './ScenePanel.vue';
+import CharacterViewerModal from './CharacterViewerModal.vue';
+
+let mockGame: any;
+let mockAssets: any;
+
+vi.mock('@engine/save-profile', () => ({ markNewsRead: vi.fn(async (p: any) => p) }));
+vi.mock('../../stores/game-store', () => ({ useGameStore: () => mockGame }));
+vi.mock('../../stores/settings-store', () => ({ useSettingsStore: () => ({ settings: {} }) }));
+vi.mock('../../stores/asset-store', () => ({ useAssetStore: () => mockAssets }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGame = {
+    activeSaveId: 'save_1',
+    gameTime: null,
+    player: null,
+    characters: [
+      { id: 'c1', name: '苏婉', type: 'npc', present: true, level: 4, tier: 2, attributes: {} },
+      { id: 'c2', name: '林霜', type: 'npc', present: true, level: 6, tier: 2, attributes: {} },
+    ],
+    saveProfile: { affections: {}, quests: {}, news: [] },
+    news: [],
+    getThoughts: vi.fn(() => ''),
+    showModal: vi.fn(),
+  };
+  mockAssets = { assets: [], assetUrl: vi.fn(async () => null), releaseAssetUrl: vi.fn() };
+});
+
+let wrapper: VueWrapper | null = null;
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = '';
+});
+
+describe('ScenePanel — 角色查看器接线', () => {
+  it('未点之前查看器关着（name=null）', async () => {
+    wrapper = mount(ScenePanel, { attachTo: document.body });
+    await flushPromises();
+    expect(wrapper.findComponent(CharacterViewerModal).props('name')).toBeNull();
+  });
+
+  it('★ 点第二位在场角色 → 查看器收到的是**那一位的名字**', async () => {
+    wrapper = mount(ScenePanel, { attachTo: document.body });
+    await flushPromises();
+
+    const items = wrapper.findAll('.scene-npc-item');
+    expect(items).toHaveLength(2);
+    await items[1].trigger('click');
+    await flushPromises();
+
+    expect(wrapper.findComponent(CharacterViewerModal).props('name')).toBe('林霜');
+    expect(document.querySelector('.head-name')?.textContent).toBe('林霜');
+  });
+
+  it('★ 不经 game.showModal —— 那个位是页面级弹窗的单选位', async () => {
+    wrapper = mount(ScenePanel, { attachTo: document.body });
+    await flushPromises();
+    await wrapper.find('.scene-npc-item').trigger('click');
+    expect(mockGame.showModal).not.toHaveBeenCalled();
+  });
+
+  it('查看器抛 close → 关回去', async () => {
+    wrapper = mount(ScenePanel, { attachTo: document.body });
+    await flushPromises();
+    await wrapper.find('.scene-npc-item').trigger('click');
+    await flushPromises();
+
+    wrapper.findComponent(CharacterViewerModal).vm.$emit('close');
+    await flushPromises();
+    expect(wrapper.findComponent(CharacterViewerModal).props('name')).toBeNull();
+    expect(document.querySelector('.viewer')).toBeNull();
+  });
+});

--- a/src/ui/components/game/ScenePanel.vue
+++ b/src/ui/components/game/ScenePanel.vue
@@ -312,13 +312,15 @@ const viewingName = ref<string | null>(null);
         </div>
 
         <div v-if="presentChars.length" class="scene-npc-list">
+          <!-- 点开角色查看器。⚠️ **这一行不加 `title`**: 它已经挂着心声悬停气泡，
+               再给一个原生 tooltip 会在同一次悬停里冒出两层浮层（本文件里其它
+               带 `title` 的都是没有气泡的控件）。可点性靠 hover 态与 `<button>` 本身表达。 -->
           <button
             v-for="char in presentChars"
             :key="char.id"
             class="scene-npc-item"
             :class="{ hovered: thoughtPop.key.value === char.id }"
             :aria-describedby="thoughtPop.key.value === char.id ? 'npc-thought-pop' : undefined"
-            :title="`查看 ${char.name} 的档案`"
             @click="viewingName = char.name"
             @mouseenter="thoughtPop.onEnter($event, char.id)"
             @mouseleave="thoughtPop.hide"

--- a/src/ui/components/game/ScenePanel.vue
+++ b/src/ui/components/game/ScenePanel.vue
@@ -10,6 +10,7 @@ import { getAffectionLabel } from '@engine/affection-system';
 import { MONTH_NAMES, WEEKDAY_NAMES, getTimeOfDay } from '@engine/time-system';
 import { nameColorVar, initialsOf } from '../../utils/name-color';
 import AppTabs from '../shared/AppTabs.vue';
+import CharacterViewerModal from './CharacterViewerModal.vue';
 
 const game = useGameStore();
 
@@ -180,6 +181,19 @@ async function toggleNews(id: string) {
 function openCharList() {
   game.showModal('characters');
 }
+
+/**
+ * ═══ 角色查看器 ═══
+ *
+ * 在场那一行本来就是 `<button>`（此前只挂着悬停心声），点开一份完整档案是它缺的那半。
+ *
+ * 存的是**名字**而不是整个角色对象: 弹窗每次都按名字回查 `game.characters`
+ * （M4 起名字唯一），于是战斗/提交换掉整份数组时它跟着更新。攥着对象的话，
+ * 打完架再看这个人，血量还是打之前的 —— 而那种缺陷没人会怀疑到弹窗上。
+ * **不走 `game.showModal`**: 那是页面级弹窗的单选位（一次只能开一个），本弹窗是
+ * 场景栏自己的一层，与「角色列表」那个页面级弹窗互不相干。
+ */
+const viewingName = ref<string | null>(null);
 </script>
 
 <template>
@@ -304,6 +318,8 @@ function openCharList() {
             class="scene-npc-item"
             :class="{ hovered: thoughtPop.key.value === char.id }"
             :aria-describedby="thoughtPop.key.value === char.id ? 'npc-thought-pop' : undefined"
+            :title="`查看 ${char.name} 的档案`"
+            @click="viewingName = char.name"
             @mouseenter="thoughtPop.onEnter($event, char.id)"
             @mouseleave="thoughtPop.hide"
             @focus="thoughtPop.onFocus($event, char.id)"
@@ -408,6 +424,9 @@ function openCharList() {
   <div v-else class="scene-panel scene-panel-empty">
     <div class="scene-empty-msg">未选择存档</div>
   </div>
+
+  <!-- ═══ 角色查看器 —— 点在场角色开（自己 Teleport 到 body，见 AppModal） ═══ -->
+  <CharacterViewerModal :name="viewingName" @close="viewingName = null" />
 
   <!-- ═══ 心声气泡（Teleport 出滚动容器，否则会被 overflow 裁掉） ═══ -->
   <Teleport to="body">

--- a/src/ui/components/game/character-viewer.test.ts
+++ b/src/ui/components/game/character-viewer.test.ts
@@ -76,6 +76,26 @@ describe('buildSubtitleSegments', () => {
     ).toEqual(['兽人']);
   });
 
+  /**
+   * ★ `identity` / `occupation` 名义上是 `string[]`，但 `state-manager` 的
+   * `update_character` 白名单落库走裸 `Object.assign`、零校验，`vars_update` 那条路
+   * 不做归一化。`(x ?? []).join()` 只兜 null/undefined —— 一个**字符串**会让
+   * `.join is not a function` 从 mount 里抛出来，整个弹窗打不开。
+   */
+  it('★ identity 是字符串（AI 直接写了一个词）→ 当一段用，不抛', () => {
+    const c = char({ tier: 0, tierName: '', level: 0 });
+    (c as unknown as Record<string, unknown>).identity = '酒馆老板';
+    expect(texts(c)).toEqual(['人类', '酒馆老板']);
+  });
+
+  it('★ occupation 是数字 / 混着非字符串 → 静默跳过，不渲染 [object Object]', () => {
+    const c = char({ tier: 0, tierName: '', level: 0 });
+    (c as unknown as Record<string, unknown>).occupation = 42;
+    expect(texts(c)).toEqual(['人类']);
+    (c as unknown as Record<string, unknown>).occupation = ['商人', { x: 1 }, null];
+    expect(texts(c)).toEqual(['人类', '商人']);
+  });
+
   it('多身份 / 多职业各自用 / 连起来', () => {
     expect(
       texts(
@@ -140,6 +160,22 @@ describe('buildProfileFields', () => {
     const fields = buildProfileFields(char({ customFields: { likes: ['秩序', '矿石'] } }));
     expect(fields).toEqual([]);
   });
+
+  /**
+   * ★ 三个正式字段与上面那个扩展位**同样**没有校验（`update_character` 裸
+   * `Object.assign`），而 `.trim()` 碰上数字会当场抛、把整个弹窗带走。
+   */
+  it('★ personality 是数字 → 转成字符串显示，绝不抛', () => {
+    const c = char();
+    (c as unknown as Record<string, unknown>).personality = 42;
+    expect(buildProfileFields(c)).toEqual([{ label: '性格', text: '42' }]);
+  });
+
+  it('★ appearance 是对象 → 当没有（不渲染 [object Object]）', () => {
+    const c = char();
+    (c as unknown as Record<string, unknown>).appearance = { hair: '银白' };
+    expect(buildProfileFields(c)).toEqual([]);
+  });
 });
 
 describe('buildAscensionTracks', () => {
@@ -195,6 +231,39 @@ describe('buildAscensionTracks', () => {
     };
     const tracks = buildAscensionTracks(legacy);
     expect(tracks[2].entries.map((e) => e.name)).toEqual(['镇压与秩序']);
+  });
+
+  /**
+   * ★ `ascension` 同样零校验落库，AI 写得出 `elements: ['空间','时间']`。
+   * 按「只要对象」过滤会让一个真有两个要素的角色显示成 `0/3` +「尚未踏上长阶」——
+   * 静默丢数据比显示得不完整糟得多。
+   */
+  it('★ 裸字符串条目当「只有名字的条目」收下，不静默丢掉', () => {
+    const c = char();
+    (c.ascension as unknown as Record<string, unknown>).elements = ['空间', '时间'];
+    const tracks = buildAscensionTracks(c);
+    expect(tracks[0].entries.map((e) => e.name)).toEqual(['空间', '时间']);
+    expect(tracks[0].entries[0]).toEqual({
+      name: '空间',
+      description: '',
+      effects: [],
+      cost: '',
+    });
+    expect(hasAnyAscension(tracks)).toBe(true);
+  });
+
+  it('无名条目（空串 / 空对象 / null）不占格', () => {
+    const c = char();
+    (c.ascension as unknown as Record<string, unknown>).law = ['  ', {}, null, '秩序'];
+    expect(buildAscensionTracks(c)[2].entries.map((e) => e.name)).toEqual(['秩序']);
+  });
+
+  it('effects 不是数组时当空 —— 模板要 v-for 它', () => {
+    const c = char();
+    (c.ascension as unknown as Record<string, unknown>).law = [
+      { name: '秩序', description: 'x', effects: '定身' },
+    ];
+    expect(buildAscensionTracks(c)[2].entries[0].effects).toEqual([]);
   });
 
   it('整个 ascension 缺失（旧数据 / 怪物）也给三条空轨道', () => {
@@ -265,7 +334,13 @@ describe('buildAlbumGroups', () => {
     expect(groups[0].tiles[0].variant).toBeUndefined();
   });
 
-  it('同变体撞车时按 createdAt → id 稳定排序（刷新两次顺序不变）', () => {
+  /**
+   * ★ 格子按行 id 做 key，图却按 `(名字, 类型, 变体)` 重新解析 —— 而索引对同一个位
+   * 只认一个胜出行。不去重就是两格标题相同、图也相同，且界面上无从区分
+   * （日后加「删除 / 设为主图」按钮时就说不清点的是哪一行了）。
+   * 留下的必须是 `compareStable` 的胜者: createdAt 最早、同 createdAt 按 id 升序。
+   */
+  it('★ 同位撞车只出一格，且留的是索引会选中的那一行', () => {
     const groups = buildAlbumGroups(
       [
         row({ id: 'z', variant: '微笑', createdAt: 5 }),
@@ -274,6 +349,22 @@ describe('buildAlbumGroups', () => {
       ],
       '维奥莱塔',
     );
-    expect(groups[0].tiles.map((t) => t.id)).toEqual(['m', 'a', 'z']);
+    expect(groups[0].tiles.map((t) => t.id)).toEqual(['m']);
+  });
+
+  it('主图撞车同样只出一格', () => {
+    const groups = buildAlbumGroups(
+      [row({ id: 'late', createdAt: 9 }), row({ id: 'early', createdAt: 1 })],
+      '维奥莱塔',
+    );
+    expect(groups[0].tiles.map((t) => t.id)).toEqual(['early']);
+  });
+
+  it('不同变体互不影响（去重只按位，不按类型整体）', () => {
+    const groups = buildAlbumGroups(
+      [row({ id: 'b' }), row({ id: 'v1', variant: '微笑' }), row({ id: 'v2', variant: '大笑' })],
+      '维奥莱塔',
+    );
+    expect(groups[0].tiles.map((t) => t.id)).toEqual(['b', 'v2', 'v1']);
   });
 });

--- a/src/ui/components/game/character-viewer.test.ts
+++ b/src/ui/components/game/character-viewer.test.ts
@@ -1,0 +1,279 @@
+/**
+ * character-viewer.ts — 角色查看器展示层判定
+ *
+ * 这些用例钉的都是「界面上少一行字 / 多一行空行」那类缺陷 —— 它们不会让任何
+ * 别的测试变红，也不会在控制台留下痕迹。
+ */
+import { describe, it, expect } from 'vitest';
+import { createDefaultCharacterState } from '@engine/types';
+import type { AssetMetaRecord, CharacterState } from '@engine/types';
+import {
+  buildAffectionView,
+  buildAlbumGroups,
+  buildAscensionTracks,
+  buildProfileFields,
+  buildSubtitleSegments,
+  hasAnyAscension,
+  itemQuality,
+  splitInventory,
+} from './character-viewer';
+
+function char(overrides: Partial<CharacterState> = {}): CharacterState {
+  return createDefaultCharacterState({ name: '维奥莱塔', ...overrides });
+}
+
+function row(over: Partial<AssetMetaRecord> = {}): AssetMetaRecord {
+  return {
+    id: 'a1',
+    name: '维奥莱塔',
+    type: '立绘',
+    ext: 'png',
+    mime: 'image/png',
+    bytes: 10,
+    createdAt: 1,
+    updatedAt: 1,
+    ...over,
+  };
+}
+
+describe('buildSubtitleSegments', () => {
+  const texts = (c: CharacterState) => buildSubtitleSegments(c).map((s) => s.text);
+
+  it('按序拼 种族 · 身份 · 职业 · 层级 · Lv', () => {
+    expect(
+      texts(
+        char({
+          race: '人类',
+          identity: ['帝王'],
+          occupation: ['法则代行者'],
+          tier: 6,
+          level: 24,
+        }),
+      ),
+    ).toEqual(['人类', '帝王', '法则代行者', '神话', 'Lv 24']);
+  });
+
+  it('★ 层级名由 tier 反查，不信 tierName —— 两者不一致是真机上实际发生的', () => {
+    // 真机走查逮到的那一份数据: tier=5（传说）却带着默认的 tierName='普通'
+    const segs = buildSubtitleSegments(char({ tier: 5, tierName: '普通', level: 18 }));
+    const tierSeg = segs.find((s) => s.kind === 'tier');
+    expect(tierSeg?.text).toBe('传说');
+  });
+
+  it('tier 越界（0 / 99）时退回 tierName —— 有话说总比空着好', () => {
+    expect(texts(char({ tier: 99, tierName: '域外之物', level: 0 }))).toContain('域外之物');
+  });
+
+  it('★ 层级段靠 kind 标记，不靠字符串比对（种族恰好同名也不会被染色）', () => {
+    const segs = buildSubtitleSegments(char({ race: '普通', tier: 1, level: 0 }));
+    expect(segs.filter((s) => s.kind === 'tier')).toHaveLength(1);
+    expect(segs[0]).toEqual({ text: '普通', kind: 'plain' });
+  });
+
+  it('★ 空段不占位（不补「未知」，也不留空段）—— 龙套多半只有种族', () => {
+    expect(
+      texts(char({ race: '兽人', identity: [], occupation: [], tier: 0, tierName: '', level: 0 })),
+    ).toEqual(['兽人']);
+  });
+
+  it('多身份 / 多职业各自用 / 连起来', () => {
+    expect(
+      texts(
+        char({
+          race: '精灵',
+          identity: ['公主', '祭司'],
+          occupation: [],
+          tier: 0,
+          tierName: '',
+          level: 0,
+        }),
+      ),
+    ).toEqual(['精灵', '公主 / 祭司']);
+  });
+});
+
+describe('buildAffectionView', () => {
+  it('0 → 中立、比例 0', () => {
+    expect(buildAffectionView(0)).toEqual({
+      value: 0,
+      ratio: 0,
+      negative: false,
+      label: '中立',
+    });
+  });
+
+  it('缺省（这个角色还没有好感记录）当 0 处理，不炸', () => {
+    expect(buildAffectionView(undefined).value).toBe(0);
+  });
+
+  it('正负各走各的方向，比例是**单边**的绝对值', () => {
+    expect(buildAffectionView(50)).toMatchObject({ ratio: 0.5, negative: false });
+    expect(buildAffectionView(-50)).toMatchObject({ ratio: 0.5, negative: true });
+  });
+
+  it('★ 越界值先夹逼 —— AI 写飞的 999 不该让条冲出轨道', () => {
+    expect(buildAffectionView(999)).toMatchObject({ value: 100, ratio: 1 });
+    expect(buildAffectionView(-999)).toMatchObject({ value: -100, ratio: 1 });
+  });
+});
+
+describe('buildProfileFields', () => {
+  it('四行按 性格 / 喜爱 / 外貌 / 着装 排', () => {
+    const fields = buildProfileFields(
+      char({
+        personality: '深沉内敛',
+        appearance: '暗金色长发',
+        outfit: '皇室军礼服',
+        customFields: { likes: '绝对的秩序' },
+      }),
+    );
+    expect(fields.map((f) => f.label)).toEqual(['性格', '喜爱', '外貌', '着装']);
+    expect(fields[1].text).toBe('绝对的秩序');
+  });
+
+  it('★ 空白行整行不出现（空串与纯空格都算空）', () => {
+    const fields = buildProfileFields(char({ personality: '沉默', outfit: '   ' }));
+    expect(fields.map((f) => f.label)).toEqual(['性格']);
+  });
+
+  it('★ customFields.likes 不是字符串时当没有 —— 扩展位躺着数组会渲染成 [object Object]', () => {
+    const fields = buildProfileFields(char({ customFields: { likes: ['秩序', '矿石'] } }));
+    expect(fields).toEqual([]);
+  });
+});
+
+describe('buildAscensionTracks', () => {
+  it('恒返回三条轨道，带上限与解锁级别', () => {
+    const tracks = buildAscensionTracks(char());
+    expect(tracks.map((t) => [t.label, t.cap])).toEqual([
+      ['要素', 3],
+      ['权能', 1],
+      ['法则', 2],
+    ]);
+    expect(tracks.every((t) => t.entries.length === 0)).toBe(true);
+    expect(hasAnyAscension(tracks)).toBe(false);
+  });
+
+  it('法则的 costDescription 进 cost，要素没有这一项', () => {
+    const tracks = buildAscensionTracks(
+      char({
+        ascension: {
+          enabled: true,
+          elements: [{ name: '空间', description: '折叠', effects: ['位移'] }],
+          authority: [],
+          law: [
+            {
+              name: '镇压与秩序',
+              description: '以法则镇压',
+              effects: ['定身'],
+              costDescription: '25% 最大MP',
+            },
+          ],
+          deityPosition: '',
+          divineKingdom: { name: '', description: '' },
+        },
+      }),
+    );
+    expect(tracks[0].entries[0]).toEqual({
+      name: '空间',
+      description: '折叠',
+      effects: ['位移'],
+      cost: '',
+    });
+    expect(tracks[2].entries[0].cost).toBe('25% 最大MP');
+    expect(hasAnyAscension(tracks)).toBe(true);
+  });
+
+  /**
+   * ★ Phase 9 把这三个字段从 Record 改成了 Array。存量存档里可能还是旧形状，
+   * 而 `.map` 对 Record 不成立 —— 不摊平的话整个弹窗白屏，不是少一行。
+   */
+  it('★ 旧存档的 Record 形状照样摊得平', () => {
+    const legacy = char();
+    (legacy.ascension as unknown as Record<string, unknown>).law = {
+      镇压与秩序: { name: '镇压与秩序', description: 'x', effects: [], costDescription: '' },
+    };
+    const tracks = buildAscensionTracks(legacy);
+    expect(tracks[2].entries.map((e) => e.name)).toEqual(['镇压与秩序']);
+  });
+
+  it('整个 ascension 缺失（旧数据 / 怪物）也给三条空轨道', () => {
+    const broken = char();
+    delete (broken as unknown as Record<string, unknown>).ascension;
+    expect(buildAscensionTracks(broken)).toHaveLength(3);
+  });
+});
+
+describe('splitInventory', () => {
+  it('按 equippedSlot 非空分家', () => {
+    const { equipped, carried } = splitInventory([
+      { name: '长剑', quantity: 1, equippedSlot: '主手' },
+      { name: '面包', quantity: 3 },
+      { name: '旧披风', quantity: 1, equippedSlot: null },
+    ]);
+    expect(equipped.map((i) => i.name)).toEqual(['长剑']);
+    expect(carried.map((i) => i.name)).toEqual(['面包', '旧披风']);
+  });
+
+  it('没有背包（怪物）不炸', () => {
+    expect(splitInventory(undefined)).toEqual({ equipped: [], carried: [] });
+  });
+});
+
+describe('itemQuality', () => {
+  it('★ 有 rarity 就用它 —— 推断封顶在传说，会把「唯一」安静降级', () => {
+    expect(itemQuality({ name: '圣剑', quantity: 1, rarity: '唯一', stats: { str: 1 } })).toBe(
+      '唯一',
+    );
+  });
+
+  it('没有 rarity 时按属性总和推断', () => {
+    expect(itemQuality({ name: '铁剑', quantity: 1, stats: { str: 12 } })).toBe('优良');
+    expect(itemQuality({ name: '木棍', quantity: 1 })).toBe('普通');
+  });
+});
+
+describe('buildAlbumGroups', () => {
+  it('★ 名字严格 === （D2）：尾随空格的素材不算这个人的', () => {
+    const groups = buildAlbumGroups([row({ name: '维奥莱塔 ' })], '维奥莱塔');
+    expect(groups).toEqual([]);
+  });
+
+  it('按 ASSET_TYPES 展示序分组，空组不出现', () => {
+    const groups = buildAlbumGroups(
+      [
+        row({ id: 'b', type: '立绘bg' }),
+        row({ id: 'a', type: '头像' }),
+        row({ id: 's', type: '立绘' }),
+      ],
+      '维奥莱塔',
+    );
+    expect(groups.map((g) => g.type)).toEqual(['头像', '立绘', '立绘bg']);
+  });
+
+  it('组内主图在前，变体按名字升序', () => {
+    const groups = buildAlbumGroups(
+      [row({ id: 'v2', variant: '微笑' }), row({ id: 'v1', variant: '大笑' }), row({ id: 'base' })],
+      '维奥莱塔',
+    );
+    expect(groups[0].tiles.map((t) => t.id)).toEqual(['base', 'v1', 'v2']);
+    expect(groups[0].tiles.map((t) => t.caption)).toEqual(['立绘', '立绘 · 大笑', '立绘 · 微笑']);
+  });
+
+  it('空串变体归一成「没有变体」—— 与 asset-index 的口径一致', () => {
+    const groups = buildAlbumGroups([row({ variant: '' })], '维奥莱塔');
+    expect(groups[0].tiles[0].variant).toBeUndefined();
+  });
+
+  it('同变体撞车时按 createdAt → id 稳定排序（刷新两次顺序不变）', () => {
+    const groups = buildAlbumGroups(
+      [
+        row({ id: 'z', variant: '微笑', createdAt: 5 }),
+        row({ id: 'a', variant: '微笑', createdAt: 5 }),
+        row({ id: 'm', variant: '微笑', createdAt: 1 }),
+      ],
+      '维奥莱塔',
+    );
+    expect(groups[0].tiles.map((t) => t.id)).toEqual(['m', 'a', 'z']);
+  });
+});

--- a/src/ui/components/game/character-viewer.ts
+++ b/src/ui/components/game/character-viewer.ts
@@ -26,6 +26,28 @@ import type {
 // 头部
 // ═══════════════════════════════════════════════════════════
 
+/**
+ * 「这个字段名义上是 `string[]`，实际可能是任何东西」的收敛器。
+ *
+ * 🔴 为什么需要它: `identity` / `occupation` 在 `state-manager` 的
+ * `update_character` 白名单里，落库走的是一句裸 `Object.assign` —— **零类型校验**。
+ * char-gen 那条路会把它归一成数组，`vars_update` 那条路不会。于是
+ * `(char.identity ?? []).join(...)` 会炸: `??` 只兜 null/undefined，一个**字符串**
+ * 照样往下走，`.join is not a function` 直接从 `mount` 里抛出来 —— 整个弹窗打不开，
+ * 而不是少显示一行。（审查逮到的，已实测。）
+ */
+function joinLoose(value: unknown, sep = ' / '): string {
+  if (Array.isArray(value)) return value.filter((v) => typeof v === 'string').join(sep);
+  return typeof value === 'string' ? value : '';
+}
+
+/** 同上: 名义上是 `string` 的叙事字段可能躺着数字/对象，`.trim()` 会当场抛 */
+function textLoose(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number') return String(value);
+  return '';
+}
+
 export interface SubtitleSegment {
   text: string;
   /** `tier` 那一段要按层级着色；其余是普通文字。**不靠字符串比对认它** */
@@ -48,15 +70,13 @@ export interface SubtitleSegment {
 export function buildSubtitleSegments(char: CharacterState): SubtitleSegment[] {
   const tierLabel = getTierConfig(char.tier)?.name ?? char.tierName;
   const raw: SubtitleSegment[] = [
-    { text: char.race, kind: 'plain' },
-    { text: (char.identity ?? []).join(' / '), kind: 'plain' },
-    { text: (char.occupation ?? []).join(' / '), kind: 'plain' },
-    { text: tierLabel, kind: 'tier' },
+    { text: textLoose(char.race), kind: 'plain' },
+    { text: joinLoose(char.identity), kind: 'plain' },
+    { text: joinLoose(char.occupation), kind: 'plain' },
+    { text: textLoose(tierLabel), kind: 'tier' },
     { text: char.level ? `Lv ${char.level}` : '', kind: 'plain' },
   ];
-  return raw
-    .map((seg) => ({ ...seg, text: (seg.text ?? '').trim() }))
-    .filter((seg) => seg.text !== '');
+  return raw.map((seg) => ({ ...seg, text: seg.text.trim() })).filter((seg) => seg.text !== '');
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -99,14 +119,17 @@ export interface ProfileField {
  * （见 char-gen-agent.ts 的 `customFields`），而 M6 那轮升格没带上它。所以这里
  * 必须防 `unknown` —— 扩展位是 `Record<string, any>`，里面完全可能躺着数组或对象，
  * 直接插值会渲染成 `[object Object]`。
+ *
+ * 🔴 另外三行**同样**要过 `textLoose`: 它们名义上是 `string?`，但与 `identity` 一样
+ * 经 `update_character` 的裸 `Object.assign` 落库、零校验。此前这里对扩展位那一行
+ * 设了防、对紧挨着的三个正式字段没设 —— 而 `.trim()` 碰上数字就当场抛。
  */
 export function buildProfileFields(char: CharacterState): ProfileField[] {
-  const likes = char.customFields?.likes;
   const raw: ProfileField[] = [
-    { label: '性格', text: char.personality ?? '' },
-    { label: '喜爱', text: typeof likes === 'string' ? likes : '' },
-    { label: '外貌', text: char.appearance ?? '' },
-    { label: '着装', text: char.outfit ?? '' },
+    { label: '性格', text: textLoose(char.personality) },
+    { label: '喜爱', text: textLoose(char.customFields?.likes) },
+    { label: '外貌', text: textLoose(char.appearance) },
+    { label: '着装', text: textLoose(char.outfit) },
   ];
   return raw.map((f) => ({ label: f.label, text: f.text.trim() })).filter((f) => f.text !== '');
 }
@@ -150,10 +173,10 @@ const ASCENSION_META = [
 
 function toEntry(d: ElementDetail | AuthorityDetail | LawDetail): AscensionEntry {
   return {
-    name: d.name,
-    description: d.description ?? '',
-    effects: d.effects ?? [],
-    cost: 'costDescription' in d ? (d.costDescription ?? '') : '',
+    name: textLoose(d.name),
+    description: textLoose(d.description),
+    effects: Array.isArray(d.effects) ? d.effects.filter((e) => typeof e === 'string') : [],
+    cost: 'costDescription' in d ? textLoose(d.costDescription) : '',
   };
 }
 
@@ -163,6 +186,11 @@ function toEntry(d: ElementDetail | AuthorityDetail | LawDetail): AscensionEntry
  * 🔴 三个字段自 Phase 9 起是**数组**（此前是 Record）。存量存档里可能还躺着旧形状，
  * 而 `Object.values` 对两者都成立、`.map` 只对数组成立 —— 所以这里统一先摊平。
  * 不做这一步的症状不是空白，是 `.map is not a function` 把整个弹窗打成白屏。
+ *
+ * 🔴 **裸字符串条目要收下，不能丢**（审查逮到）: `ascension` 同样在
+ * `update_character` 白名单里、零校验落库，AI 完全写得出 `elements: ['空间','时间']`。
+ * 按「只要对象」过滤的话，一个真有两个要素的角色会显示成 `0/3` +「尚未踏上长阶」——
+ * 静默丢数据比显示得不完整糟得多，所以字符串按「只有名字的条目」收。
  */
 export function buildAscensionTracks(char: CharacterState): AscensionTrack[] {
   const asc = char.ascension;
@@ -176,8 +204,14 @@ export function buildAscensionTracks(char: CharacterState): AscensionTrack[] {
     return {
       ...meta,
       entries: list
-        .filter((d): d is ElementDetail => Boolean(d) && typeof d === 'object')
-        .map(toEntry),
+        .map((d) =>
+          typeof d === 'string'
+            ? { name: d.trim(), description: '', effects: [], cost: '' }
+            : d && typeof d === 'object'
+              ? toEntry(d as ElementDetail)
+              : null,
+        )
+        .filter((e): e is AscensionEntry => e !== null && e.name !== ''),
     };
   });
 }
@@ -250,12 +284,19 @@ export interface AlbumGroup {
  *
  * 组内: 主图（无变体）在前，其余按变体名升序、同名按 `createdAt` —— 与
  * `buildAssetIndex` 的 `compareStable` 同一条口径，于是刷新两次顺序不变。
+ *
+ * 🔴 **一个 (类型, 变体) 只出一格**（审查逮到）: 格子按行 `id` 做 key，但图是按
+ * `(名字, 类型, 变体)` 重新解析的 —— 索引对同一个位只认一个胜出行
+ * （`buildAssetIndex` 明写了撞车规则）。不去重就会出现**两格标题相同、图也相同**的
+ * 并排格子，而它们在界面上无从区分；日后相册长出「删除 / 设为主图」这类按钮时，
+ * 用户点的是哪一行就说不清了。排序在前、去重在后，所以留下的恰是索引会选中的那一行。
  */
 export function buildAlbumGroups(rows: readonly AssetMetaRecord[], name: string): AlbumGroup[] {
   const mine = rows.filter((r) => r.name === name);
   const groups: AlbumGroup[] = [];
 
   for (const type of ASSET_TYPES) {
+    const seen = new Set<string>();
     const tiles = mine
       .filter((r) => r.type === type)
       .sort((a, b) => {
@@ -265,6 +306,13 @@ export function buildAlbumGroups(rows: readonly AssetMetaRecord[], name: string)
         if (av !== bv) return av === '' ? -1 : bv === '' ? 1 : av < bv ? -1 : 1;
         if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
         return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      })
+      // 同位撞车时留排序后的第一行 —— 与 compareStable 的胜者同一个
+      .filter((r) => {
+        const slot = r.variant ?? '';
+        if (seen.has(slot)) return false;
+        seen.add(slot);
+        return true;
       })
       .map<AlbumTile>((r) => ({
         id: r.id,

--- a/src/ui/components/game/character-viewer.ts
+++ b/src/ui/components/game/character-viewer.ts
@@ -1,0 +1,279 @@
+/**
+ * character-viewer.ts — 角色查看器的展示层纯函数（零副作用，不 mount 可测）
+ *
+ * 为什么单独一层（照 portrait-messages.ts / cg-gallery.ts / scene-image-view.ts 的先例）:
+ * 「这个角色现在该显示哪几行」与「这几行长什么样」是两个不相干的变更理由。
+ * 弹窗那边全是样式与滚动容器，而这里的每一条都是**判定**，判错了的症状是
+ * 界面上少一行字 —— 那种缺陷在模板表达式里没法钉住。
+ *
+ * 纯度约束: 无 Vue、无 Pinia、无 I/O、无浏览器全局。
+ */
+import { clampAffection, getAffectionLabel } from '@engine/affection-system';
+import { inferQualityFromStats } from '@engine/quality-inference';
+import { getTierConfig } from '@engine/tier-constants';
+import { ASSET_TYPES } from '@engine/types';
+import type {
+  AssetMetaRecord,
+  AssetType,
+  AuthorityDetail,
+  CharacterState,
+  ElementDetail,
+  InventoryItem,
+  LawDetail,
+} from '@engine/types';
+
+// ═══════════════════════════════════════════════════════════
+// 头部
+// ═══════════════════════════════════════════════════════════
+
+export interface SubtitleSegment {
+  text: string;
+  /** `tier` 那一段要按层级着色；其余是普通文字。**不靠字符串比对认它** */
+  kind: 'plain' | 'tier';
+}
+
+/**
+ * 名字下面那一行 —— `种族 · 身份 · 职业 · 层级 · Lv N`。
+ *
+ * **空段一律不占位**（不补「未知」也不留两个连着的 `·`）: 这一行是给玩家看的
+ * 一句介绍，而 AI 造出来的龙套很可能只有种族。写成「人类 · 未知 · 未知 · 普通」
+ * 比少两段更难读。
+ *
+ * 🔴 **层级名由 `tier` 反查 `TIER_CONFIGS`，`tierName` 只当兜底。** 两个字段会不一致
+ * （真机走查当场逮到: 测试存档里 `tier: 5` 配着默认的 `tierName: '普通'`，于是一位
+ * Lv.18 的传说贤者自称「普通」）。`tier` 是数值侧的驱动量 —— 资源上限、战斗系数、
+ * 属性上限全从它算 —— 所以它才是可信的那一个；`tierName` 是给 AI 写的展示字段，
+ * 没人保证会跟着改。
+ */
+export function buildSubtitleSegments(char: CharacterState): SubtitleSegment[] {
+  const tierLabel = getTierConfig(char.tier)?.name ?? char.tierName;
+  const raw: SubtitleSegment[] = [
+    { text: char.race, kind: 'plain' },
+    { text: (char.identity ?? []).join(' / '), kind: 'plain' },
+    { text: (char.occupation ?? []).join(' / '), kind: 'plain' },
+    { text: tierLabel, kind: 'tier' },
+    { text: char.level ? `Lv ${char.level}` : '', kind: 'plain' },
+  ];
+  return raw
+    .map((seg) => ({ ...seg, text: (seg.text ?? '').trim() }))
+    .filter((seg) => seg.text !== '');
+}
+
+// ═══════════════════════════════════════════════════════════
+// 好感度
+// ═══════════════════════════════════════════════════════════
+
+export interface AffectionView {
+  /** 夹逼后的值（真源可能被 AI 写飞，[-100,100] 之外的条不该冲出轨道） */
+  value: number;
+  /** 单边填充比例 [0,1] —— 中线是 0，符号决定往哪边长 */
+  ratio: number;
+  negative: boolean;
+  /** 11 级中文标签（affection-system 是唯一出处，这里不另分档） */
+  label: string;
+}
+
+export function buildAffectionView(raw: number | undefined): AffectionView {
+  const value = clampAffection(raw ?? 0);
+  return {
+    value,
+    ratio: Math.min(1, Math.abs(value) / 100),
+    negative: value < 0,
+    label: getAffectionLabel(value),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════
+// 档案
+// ═══════════════════════════════════════════════════════════
+
+export interface ProfileField {
+  label: string;
+  text: string;
+}
+
+/**
+ * 档案四行。**空的整行不渲染** —— 一个「外貌: —」的空行既不好看也不传达信息。
+ *
+ * 🔴 `喜爱` 取的是 `customFields.likes`，不是正式字段: char-gen 把它落在扩展位上
+ * （见 char-gen-agent.ts 的 `customFields`），而 M6 那轮升格没带上它。所以这里
+ * 必须防 `unknown` —— 扩展位是 `Record<string, any>`，里面完全可能躺着数组或对象，
+ * 直接插值会渲染成 `[object Object]`。
+ */
+export function buildProfileFields(char: CharacterState): ProfileField[] {
+  const likes = char.customFields?.likes;
+  const raw: ProfileField[] = [
+    { label: '性格', text: char.personality ?? '' },
+    { label: '喜爱', text: typeof likes === 'string' ? likes : '' },
+    { label: '外貌', text: char.appearance ?? '' },
+    { label: '着装', text: char.outfit ?? '' },
+  ];
+  return raw.map((f) => ({ label: f.label, text: f.text.trim() })).filter((f) => f.text !== '');
+}
+
+// ═══════════════════════════════════════════════════════════
+// 登神长阶
+// ═══════════════════════════════════════════════════════════
+
+/** 一条登神条目。**刻意不导出** —— 它只经 {@link AscensionTrack} 露出去，没有第二个调用面 */
+interface AscensionEntry {
+  name: string;
+  description: string;
+  effects: string[];
+  /** 权能 / 法则 才有的消耗描述；要素没有这一项 */
+  cost: string;
+}
+
+export interface AscensionTrack {
+  key: 'elements' | 'authority' | 'law';
+  label: string;
+  /** 上限；`0` = 没有明确上限，只报个数 */
+  cap: number;
+  /** 这一档从哪一级开始拿得到（空态说明用） */
+  unlockLevel: string;
+  entries: AscensionEntry[];
+}
+
+/**
+ * 三档的上限与解锁级别。
+ *
+ * 数字来自 `types.ts` 的 `CharGenResult.ascension`（要素 1-3 / 权能 1 / 法则 1-2）
+ * 与三个 Detail 类型的注释（要素 Lv.13-16 / 权能 Lv.17-20 / 法则 Lv.21-24）。
+ * 抄在这里是**展示口径**，不是规则真源: 引擎侧唯一会拿它做判断的地方是
+ * `canBreakthrough`（只看要素个数），它不读本表。
+ */
+const ASCENSION_META = [
+  { key: 'elements' as const, label: '要素', cap: 3, unlockLevel: 'Lv.13' },
+  { key: 'authority' as const, label: '权能', cap: 1, unlockLevel: 'Lv.17' },
+  { key: 'law' as const, label: '法则', cap: 2, unlockLevel: 'Lv.21' },
+];
+
+function toEntry(d: ElementDetail | AuthorityDetail | LawDetail): AscensionEntry {
+  return {
+    name: d.name,
+    description: d.description ?? '',
+    effects: d.effects ?? [],
+    cost: 'costDescription' in d ? (d.costDescription ?? '') : '',
+  };
+}
+
+/**
+ * 三条轨道，**恒返回三条**（没开登神也一样）—— 空轨道由界面画成占位格。
+ *
+ * 🔴 三个字段自 Phase 9 起是**数组**（此前是 Record）。存量存档里可能还躺着旧形状，
+ * 而 `Object.values` 对两者都成立、`.map` 只对数组成立 —— 所以这里统一先摊平。
+ * 不做这一步的症状不是空白，是 `.map is not a function` 把整个弹窗打成白屏。
+ */
+export function buildAscensionTracks(char: CharacterState): AscensionTrack[] {
+  const asc = char.ascension;
+  return ASCENSION_META.map((meta) => {
+    const bag = asc?.[meta.key] as unknown;
+    const list: unknown[] = Array.isArray(bag)
+      ? bag
+      : bag && typeof bag === 'object'
+        ? Object.values(bag as Record<string, unknown>)
+        : [];
+    return {
+      ...meta,
+      entries: list
+        .filter((d): d is ElementDetail => Boolean(d) && typeof d === 'object')
+        .map(toEntry),
+    };
+  });
+}
+
+/** 有没有任何一档拿到了东西 —— 决定「登神长阶」这一节画不画（空态口径） */
+export function hasAnyAscension(tracks: readonly AscensionTrack[]): boolean {
+  return tracks.some((t) => t.entries.length > 0);
+}
+
+// ═══════════════════════════════════════════════════════════
+// 装备 / 背包
+// ═══════════════════════════════════════════════════════════
+
+export interface InventorySplit {
+  /** 已穿在身上的 —— 判据是 `equippedSlot` 非空（规范 §3，装备是物品的状态） */
+  equipped: InventoryItem[];
+  /** 背着的 */
+  carried: InventoryItem[];
+}
+
+/**
+ * 这件东西按什么品质着色。
+ *
+ * 🔴 **有 `rarity` 就用它，别推断** —— `inferQualityFromStats` 的文件头点名了这条：
+ * 那个函数封顶在「传说」，拿它去盖掉一件写着「唯一」的物品，界面上是安静地降一级。
+ * 推断只服务于没有显式品质的条目（AI 临时造的、旧存档里的）。
+ */
+export function itemQuality(item: InventoryItem): string {
+  return item.rarity ?? inferQualityFromStats(item.stats);
+}
+
+export function splitInventory(items: readonly InventoryItem[] | undefined): InventorySplit {
+  const equipped: InventoryItem[] = [];
+  const carried: InventoryItem[] = [];
+  for (const item of items ?? []) {
+    if (item.equippedSlot) equipped.push(item);
+    else carried.push(item);
+  }
+  return { equipped, carried };
+}
+
+// ═══════════════════════════════════════════════════════════
+// 相册
+// ═══════════════════════════════════════════════════════════
+
+export interface AlbumTile {
+  /** 素材行 id —— 只做 `:key`，**取图仍按 (名字, 类型, 变体) 走渲染缝**（§7.5） */
+  id: string;
+  type: AssetType;
+  /** 无变体行是 `undefined`（= 主图），不是空串 */
+  variant?: string;
+  /** 格子下面那行小字 */
+  caption: string;
+}
+
+export interface AlbumGroup {
+  type: AssetType;
+  tiles: AlbumTile[];
+}
+
+/**
+ * 这个角色名下的全部素材，按类型分组。
+ *
+ * 🔴 名字**严格 `===`**（D2）—— 不 trim、不折大小写。相册宽容匹配就会把
+ * 「苏婉 」的素材列进「苏婉」的相册里，而那两个在状态层是两个人。
+ *
+ * 组序走 `ASSET_TYPES`（types.ts 里那条**UI 展示序**）。刻意不用
+ * `ASSET_TYPE_FALLBACK_CHAIN` / `ASSET_TYPE_AVATAR_CHAIN`: 那两条是**解析优先级**，
+ * asset-resolve 的文件头专门写着两者含义不同、不能共用一个数组。
+ *
+ * 组内: 主图（无变体）在前，其余按变体名升序、同名按 `createdAt` —— 与
+ * `buildAssetIndex` 的 `compareStable` 同一条口径，于是刷新两次顺序不变。
+ */
+export function buildAlbumGroups(rows: readonly AssetMetaRecord[], name: string): AlbumGroup[] {
+  const mine = rows.filter((r) => r.name === name);
+  const groups: AlbumGroup[] = [];
+
+  for (const type of ASSET_TYPES) {
+    const tiles = mine
+      .filter((r) => r.type === type)
+      .sort((a, b) => {
+        const av = a.variant ?? '';
+        const bv = b.variant ?? '';
+        // 主图恒在最前（空变体排第一），其余按变体名
+        if (av !== bv) return av === '' ? -1 : bv === '' ? 1 : av < bv ? -1 : 1;
+        if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      })
+      .map<AlbumTile>((r) => ({
+        id: r.id,
+        type: r.type,
+        variant: r.variant === '' ? undefined : r.variant,
+        caption: r.variant ? `${r.type} · ${r.variant}` : r.type,
+      }));
+    if (tiles.length) groups.push({ type, tiles });
+  }
+
+  return groups;
+}

--- a/src/ui/components/shared/AppModal.test.ts
+++ b/src/ui/components/shared/AppModal.test.ts
@@ -1,0 +1,147 @@
+/**
+ * AppModal — 弹窗外壳
+ *
+ * 本文件是**审查催生的**: 这个组件有约 15 个调用方、却一条测试都没有，而本轮给它加了
+ * 两个档（`size="full"` / `bare`）。最要紧的一条是 `bare` 与 `closable` **必须互不干涉** ——
+ * 组件注释里那句「Esc 与点遮罩照旧生效」此前没有任何东西保证它。
+ *
+ * 顺带把它一直以来的两条不变式也钉住（都属于"坏了不会有人发现"那一类）:
+ * - 滚动锁: 带着 `open === true` 被销毁时必须把 `body.overflow` 还回去，
+ *   否则整页从此滚不动直到刷新（组件里那段长注释讲的就是这个）。
+ * - 点遮罩才关，点内容不关。
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import AppModal from './AppModal.vue';
+
+let wrapper: VueWrapper | null = null;
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = '';
+  document.body.style.overflow = '';
+});
+
+function modal(props: Record<string, unknown> = {}, slots: Record<string, string> = {}) {
+  wrapper?.unmount();
+  wrapper = mount(AppModal, {
+    props: { open: true, ...props },
+    slots: { default: '<p class="probe">内容</p>', ...slots },
+    attachTo: document.body,
+  });
+  return wrapper;
+}
+
+function pressEscape() {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+}
+
+/**
+ * 弹窗 `Teleport` 到 body，**`wrapper.find` 够不到它** —— 一律在 document 上找。
+ * 点遮罩必须点在遮罩**本身**（`onOverlayClick` 比对 target === currentTarget）。
+ */
+function clickInDocument(selector: string) {
+  (document.querySelector(selector) as HTMLElement).click();
+}
+
+describe('AppModal — bare 档', () => {
+  it('bare 不画页头（连关闭 × 也不画），内容照旧渲染', () => {
+    modal({ bare: true, title: '标题' });
+    expect(document.querySelector('.modal-header')).toBeNull();
+    expect(document.querySelector('.modal-close')).toBeNull();
+    expect(document.querySelector('.probe')).not.toBeNull();
+  });
+
+  it('不传 bare 时页头照旧（回归护栏：老调用方零改动）', () => {
+    modal({ title: '标题' });
+    expect(document.querySelector('.modal-header')).not.toBeNull();
+    expect(document.querySelector('.modal-title')?.textContent).toBe('标题');
+  });
+
+  /**
+   * ★ 本文件存在的首要理由。`bare` 让出的只是**外壳**，不是"能不能关" ——
+   * 把它写成 `closable: false` 会顺手废掉 design.md §4.5 要求必须支持的 Esc，
+   * 而那种回归在界面上完全看不出来（弹窗还能用，只是按 Esc 没反应）。
+   */
+  it('★ bare 之下 Esc 照旧关闭', () => {
+    const w = modal({ bare: true });
+    pressEscape();
+    expect(w.emitted('update:open')?.[0]).toEqual([false]);
+    expect(w.emitted('close')).toHaveLength(1);
+  });
+
+  it('★ bare 之下点遮罩照旧关闭', () => {
+    const w = modal({ bare: true });
+    clickInDocument('.modal-overlay');
+    expect(w.emitted('close')).toHaveLength(1);
+  });
+
+  it('bare 给 .modal-content 挂 modal-bare（body 内边距靠它撤）', () => {
+    modal({ bare: true, size: 'full' });
+    const content = document.querySelector('.modal-content') as HTMLElement;
+    expect(content.className).toContain('modal-bare');
+    expect(content.className).toContain('modal-full');
+  });
+});
+
+describe('AppModal — closable: false', () => {
+  it('三条关闭途径一起没（Esc / 点遮罩 / ×）', () => {
+    const w = modal({ closable: false });
+    pressEscape();
+    clickInDocument('.modal-overlay');
+    expect(w.emitted('close')).toBeUndefined();
+    expect(document.querySelector('.modal-close')).toBeNull();
+  });
+});
+
+describe('AppModal — 尺寸档', () => {
+  it('缺省是 md；每一档落到同名 class 上', () => {
+    modal();
+    expect(document.querySelector('.modal-content')?.className).toContain('modal-md');
+    for (const size of ['sm', 'md', 'lg', 'xl', 'xxl', 'full']) {
+      modal({ size });
+      expect(document.querySelector('.modal-content')?.className).toContain(`modal-${size}`);
+    }
+  });
+});
+
+describe('AppModal — 交互与副作用', () => {
+  it('点内容不关（只有点在遮罩本身才算）', () => {
+    const w = modal();
+    clickInDocument('.probe');
+    expect(w.emitted('close')).toBeUndefined();
+  });
+
+  it('open 切换时锁/解锁页面滚动', async () => {
+    const w = modal({ open: false });
+    await w.setProps({ open: true });
+    expect(document.body.style.overflow).toBe('hidden');
+    await w.setProps({ open: false });
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  /**
+   * ★ 组件里那段长注释讲的路径: 带着 `open === true` 被销毁时 watch 不触发，
+   * `body` 会永远停在 `overflow: hidden` —— 整页从此滚不动，直到刷新。
+   *
+   * 📌 先 `open: false` 再切真，是照**生产的挂载方式**来的: 那个 watch 不是
+   * `immediate`，所以「挂载时就已经是 open」并不会上锁。全部调用方都是常驻挂载 +
+   * 切 prop（本次新增的角色查看器也是），所以这条路径不存在；这里刻意按真实用法
+   * 触发上锁，而不是把测试写成组件做不到的样子。
+   */
+  it('★ 带着 open=true 被销毁时把滚动锁还回去', async () => {
+    const w = modal({ open: false });
+    await w.setProps({ open: true });
+    expect(document.body.style.overflow).toBe('hidden');
+    w.unmount();
+    wrapper = null;
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('open=false 时不渲染任何东西', () => {
+    modal({ open: false });
+    expect(document.querySelector('.modal-overlay')).toBeNull();
+  });
+});

--- a/src/ui/components/shared/AppModal.vue
+++ b/src/ui/components/shared/AppModal.vue
@@ -5,11 +5,23 @@ const props = withDefaults(
   defineProps<{
     open: boolean;
     title?: string;
-    size?: 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+    size?: 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'full';
     closable?: boolean;
+    /**
+     * 不画页头、body 也不留内边距 —— **内容自己画整个面**。
+     *
+     * 🔴 与 `closable: false` 刻意分开: 那一档关掉的是"能不能关"（Esc / 点遮罩 / ×
+     * 三条一起没），而这一档只是把**外壳**让出去，Esc 与点遮罩照旧生效。查看器这类
+     * 通栏版式需要的是后者 —— 把它写成 `closable: false` 就等于顺手废掉 Esc，
+     * 而那是 design.md §4.5 要求必须支持的。
+     *
+     * 用它的组件必须自己提供一个关闭控件（否则触屏用户只剩点遮罩这一条路）。
+     */
+    bare?: boolean;
   }>(),
   {
     closable: true,
+    bare: false,
     // 显式写 undefined：这两项**本来就没有默认值**（无标题 / 由 CSS 决定尺寸），
     // 但 vue/require-default-prop 要求每个可选 prop 都有交代，写出来比关规则好
     title: undefined,
@@ -71,8 +83,8 @@ function onOverlayClick(e: MouseEvent) {
         @click="onOverlayClick"
         @keydown="onKeydown"
       >
-        <div class="modal-content" :class="`modal-${size || 'md'}`">
-          <div v-if="title || $slots.header || closable !== false" class="modal-header">
+        <div class="modal-content" :class="[`modal-${size || 'md'}`, { 'modal-bare': bare }]">
+          <div v-if="!bare && (title || $slots.header || closable !== false)" class="modal-header">
             <h3 v-if="title" class="modal-title">{{ title }}</h3>
             <slot name="header" />
             <button
@@ -132,6 +144,25 @@ function onOverlayClick(e: MouseEvent) {
 .modal-xxl {
   width: min(94vw, 1600px);
   max-height: 85vh;
+}
+/**
+ * 通栏档 —— 画像 + 信息两栏并排的版式（角色查看器）。
+ *
+ * 与其它档不同的是它**定死高度**而不是给 `max-height`: 里面是"左栏铺满、右栏自己滚"
+ * 的布局，而那需要一个确定的高度可以百分比化。`overflow: hidden` 同理必须盖掉
+ * `.modal-content` 的 `overflow-y: auto` —— 否则内容一长就变成外层整块滚，
+ * 左边的画像会跟着滚出视野。
+ */
+.modal-full {
+  width: min(96vw, 1720px);
+  height: min(92vh, 60rem);
+  max-height: 92vh;
+  overflow: hidden;
+}
+/** 外壳让给内容: 页头已经不渲染，这里把 body 的内边距也撤掉（见 `bare` 的说明） */
+.modal-bare > .modal-body {
+  padding: 0;
+  overflow: hidden;
 }
 
 .modal-header {

--- a/src/ui/components/shared/AssetMedia.vue
+++ b/src/ui/components/shared/AssetMedia.vue
@@ -26,13 +26,22 @@ const props = withDefaults(
     name?: string | null;
     /** 单个类型（精确匹配）或类型链（按序降级） */
     type: AssetType | readonly AssetType[];
+    /**
+     * 情绪/表情变体（D11）；缺省 = 主图。
+     *
+     * ⚠️ **不是精确寻址**: 该类型没有这个变体时会退回主图、再退回类型链下一档
+     * （asset-resolve 的 `pickFromSlot`）。一格一定要显示"那一行"的调用方
+     * （相册之类）得自己保证传进来的三元组存在。
+     */
+    variant?: string;
   }>(),
-  { name: '' },
+  { name: '', variant: undefined },
 );
 
 const { url, isVideo } = useAssetImage(
   () => props.name,
   () => props.type,
+  { variant: () => props.variant },
 );
 </script>
 

--- a/src/ui/components/shared/CharacterPortrait.vue
+++ b/src/ui/components/shared/CharacterPortrait.vue
@@ -39,8 +39,17 @@ const props = withDefaults(
      * 调节中的实时预览直接把草稿传进来即可（本组件不区分草稿与落库值）。
      */
     framing?: AssetFraming | null;
+    /**
+     * 撑满外层容器，而不是自己定 4:5 与 24rem 上限。
+     *
+     * 本组件的常态是**画框自己定尺寸/比例**（见下面 `.portrait-frame` 的说明）——
+     * 状态栏那一位就靠它保证「一张角色立牌该长什么样」全站只有一个答案。
+     * 但角色查看器的画像位是一整栏（高度由弹窗给、宽度由布局给），4:5 会在里面
+     * 留出两条空带。这一档只放开**尺寸**，取景与焦点缩放那两条铁律照旧。
+     */
+    fill?: boolean;
   }>(),
-  { src: null, video: false, framing: null },
+  { src: null, video: false, framing: null, fill: false },
 );
 
 /** 真正交给 CSS 的那一份，**永远夹逼过** */
@@ -59,7 +68,7 @@ const mediaStyle = computed(() => {
 </script>
 
 <template>
-  <div class="character-portrait">
+  <div class="character-portrait" :class="{ 'portrait-fill': fill }">
     <!-- 画框: overflow 归它，尺寸/比例归它；里面的媒体只管铺满 -->
     <div class="portrait-frame">
       <video
@@ -114,5 +123,24 @@ const mediaStyle = computed(() => {
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+/**
+ * `fill` 档 —— 尺寸交回外层容器。
+ *
+ * 比例、上限、圆角、边框全部撤掉（外层是一整栏，里面再画一层框就成了双层边），
+ * 但 `overflow: hidden` 必须留着: 焦点缩放靠 `transform: scale()`，没有它放大的图
+ * 会溢出栏外盖住旁边的信息面。
+ */
+.portrait-fill,
+.portrait-fill .portrait-frame {
+  height: 100%;
+}
+.portrait-fill .portrait-frame {
+  aspect-ratio: auto;
+  max-height: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
 }
 </style>

--- a/src/ui/composables/useAssetImage.test.ts
+++ b/src/ui/composables/useAssetImage.test.ts
@@ -254,6 +254,67 @@ describe('useAssetImage · 名字匹配', () => {
     expect(h.released).toEqual(['av']);
   });
 
+  // ── 变体（D11）──
+  // 相册那类「一格一行」的使用面靠它；此前 `resolveAsset` 早就收第四个参数，
+  // 只是这一层没有入口，于是 UI 侧永远只取得到每个类型的主图。
+
+  it('指定变体 → 命中该变体那一行', async () => {
+    const h = makeHarness([
+      row({ id: 'base', name: '苏婉', type: '立绘' }),
+      row({ id: 'smile', name: '苏婉', type: '立绘', variant: '微笑' }),
+    ]);
+    const { api } = run(() => useAssetImage('苏婉', '立绘', { source: h.source, variant: '微笑' }));
+    await flush();
+    expect(api.url.value).toBe('blob:smile');
+    expect(api.row.value?.id).toBe('smile');
+  });
+
+  it('不指定变体 → 主图（变体存在也不会被抓来顶替）', async () => {
+    const h = makeHarness([
+      row({ id: 'base', name: '苏婉', type: '立绘' }),
+      row({ id: 'smile', name: '苏婉', type: '立绘', variant: '微笑' }),
+    ]);
+    const { api } = run(() => useAssetImage('苏婉', '立绘', { source: h.source }));
+    await flush();
+    expect(api.url.value).toBe('blob:base');
+  });
+
+  /**
+   * ⚠️ 变体寻址**不是精确寻址**（`pickFromSlot` 的既有行为，本层只是把参数接上）：
+   * 该类型没有这个变体时退回主图。要「必须正是那一行」的调用方得自己核对 `row`。
+   */
+  it('变体缺席 → 退回该类型主图，不空手', async () => {
+    const h = makeHarness([row({ id: 'base', name: '苏婉', type: '立绘' })]);
+    const { api } = run(() =>
+      useAssetImage('苏婉', '立绘', { source: h.source, variant: '没有这个表情' }),
+    );
+    await flush();
+    expect(api.url.value).toBe('blob:base');
+  });
+
+  it('空串变体等同未指定（与 asset-index 的归一口径一致）', async () => {
+    const h = makeHarness([row({ id: 'base', name: '苏婉', type: '立绘' })]);
+    const { api } = run(() => useAssetImage('苏婉', '立绘', { source: h.source, variant: '' }));
+    await flush();
+    expect(api.url.value).toBe('blob:base');
+  });
+
+  it('变体是响应式的: 换变体就换图，且恰好撤旧的一次', async () => {
+    const h = makeHarness([
+      row({ id: 'smile', name: '苏婉', type: '立绘', variant: '微笑' }),
+      row({ id: 'cry', name: '苏婉', type: '立绘', variant: '哭' }),
+    ]);
+    const variant = ref('微笑');
+    const { api } = run(() => useAssetImage('苏婉', '立绘', { source: h.source, variant }));
+    await flush();
+    expect(api.url.value).toBe('blob:smile');
+
+    variant.value = '哭';
+    await flush();
+    expect(api.url.value).toBe('blob:cry');
+    expect(h.released).toEqual(['smile']);
+  });
+
   it('字节缺失（assetUrl 给 null）→ url 为 null，且不欠任何 release', async () => {
     const h = makeHarness([row({ id: 'a1', name: '苏婉' })], false);
     const { scope, api } = run(() => useAssetImage('苏婉', undefined, { source: h.source }));

--- a/src/ui/composables/useAssetImage.ts
+++ b/src/ui/composables/useAssetImage.ts
@@ -79,6 +79,18 @@ export interface AssetImageSource {
 export interface UseAssetImageOptions {
   /** 注入缝；缺省即 asset-store 单例（只在缺省时才会去碰 Pinia） */
   source?: AssetImageSource;
+  /**
+   * 情绪/表情变体（D11），缺省 / `''` = 要主图。
+   *
+   * 为什么住在 options 里而不是第三个位置参数: 位置参数已经被注入缝占了，而在
+   * 一个 options 包**后面**再挂位置参数是纯粹的读者陷阱。它跟 `name` / `type`
+   * 一样是"要解析什么"的一部分，所以同样收 getter（`MaybeRefOrGetter`）。
+   *
+   * ⚠️ **变体缺席不是失败**: `resolveAsset` 会退回该类型的主图，再退回类型链下一档
+   * （见 asset-resolve.ts 的 `pickFromSlot`）。要"这一格必须正是这张"的调用方，
+   * 得自己核对 `row`。
+   */
+  variant?: MaybeRefOrGetter<string | undefined>;
 }
 
 export interface UseAssetImage {
@@ -149,7 +161,7 @@ function sharedIndexes(source: AssetImageSource): ComputedRef<readonly AssetInde
  * @param name 角色名，**原样比较**（D2）。空串 / null / undefined → `url` 恒 null
  * @param type 单个类型（精确匹配）或类型链（按序降级）；缺省走脸位链
  *   `头像 → 立绘 → 立绘bg`（{@link DEFAULT_ASSET_TYPE}）
- * @param options 注入缝，生产不传
+ * @param options `source` 是注入缝（生产不传）；`variant` 是要哪个变体（生产会传）
  */
 export function useAssetImage(
   name: MaybeRefOrGetter<string | null | undefined>,
@@ -166,7 +178,12 @@ export function useAssetImage(
     const raw = toValue(name);
     // 空名字不是错误，是「这个位没人」—— 静默给 null，不抛也不打日志（§3 的静默口径）
     if (raw === null || raw === undefined || raw === '') return null;
-    return resolveAsset(indexes.value, raw, toValue(type) ?? DEFAULT_ASSET_TYPE);
+    return resolveAsset(
+      indexes.value,
+      raw,
+      toValue(type) ?? DEFAULT_ASSET_TYPE,
+      toValue(options.variant),
+    );
   });
 
   /**


### PR DESCRIPTION
场景栏「在场」那一行点下去，开一份完整档案。左边通栏画像，右边 6 个页签
（档案 / 状态 / 装备 / 技能 / 背包 / 相册）。

分工按**角色归属**不按内容：`StatusOverview` 是**玩家自己的**面，本弹窗是**别人的**面 ——
字段重叠很多，但一个是「我的资源/我的分配点」，另一个是「我对这个人知道什么」，
变更理由不同，所以不共用组件。

## 内容

| 页签 | 内容 |
| --- | --- |
| 档案 | 好感度（中线为 0 的双向条 + −100/0/+100 刻度）· 档案四行（性格/喜爱/外貌/着装，空行整行不渲染）· 属性 · 登神长阶（三轨 `n/3`·`n/1`·`n/2`，有内容那一档着重，条目点 `+` 展开）· 神位/神国 · 心里话 · 背景故事 |
| 状态 | HP/MP/SP 资源条 + 状态效果（点一条展开详情） |
| 装备 / 背包 | 按 `equippedSlot` 分家；品质色点 + 名字着色 |
| 相册 | 该角色名下的全部素材，按类型分组、含变体（`立绘 · 微笑`）；点一格铺满整行且不裁切 |

## 三条要害

- 🔴 **画像位只认 `立绘bg → 立绘`**，刻意**不**复用 asset-resolve 那两条共享链 ——
  两条都以 `头像` 收尾（「构图不对总好过留一个洞」），而这一位是一整栏的高度：
  一张 1:1 证件照拉满整栏看起来像 bug 而不像功能。这一位宁可空着走首字母兜底。
- 🔴 **收的是名字不是角色对象**：每次从 store 回查（M4 起名字唯一）。攥着对象的话，
  打完架再看这个人，血量还是打之前的 —— 那种缺陷没人会怀疑到弹窗上。
- 🔴 **不占 `game.activeModal`**（那是页面级弹窗的单选位，一次只能开一个），
  它是场景栏自己的一层。

## 共享组件加的三档（全部增量，老调用方零改动）

- `AppModal`：`size="full"`（**定死高度**而不是给 max-height —— 内部「左栏铺满 +
  右栏自己滚」需要一个能百分比化的高度）+ `bare`（不画页头、body 不留内边距，
  **Esc 与点遮罩照旧生效**。写成 `closable: false` 会顺手废掉 design.md §4.5 要求的 Esc，
  所以这是两个独立开关）
- `CharacterPortrait`：`fill` 只放开**尺寸**（撤掉 4:5 与 24rem 上限），
  取景夹逼与焦点缩放两条铁律不变，`overflow: hidden` 必须留（否则放大的图溢出栏外）
- `useAssetImage` / `AssetMedia`：`variant` —— 相册要按变体逐格取图。
  `resolveAsset` 早就支持变体，只是 UI 这一侧一直没有入口。
  放进 options 而不是在 options 包**后面**再挂位置参数（那是读者陷阱）

## 真机走查逮到的两条（均已修 + 补测试）

用测试存档 + 直接注入探针素材行走的：

1. **窄屏（≤900px）底部内容被切掉且滚不到** —— `.viewer-body` 少了 `min-height: 0`。
   flex 子项默认 `min-*: auto`（不小于内容），所以 `flex: 1` 只给「可以长」不给
   「可以缩」；竖向叠栏那一档它撑到内容自然高度，把 `.viewer-scroll` 的内部滚动
   整个作废（实测 320 + 848 撑出 942 高的弹窗外）。
2. **层级名显示错** —— 测试存档里 `tier: 5` 配着默认的 `tierName: '普通'`，
   于是一位 Lv.18 的传说贤者自称「普通」。现在层级名由 `tier` 反查 `TIER_CONFIGS`，
   `tierName` 只当兜底：`tier` 是数值侧的驱动量（资源上限/战斗系数/属性上限全从它算），
   `tierName` 是给 AI 写的展示字段，没人保证会跟着改。

同一轮还确认了：只有 `头像` 的角色画像栏走首字母兜底（而场景栏立牌位照旧出图）、
加一张 `立绘` 后取景真的落到 CSS（`object-position` + 同焦点的 `transform-origin`）、
再加 `立绘bg` 后画像位改用它、相册三张图按 (名字, 类型, 变体) 各自命中、
放大格 `object-fit: contain`、375/768/1280 三档均无横向溢出。

**截图缺席的原因**：本次会话的 Browser pane 未显示，页面不 compositing，
screenshot 一律超时（这是环境限制，见 `.claude/agent-memory/code-writer/browser-pane-raf-blocks-transitions.md`）。
上面每一条都是量 `getBoundingClientRect` / 读 computed style / 读 DOM 得到的。

## 闸门

- `7614 tests` 全绿（**50 条新测试**：判定层 26 · 弹窗链路 20 · 接线 4）
- `lint`（--max-warnings 0）· `tsc --noEmit` · `vue-tsc --noEmit` 全过
- 改过的 11 个文件 prettier `--check` 全过（**没跑仓库级 format** —— Windows 上会
  把约 520 个文件重写成 LF）
- knip 棘轮：无新增死代码
- 文档已同步 `src/ui/AGENTS.md`（新组件 + 三处共享组件加档 + 两条真机结论）

## 未做（留给后续，非本 PR 缺口）

`CharacterListPanel`（页面级「角色列表」弹窗）仍有自己的一套 master-detail 角色详情，
于是现在有**两处**角色详情 UI。本次刻意没动它（范围是场景栏那条入口）；
要收口就是把它的卡片也接到本弹窗、并撤掉右侧详情区。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
