### PR TITLE
fix(agent-client): 全 system 消息补的 user 占位改为非空，修 Gemini 网关 400

### DIFF
--- a/src/sillytavern/agent-client.test.ts
+++ b/src/sillytavern/agent-client.test.ts
@@ -2,7 +2,7 @@
  * agent-client.ts — API 客户端测试
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AgentClient, buildUserId, parseUserId } from './agent-client';
+import { AgentClient, buildUserId, parseUserId, USER_PLACEHOLDER_CONTENT } from './agent-client';
 import type { ApiEndpoint } from './types';
 
 function makeEndpoint(overrides: Partial<ApiEndpoint> = {}): ApiEndpoint {
@@ -196,6 +196,56 @@ describe('AgentClient', () => {
       const result = await client.chat({ messages: [{ role: 'user', content: 'test' }] });
       expect(result.rawResponse).toBe('from cline');
       expect(result.tokensUsed).toBe(42);
+    });
+  });
+
+  describe('ensureUserMessage — 全 system 消息补位', () => {
+    // `buildAgentMessages` 对每个 Agent 都只产出一条 system 消息，所以这条补位路径
+    // 落在**每一次**生产请求上（不是边缘分支），此前零覆盖。
+    const okRes = { choices: [{ message: { content: 'ok' } }], usage: { total_tokens: 1 } };
+
+    it('🔴 回归(2026-08-13): 补的 user 消息必须非空 —— 空串会让 Gemini 系网关 400 contents field is required', async () => {
+      const mockFn = mockFetch(okRes);
+      globalThis.fetch = mockFn;
+
+      await client.chat({ messages: [{ role: 'system', content: '你是叙事引擎' }] });
+
+      const body = JSON.parse(mockFn.mock.calls[0][1].body);
+      expect(body.messages).toHaveLength(2);
+      expect(body.messages[1].role).toBe('user');
+      // 判据是「非空」而不是「等于某个字」—— 占位词可以换，空串不行
+      expect(body.messages[1].content.length).toBeGreaterThan(0);
+      expect(body.messages[1].content).toBe(USER_PLACEHOLDER_CONTENT);
+    });
+
+    it('常量自身非空（换占位词时的护栏）', () => {
+      expect(USER_PLACEHOLDER_CONTENT.trim()).not.toBe('');
+    });
+
+    it('已有 user 消息时不追加、不改写', async () => {
+      const mockFn = mockFetch(okRes);
+      globalThis.fetch = mockFn;
+
+      await client.chat({
+        messages: [
+          { role: 'system', content: 'sys' },
+          { role: 'user', content: '玩家输入' },
+        ],
+      });
+
+      const body = JSON.parse(mockFn.mock.calls[0][1].body);
+      expect(body.messages).toHaveLength(2);
+      expect(body.messages[1].content).toBe('玩家输入');
+    });
+
+    it('空 messages 数组保持原样（不无中生有）', async () => {
+      const mockFn = mockFetch(okRes);
+      globalThis.fetch = mockFn;
+
+      await client.chat({ messages: [] });
+
+      const body = JSON.parse(mockFn.mock.calls[0][1].body);
+      expect(body.messages).toEqual([]);
     });
   });
 

--- a/src/sillytavern/agent-client.ts
+++ b/src/sillytavern/agent-client.ts
@@ -15,6 +15,12 @@ import type { ApiEndpoint, AgentResult, ToolDefinition } from './types';
 /** 内部扩展 — 包含原始 tool_calls 数据 */
 type InternalAgentResult = AgentResult & { _toolCalls?: any[] };
 
+/**
+ * 全 system 消息时补的那条 user 消息的内容 —— **不许改成空串**，理由见 `ensureUserMessage`。
+ * 导出仅供单测断言「它非空」，生产代码只有 `ensureUserMessage` 一个消费者。
+ */
+export const USER_PLACEHOLDER_CONTENT = '继续';
+
 // ========== Types ==========
 
 export interface ChatRequest {
@@ -123,17 +129,30 @@ export class AgentClient {
   }
 
   /**
-   * 确保 messages 至少包含一条 user 消息。
+   * 确保 messages 至少包含一条**非空** user 消息。
+   *
+   * `buildAgentMessages` 对**每一个** Agent 都只产出一条 system 消息
+   * （agent-templates.ts 末尾 `return [{ role: 'system', content: resolved }]`，
+   * 玩家输入与历史全拼进那一条里），所以这个补丁不是边缘路径 —— 它落在每一次请求上。
    *
    * 修复(2026-07-30): 部分 API（如 ollama.com）当 messages 只有 system 消息时
    * 返回 finish_reason="load" 和空内容（模型不加载），导致所有 agent 空回。
-   * 当 messages 全是 system 时追加一条空 user 消息以触发正常生成。
+   * 当 messages 全是 system 时追加一条 user 消息以触发正常生成。
+   *
+   * 🔴 修复(2026-08-13): 追加的这条**必须有内容**，`content: ''` 会打死 Gemini 系网关。
+   * OpenAI→Gemini 的转换层把 system 收进 `system_instruction`、其余收进 `contents`，
+   * 空文本那条在转换中被丢掉 → `contents` 空 → `HTTP 400: contents field is required`。
+   * 真机症状（gcli.ggchan.dev + gemini-3-flash-preview）：第 0 轮 memory_recall 400，
+   * 而 story stage 的 `waitFor` 含 memory_recall、`stageDependenciesMet` 要求依赖全部无
+   * error，于是**整轮正文被跳过、界面一片空白**。
+   * 占位内容取「继续」而非标点：中文语料下最中性、且是常量（不随轮次变化），
+   * 不破坏 DeepSeek KVCache 的静态前缀命中。
    */
   private ensureUserMessage(messages: ChatRequest['messages']): ChatRequest['messages'] {
     if (messages.length === 0) return messages;
     const hasUser = messages.some((m) => m.role === 'user');
     if (hasUser) return messages;
-    return [...messages, { role: 'user', content: '' }];
+    return [...messages, { role: 'user', content: USER_PLACEHOLDER_CONTENT }];
   }
 
   /**


### PR DESCRIPTION
## 症状

真机（`gcli.ggchan.dev` + `gemini-3-flash-preview`）开新档，第 0 轮直接一片空白，存档导出的 `agentLog` 里：

```
memory_recall / gemini-3-flash-preview
HTTP 400: {"error":{"message":"contents field is required", ...}}
```

## 根因

`buildAgentMessages` 对**每一个** Agent 都只产出一条 system 消息（`agent-templates.ts` 末尾 `return [{ role: 'system', content: resolved }]`，玩家输入与历史全拼进那一条），所以 `ensureUserMessage` 的补位不是边缘路径 —— 它落在每一次请求上。

而此前补的是 `content: ''`。OpenAI→Gemini 的转换层把 system 收进 `system_instruction`、其余收进 `contents`，空文本那条在转换中被丢掉 → `contents` 空 → 400。

放大成整轮空白的一环：story stage 的 `waitFor` 含 `memory_recall`，而 `stageDependenciesMet` 要求依赖**全部**无 error，于是正文 stage 被整个跳过。

## 改动

- `ensureUserMessage` 补的 user 消息改为非空常量 `USER_PLACEHOLDER_CONTENT = '继续'`。
  取常量而非标点：不随轮次变化，不破坏 `userId` 那套 DeepSeek KVCache 静态前缀命中。
- 注释里把 2026-07-30 的 ollama 原因与本次 Gemini 原因**并列写清**，防止将来有人看到「一条没用的『继续』」又改回空串。
- 补上此前**完全缺失**的 `ensureUserMessage` 覆盖 4 条：非空回归断言 / 常量自身非空的护栏 / 已有 user 消息不被追加改写 / 空数组不无中生有。

一处改动覆盖三条路径：`ensureUserMessage` 只在 `buildRequestBody` 里调用一次，而流式、非流式、工具循环共用这一份装配（Q-17 已合并）。

## 验证

| 检查 | 结果 |
|---|---|
| `agent-client.test.ts` | 29 passed |
| `src/sillytavern` 全量 | 167 files / 5567 passed, 4 skipped |
| `tsc --noEmit` | 通过 |
| `eslint --max-warnings 0` | 通过 |
| `tests/encoding-invariants` | 57 passed |
| 改动文件 U+FFFD / 控制字符 | 均为 0 |

## 未包含（刻意）

本 PR 只解触发 400 的那个形状问题，**不动**放大器：`memory_recall` 失败仍会让整轮正文被跳过。该项与「`onAgentError` 丢掉 `requestMessages`/`duration` 导致失败时日志无证据」一并另议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)