### PR TITLE
fix(map): 标记地图 overlay 双重位移 + 势力地图 provinces.png 撞 HTTP 缓存

### DIFF
--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -21,14 +21,24 @@ src/ui/                              ← Vue 3 + Pinia + Vite 前端（单 URL �
 ├── composables/
 │   ├── useMapViewer.ts              ← OpenSeadragon 生命周期
 │   ├── useMapMarkers.ts             ← 地图标记 CRUD + Overlay 同步
+│   │                                   🔴 overlay 居中**只做一次，归 OSD 的 `Placement.CENTER`**
+│   │                                      （2026-08-13）：`.osd-marker` 根元素（MapPanel.vue 非
+│   │                                      scoped 样式）尺寸恒等于图标、零位移样式 —— 在根元素上
+│   │                                      叠 translate/margin 等于恒定屏幕偏移，缩放时标记就在
+│   │                                      地图上滑走。名字标签绝对定位在根盒子外，**必须
+│   │                                      pointer-events: auto**（none 会让点名牌穿透到画布）。
+│   │                                      钉在 MapPanel.marker-anchor.test.ts（?raw 源码断言）
 │   ├── useMapPolitical.ts           ← [地图 v1] 势力地图舞台的状态与生命周期（懒建 / 按
 │   │                                   `contentHash` 失效 / 卸载释放 / 失败分档）
 │   │                                   🔴 懒 + 释放两头都要（设计 §9 预算：一次构建约 280ms、
 │   │                                      常驻 idBuf 约 35MB）。提到模块级「反正只建一次」
 │   │                                      = 手滑点开一次就常驻 35MB 到本局结束
-│   │                                   🔴 失效键是 `contentHash` 不是 URL —— `provinces.png`
-│   │                                      的地址是常量，换图时内容变地址不变；拿地址当键
-│   │                                      会让新图配着旧像素画，而那不报错
+│   │                                   🔴 失效纪律分两层（2026-08-13 补第二层）：内存缓存按
+│   │                                      `contentHash` 失效（不拿路径当键 —— 换图时内容变
+│   │                                      路径不变，旧像素配新图不报错）；HTTP 请求经
+│   │                                      content-store 的 `provincesRasterUrl(hash)` 挂
+│   │                                      `?v=` 回源 + 取图 fetch `no-cache` 验新兜底 ——
+│   │                                      只堵内存层时，换包重建仍会拿浏览器缓存的旧像素
 │   ├── useHoverPopup.ts             ← 悬停浮层唯一实现（读 settings.hoverDelayMs）
 │   ├── useAssetImage.ts             ← [素材] 渲染缝：(name,type?) → {url,isVideo,row}，世代号守卫 + 引用计数索引
 │   │                                   `options.variant` 指定表情/差分（与 name/type 同属"要解析什么"，

--- a/src/ui/components/game/MapPanel.marker-anchor.test.ts
+++ b/src/ui/components/game/MapPanel.marker-anchor.test.ts
@@ -2,41 +2,58 @@
  * 标记地图 overlay 的锚定结构 —— 源码断言（照本目录既有做法读 SFC 源码，不 mount：
  * jsdom 里没有 OSD 的真渲染，而这里守的全是「谁负责对准锚点」这种结构决定）。
  *
- * 背景（2026-08-13 真机定量）：OSD 侧用 `Placement.CENTER` 加 overlay，wrapper 已把
- * **元素中心对准锚点**；`.osd-marker` 上曾再叠一层 `translate(-50%, -100%)`，把元素
- * 又挪出半宽 + 全高 —— 而元素高度里含着图标下方的名字标签，于是每个标记都带着一个
- * **恒定屏幕像素**的偏移（实测约 (−标签宽/2, −50)px，随标签文字长短各不相同）。
- * 缩放时地图点动、偏移不动，标记看起来就在地图上滑走。
- *
- * 裁定：居中只做一次，归 OSD。根元素尺寸恒等于图标（18×18）、零位移 transform，
- * 名字标签绝对定位挂在图标下方**不进布局流** —— 「图标中心 = 锚点」是结构保证。
+ * 背景与量化记录见 MapPanel.vue `.osd-marker` 规则上的红字注释（2026-08-13 真机定量）。
+ * 裁定一句话：**居中只做一次，归 OSD 的 `Placement.CENTER`**。根元素尺寸恒等于图标、
+ * 零位移样式；名字标签绝对定位挂在图标下方**不进布局流**，但必须**可命中**
+ * （名牌在根盒子外面，`pointer-events: none` 会让点名牌穿透到画布 —— 浏览模式点名牌
+ * 变成取消选中，加标记模式点名牌会误落新标记）。
  */
 import { describe, it, expect } from 'vitest';
 import source from '@ui/components/game/MapPanel.vue?raw';
 import markersSource from '@ui/composables/useMapMarkers.ts?raw';
 
+/** 取选择器**恰好**为 `selector` 的规则块声明部分（剥掉块内注释 —— 注释里提到属性名不算数） */
+function cssRule(selector: string): string {
+  const re = new RegExp(`(^|\\n)\\s*${selector.replace(/\./g, '\\.')}\\s*\\{([^}]*)\\}`);
+  const body = source.match(re)?.[2] ?? '';
+  expect(body, `找不到 ${selector} 规则块（选择器改名要连本测试一起改）`).not.toBe('');
+  return body.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
 describe('标记地图：overlay 锚定只做一次（OSD Placement.CENTER）', () => {
-  it('`.osd-marker` 根元素上没有位移 transform', () => {
-    // 加回来不报错，只是标记又开始随缩放在地图上漂 —— 所以钉死这个规则块。
-    // （`.map-marker-card` 的 translate(-50%, -100%) 是合法的：浮卡走自己的
-    //   left/top 定位，不在 OSD 的 CENTER placement 之上叠加）
-    const rule = source.match(/\.osd-marker\s*\{[^}]*\}/)?.[0] ?? '';
-    expect(rule).not.toBe('');
-    expect(rule).not.toContain('transform:');
+  it('`.osd-marker` 根元素上没有任何位移样式', () => {
+    // transform / translate / margin 任意一个都能把标记挪出一个恒定屏幕偏移 ——
+    // 缩放时地图点动、偏移不动，标记就又开始在地图上漂
+    const rule = cssRule('.osd-marker');
+    expect(rule).not.toContain('transform');
+    expect(rule).not.toContain('translate');
+    expect(rule).not.toContain('margin');
   });
 
-  it('`.osd-marker` 尺寸恒等于图标，标签不进布局流', () => {
-    const rule = source.match(/\.osd-marker\s*\{[^}]*\}/)?.[0] ?? '';
+  it('`.osd-marker` 尺寸恒等于图标（图标跟根走，单一来源）', () => {
+    const rule = cssRule('.osd-marker');
     expect(rule).toContain('width: 18px');
     expect(rule).toContain('height: 18px');
-    const labelRule = source.match(/\.osd-marker-label\s*\{[^}]*\}/)?.[0] ?? '';
-    expect(labelRule).toContain('position: absolute');
-    expect(labelRule).toContain('top: 100%');
+    const icon = cssRule('.osd-marker-icon');
+    expect(icon).toContain('width: 100%');
+    expect(icon).toContain('height: 100%');
   });
 
-  it('OSD 侧新增与更新 overlay 都用 Placement.CENTER', () => {
-    // 居中归 OSD 这一侧；两处（addOverlay / updateOverlay）都要是 CENTER，
-    // 少一处就会出现「新加的标记准、拖动过的标记漂」这类只在部分标记上复现的错位
-    expect(markersSource.match(/Placement\.CENTER/g) ?? []).toHaveLength(2);
+  it('名字标签不进布局流，但保持可命中', () => {
+    const label = cssRule('.osd-marker-label');
+    expect(label).toContain('position: absolute');
+    expect(label).toContain('top: 100%');
+    // 🔴 名牌在 18×18 根盒子外面：none 会让点击穿透到 OSD 画布（加标记模式误落新标记）
+    expect(label).toContain('pointer-events: auto');
+    expect(label).not.toContain('pointer-events: none');
+  });
+
+  it('OSD 侧新增与更新 overlay 两个调用点都用 Placement.CENTER', () => {
+    // 点名**调用点**而不是数出现次数：注释里写到 CENTER、或加第三个合法调用点，
+    // 都不该让本测试变红；两处任何一处换成别的 placement 才该红
+    expect(markersSource).toMatch(
+      /addOverlay\(\{[\s\S]*?placement:\s*OpenSeadragon\.Placement\.CENTER/,
+    );
+    expect(markersSource).toMatch(/updateOverlay\([^)]*OpenSeadragon\.Placement\.CENTER\s*\)/);
   });
 });

--- a/src/ui/components/game/MapPanel.marker-anchor.test.ts
+++ b/src/ui/components/game/MapPanel.marker-anchor.test.ts
@@ -1,0 +1,42 @@
+/**
+ * 标记地图 overlay 的锚定结构 —— 源码断言（照本目录既有做法读 SFC 源码，不 mount：
+ * jsdom 里没有 OSD 的真渲染，而这里守的全是「谁负责对准锚点」这种结构决定）。
+ *
+ * 背景（2026-08-13 真机定量）：OSD 侧用 `Placement.CENTER` 加 overlay，wrapper 已把
+ * **元素中心对准锚点**；`.osd-marker` 上曾再叠一层 `translate(-50%, -100%)`，把元素
+ * 又挪出半宽 + 全高 —— 而元素高度里含着图标下方的名字标签，于是每个标记都带着一个
+ * **恒定屏幕像素**的偏移（实测约 (−标签宽/2, −50)px，随标签文字长短各不相同）。
+ * 缩放时地图点动、偏移不动，标记看起来就在地图上滑走。
+ *
+ * 裁定：居中只做一次，归 OSD。根元素尺寸恒等于图标（18×18）、零位移 transform，
+ * 名字标签绝对定位挂在图标下方**不进布局流** —— 「图标中心 = 锚点」是结构保证。
+ */
+import { describe, it, expect } from 'vitest';
+import source from '@ui/components/game/MapPanel.vue?raw';
+import markersSource from '@ui/composables/useMapMarkers.ts?raw';
+
+describe('标记地图：overlay 锚定只做一次（OSD Placement.CENTER）', () => {
+  it('`.osd-marker` 根元素上没有位移 transform', () => {
+    // 加回来不报错，只是标记又开始随缩放在地图上漂 —— 所以钉死这个规则块。
+    // （`.map-marker-card` 的 translate(-50%, -100%) 是合法的：浮卡走自己的
+    //   left/top 定位，不在 OSD 的 CENTER placement 之上叠加）
+    const rule = source.match(/\.osd-marker\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(rule).not.toBe('');
+    expect(rule).not.toContain('transform:');
+  });
+
+  it('`.osd-marker` 尺寸恒等于图标，标签不进布局流', () => {
+    const rule = source.match(/\.osd-marker\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(rule).toContain('width: 18px');
+    expect(rule).toContain('height: 18px');
+    const labelRule = source.match(/\.osd-marker-label\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(labelRule).toContain('position: absolute');
+    expect(labelRule).toContain('top: 100%');
+  });
+
+  it('OSD 侧新增与更新 overlay 都用 Placement.CENTER', () => {
+    // 居中归 OSD 这一侧；两处（addOverlay / updateOverlay）都要是 CENTER，
+    // 少一处就会出现「新加的标记准、拖动过的标记漂」这类只在部分标记上复现的错位
+    expect(markersSource.match(/Placement\.CENTER/g) ?? []).toHaveLength(2);
+  });
+});

--- a/src/ui/components/game/MapPanel.test.ts
+++ b/src/ui/components/game/MapPanel.test.ts
@@ -759,6 +759,26 @@ describe('MapPanel — 势力地图页签（地图 v1 / §9）', () => {
     expect(wrapper.find('.pol-card-title').text()).toBe('乙一·新');
   });
 
+  it('取图 URL 挂着 contentHash —— 换包后重建必然绕开 HTTP 缓存（2026-08-13）', async () => {
+    // 「失效键是 contentHash」那条红线堵的是内存层；地址恒定时浏览器缓存可以在换包后
+    // 把旧像素回给新一轮重建 —— 新 pack 的标签配旧图画，偶发一次且硬刷新自愈。
+    // hash 进查询串让「包变 → 地址变 → 必然回源」，包没变时照旧命中缓存。
+    await useGameStub({});
+    setContentRegistry({ ...emptyRegistry(), mapPack: MAP_PACK });
+    const wrapper = await mountPanel();
+    await openPoliticalTab(wrapper);
+    expect(vi.mocked(loadProvinceRaster).mock.calls[0]?.[0]).toContain('?v=test-hash');
+
+    await wrapper.findAll('.tab-item')[0].trigger('click');
+    await flushPromises();
+    setContentRegistry({
+      ...emptyRegistry(),
+      mapPack: { ...MAP_PACK, contentHash: 'test-hash-2' },
+    });
+    await openPoliticalTab(wrapper);
+    expect(vi.mocked(loadProvinceRaster).mock.calls[1]?.[0]).toContain('?v=test-hash-2');
+  });
+
   it('势力页签的源码里也不许出现指向 data/ 的 import', async () => {
     const src = (await import('./MapPoliticalTab.vue?raw')).default;
     const imports = src.match(/^\s*import\s[^;]*;/gm) ?? [];

--- a/src/ui/components/game/MapPanel.vue
+++ b/src/ui/components/game/MapPanel.vue
@@ -1485,14 +1485,18 @@ onBeforeUnmount(() => {
 /* OSD marker overlay 样式 */
 .osd-marker {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  width: 18px;
+  height: 18px;
   cursor: pointer;
   pointer-events: auto;
   z-index: 3;
-  transform: translate(-50%, -100%);
-  /* 图标锚点对准地图坐标，文字在图标下方 */
+  /* 🔴 根元素上不准有任何位移 transform，尺寸必须恒等于图标（2026-08-13）：
+     OSD 的 Placement.CENTER 已把 overlay 中心对准锚点，这里再叠 translate
+     等于把标记挪出一个**恒定屏幕像素**的偏移 —— 地图点随缩放动、偏移不动，
+     标记看起来就在地图上滑走，且偏移量跟着标签文字长短各不相同
+     （真机定量：图标中心偏离锚点约 (−标签宽/2, −50)px）。
+     名字标签绝对定位挂在图标下方、不进布局流，这样「图标中心 = 锚点」
+     是结构保证，任何缩放下零偏移。 */
 }
 .osd-marker-active {
   z-index: 5;
@@ -1514,6 +1518,10 @@ onBeforeUnmount(() => {
   flex-shrink: 0;
 }
 .osd-marker-label {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
   margin-top: 2px;
   background: var(--theme-card-bg, #1a1a2e);
   border: 1px solid var(--theme-card-border, #333);

--- a/src/ui/components/game/MapPanel.vue
+++ b/src/ui/components/game/MapPanel.vue
@@ -1506,8 +1506,10 @@ onBeforeUnmount(() => {
   transform: scale(1.2);
 }
 .osd-marker-icon {
-  width: 18px;
-  height: 18px;
+  /* 尺寸跟根元素走（单一来源在 .osd-marker 上）—— 图标与根不同尺寸时
+     OSD 居中的是根盒子而不是图标，每个标记都会差出半个差值 */
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1515,7 +1517,6 @@ onBeforeUnmount(() => {
   color: #ffcc66;
   text-shadow: 0 0 6px rgba(0, 0, 0, 0.35);
   transition: transform 100ms;
-  flex-shrink: 0;
 }
 .osd-marker-label {
   position: absolute;
@@ -1530,7 +1531,12 @@ onBeforeUnmount(() => {
   font-size: 10px;
   white-space: nowrap;
   color: var(--theme-text-primary, #eee);
-  pointer-events: none;
+  /* 🔴 必须可命中（auto）：名牌已脱离布局流、在 18×18 根盒子**外面**，
+     pointer-events: none 会让点名牌的点击穿透到 OSD 画布 —— 浏览模式点名牌
+     变成取消选中，加标记模式点名牌会在原标记上再落一个新标记。
+     设成 auto 后点击落在名牌上、冒泡回根元素，MouseTracker 与
+     `closest('.osd-marker')` 两条路都照常命中（= 名牌还在盒子里时的旧行为）。 */
+  pointer-events: auto;
   user-select: none;
   max-width: 120px;
   overflow: hidden;

--- a/src/ui/composables/useMapPolitical.ts
+++ b/src/ui/composables/useMapPolitical.ts
@@ -11,9 +11,11 @@
  *    整份丢掉。把它提到模块级「反正只建一次」是很诱人的，但那意味着玩家哪怕只手滑点开一次
  *    势力地图，之后整局游戏都常驻 35MB —— 而这一层的数据在关掉之后毫无用处。
  *
- * 🔴 **失效键是 `contentHash`**（设计 §3.4-3），不是 URL：`provinces.png` 的地址是常量
- *    （`MAP_PROVINCES_URL`），换图时它的**内容**变、地址不变。拿地址当键会让新图配着旧像素画，
- *    而那不报错 —— 只是每一块地都指着隔壁那一块。附带按包对象同一性也比一次
+ * 🔴 **失效键是 `contentHash`**（设计 §3.4-3），不是 URL：`provinces.png` 的**路径**是常量，
+ *    换图时它的**内容**变、路径不变。拿路径当键会让新图配着旧像素画，而那不报错 ——
+ *    只是每一块地都指着隔壁那一块。这条纪律有两层：内存缓存按 `contentHash` 失效（本文件），
+ *    HTTP 请求经 `provincesRasterUrl(hash)` 挂 `?v=` 参数回源（content-store，2026-08-13）——
+ *    只堵内存那层时，换包重建仍可能拿浏览器缓存的旧像素配新 pack。附带按包对象同一性也比一次
  *    （`contentHash` 允许是空串 / `'placeholder'`，两份不同的坏包会撞成同一个键）。
  *
  * 🔴 **失败一律不抛**：这张图在公开仓根本不存在（占位包无像素面）。势力地图退化成友好空态，
@@ -34,7 +36,7 @@ import {
   type ProvinceRaster,
 } from '../lib/map-political';
 import { loadProvinceRaster } from '../lib/map-provinces-raster';
-import { MAP_PROVINCES_URL } from '../stores/content-store';
+import { provincesRasterUrl } from '../stores/content-store';
 
 /** `empty` 与 `error` 都是「画不出来」，但措辞与可操作性不同（缺内容 vs 环境/数据坏了） */
 export type MapPoliticalStatus = 'idle' | 'building' | 'ready' | 'empty' | 'error';
@@ -68,6 +70,8 @@ export function useMapPolitical() {
 
   let controller: AbortController | null = null;
   let building: Promise<void> | null = null;
+  /** 在建的是**哪一份包**（构建复用只对同一份包成立；换包中途要弃旧起新） */
+  let buildingPack: MapPack | null = null;
 
   /**
    * 建（或复用）政治层。**幂等**：并发调用共享同一个 promise，已建好且包没变时立刻返回。
@@ -91,7 +95,9 @@ export function useMapPolitical() {
       return;
     }
 
-    if (building !== null) return building;
+    // 🔴 在建复用只对**同一份包**成立：换包中途返回旧包的构建，等到的是一版马上要作废的
+    //    舞台（280ms + 35MB 白干一轮），随后还得再建一次。包变了就弃旧起新。
+    if (building !== null && buildingPack === pack) return building;
 
     controller?.abort();
     controller = new AbortController();
@@ -99,21 +105,14 @@ export function useMapPolitical() {
     status.value = 'building';
     message.value = '';
 
-    building = (async () => {
+    buildingPack = pack;
+    const run = (async () => {
       const startedAt = Date.now();
       const lookup = buildTileColorLookup(pack.tiles);
-      // 🔴 取图 URL 必须挂上 contentHash（2026-08-13）：文件头那条「失效键是 contentHash」
-      //    红线堵的是内存这一层；HTTP 缓存是**同一个坑的第二处** —— 地址恒定时，换包后的
-      //    重建会拿浏览器（启发式）缓存里的**旧像素**配新 pack 画，标签/命中/边界整层错位，
-      //    不报错、硬刷新后自愈，表现为「偶发一次、无法复现」。hash 进查询串让
-      //    「包变 → 地址变 → 必然回源」，包没变时照旧命中缓存。
-      //    空串 / 'placeholder' 不挂参：占位包根本没有这张图（404 是常态），两份坏包
-      //    共用一个键在这里无害。
-      const rasterUrl =
-        pack.contentHash !== '' && pack.contentHash !== 'placeholder'
-          ? `${MAP_PROVINCES_URL}?v=${encodeURIComponent(pack.contentHash)}`
-          : MAP_PROVINCES_URL;
-      const result = await loadProvinceRaster(rasterUrl, lookup, signal);
+      // 🔴 取图必须走 `provincesRasterUrl`（content-store）：内存缓存按 contentHash 失效
+      //    只堵了一半，HTTP 缓存是同一个坑的第二处 —— 换包后的重建会拿浏览器缓存里的
+      //    **旧像素**配新 pack 画，整层错位且不报错。`?v=<hash>` 让「包变 → 地址变 → 必然回源」。
+      const result = await loadProvinceRaster(provincesRasterUrl(pack.contentHash), lookup, signal);
 
       if (signal.aborted) return;
 
@@ -148,18 +147,27 @@ export function useMapPolitical() {
         buildMs: Date.now() - startedAt,
       };
       status.value = 'ready';
-    })()
+    })();
+
+    const tracked: Promise<void> = run
       .catch((err: unknown) => {
         // 到这里只可能是意料之外的（loadProvinceRaster 自己永不抛）——照样不许穿出去
+        if (signal.aborted) return;
         stage.value = null;
         status.value = 'error';
         message.value = `势力地图构建失败：${err instanceof Error ? err.message : String(err)}`;
       })
       .finally(() => {
-        building = null;
+        // 🔴 只清**自己**：换包弃旧起新后，旧构建的 finally 晚于新构建的登记到来，
+        //    无条件置 null 会把新构建的在建标记抹掉，下一次调用就会再起第三份
+        if (building === tracked) {
+          building = null;
+          buildingPack = null;
+        }
       });
+    building = tracked;
 
-    return building;
+    return tracked;
   }
 
   /** 丢掉全部大缓冲（Modal 关闭 = 本组件卸载）。可重入。 */

--- a/src/ui/composables/useMapPolitical.ts
+++ b/src/ui/composables/useMapPolitical.ts
@@ -102,7 +102,18 @@ export function useMapPolitical() {
     building = (async () => {
       const startedAt = Date.now();
       const lookup = buildTileColorLookup(pack.tiles);
-      const result = await loadProvinceRaster(MAP_PROVINCES_URL, lookup, signal);
+      // 🔴 取图 URL 必须挂上 contentHash（2026-08-13）：文件头那条「失效键是 contentHash」
+      //    红线堵的是内存这一层；HTTP 缓存是**同一个坑的第二处** —— 地址恒定时，换包后的
+      //    重建会拿浏览器（启发式）缓存里的**旧像素**配新 pack 画，标签/命中/边界整层错位，
+      //    不报错、硬刷新后自愈，表现为「偶发一次、无法复现」。hash 进查询串让
+      //    「包变 → 地址变 → 必然回源」，包没变时照旧命中缓存。
+      //    空串 / 'placeholder' 不挂参：占位包根本没有这张图（404 是常态），两份坏包
+      //    共用一个键在这里无害。
+      const rasterUrl =
+        pack.contentHash !== '' && pack.contentHash !== 'placeholder'
+          ? `${MAP_PROVINCES_URL}?v=${encodeURIComponent(pack.contentHash)}`
+          : MAP_PROVINCES_URL;
+      const result = await loadProvinceRaster(rasterUrl, lookup, signal);
 
       if (signal.aborted) return;
 

--- a/src/ui/lib/map-provinces-raster.ts
+++ b/src/ui/lib/map-provinces-raster.ts
@@ -111,7 +111,10 @@ export async function loadProvinceRaster(
 
   let blob: Blob;
   try {
-    const response = await fetch(url, { signal });
+    // 🔴 no-cache（必回源验新，304 时零字节）是 `?v=<contentHash>` 之外的第二道闸：
+    //    hash 只盖 pack JSON（编译器对规范形 JSON 求哈希），一次只动像素不动数据的重涂、
+    //    或者一份漏了 contentHash 的手工包，URL 都不会变 —— 那时全靠这里的条件请求兜底。
+    const response = await fetch(url, { signal, cache: 'no-cache' });
     if (!response.ok) {
       return { ok: false, reason: 'missing', detail: `HTTP ${response.status}` };
     }

--- a/src/ui/stores/content-store.ts
+++ b/src/ui/stores/content-store.ts
@@ -451,14 +451,30 @@ export const CONTENT_REGISTRY_SOURCES: ReadonlyArray<{
  *
  * 🔴 **content pack 替换不了它**：pack 是一份 JSON，装不下 PNG 字节。真实地图的
  * `provinces.png` 与 `map-pack.json` 同住内容树 `data/content/`（私有内容仓，经
- * `POEM_CONTENT_DIR` 开发覆盖 / 部署时铺进 `public/`），所以这里是**常量**而不是从包里读出的
- * 路径 —— 换图时它的内容变、URL 不变。渲染缓存的失效键因此必须取包的 `contentHash`
- * （§3.4-3），拿这个 URL 当键会让新图配着旧像素画。
+ * `POEM_CONTENT_DIR` 开发覆盖 / 部署时铺进 `public/`），所以路径是**常量**而不是从包里
+ * 读出的 —— 换图时它的内容变、路径不变。由此有两层失效纪律（2026-08-13 补第二层）：
+ * ① 渲染缓存（内存）的失效键必须取包的 `contentHash`（§3.4-3），拿路径当键会让新图配着
+ *   旧像素画；② **请求 URL 必须经 `provincesRasterUrl(pack.contentHash)` 挂上 `?v=` 参数**，
+ *   否则换包后的重建可能拿浏览器 HTTP 缓存里的旧像素配新 pack —— 同一个坑在 HTTP 层的分身
+ *   （dev 中间件发 no-cache 不受影响，生产/静态托管会中）。
  *
  * 🔴 公开仓的占位包**没有**这张图（占位是十几块合成地块，没有像素面）：取它会 404。
  * 调用方按「取不到 → 不画政治层」处置，与 `resolveMapSources` 没图源时返回空数组同一口径。
  */
 export const MAP_PROVINCES_URL = '/data/content/provinces.png';
+
+/**
+ * `provinces.png` 的**唯一**取图 URL 出口：包变 → 地址变 → 必然回源；包没变照旧命中缓存。
+ *
+ * 空串 / `'placeholder'`（占位包 `map-pack.json` 里的字面哨兵）不挂参：占位包根本没有
+ * 这张图（404 是常态），两份坏包共用一个键在这里无害。裸常量 `MAP_PROVINCES_URL` 只用于
+ * 文档与测试 —— 生产取图一律走本函数，绕开它就等于把 HTTP 缓存那半个坑挖回来。
+ */
+export function provincesRasterUrl(contentHash: string): string {
+  return contentHash !== '' && contentHash !== 'placeholder'
+    ? `${MAP_PROVINCES_URL}?v=${encodeURIComponent(contentHash)}`
+    : MAP_PROVINCES_URL;
+}
 
 /** 首轮占位加载的 memo（幂等闸；`ensureContentRegistryLoaded` 的全部状态） */
 let registryLoadPromise: Promise<void> | null = null;
@@ -482,7 +498,10 @@ async function fetchRegistryFace(
 ): Promise<RegistryFaceFetch> {
   const source = `content-registry:${face}`;
   try {
-    const res = await fetch(url);
+    // 🔴 no-cache（= 必回源验新，命中 304 时零流量）：这些面全是「常量 URL、内容随包换」，
+    //    其中 map-pack.json 还供给 provinces.png 取图的 `?v=` —— 这一面被缓存住，挂出去的
+    //    就是**旧** hash，下游的防缓存等于没做。八面 JSON 都很小，验新成本可忽略。
+    const res = await fetch(url, { cache: 'no-cache' });
     if (!res.ok) {
       reportEngineContentFetch({
         source,


### PR DESCRIPTION
## 两处地图错位修复（2026-08-13 真机定量诊断）

### 1. 标记地图：overlay 双重居中 → 标记随缩放在地图上滑走

OSD 已用 `Placement.CENTER` 把 overlay 中心对准锚点，`.osd-marker` 上再叠
`translate(-50%,-100%)` 等于给每个标记挪出一个**恒定屏幕像素**偏移
（实测约 `(-标签宽/2, -50)px`，随标签文字长短各异）。缩放时地图点动、偏移不动，
标记看起来就在地图上滑走。

**改法**：根元素尺寸恒等于图标（18×18）、零位移 transform；名字标签绝对定位
挂图标下方、不进布局流 ——「图标中心 = 锚点」成为结构保证。
修后真机探针：静止与 1×→6× 缩放动画全程误差 (1,1)px（修前 -34~-74px 且随缩放放大）。

### 2. 势力地图：换包重建撞浏览器 HTTP 缓存 → 偶发整层错位

舞台失效键是 `contentHash`（内存层已按设计防住），但取图地址恒定：换包后的重建
可能拿浏览器启发式缓存里的**旧 provinces.png** 配新 pack 画 —— 标签/命中/边界
整层错位，不报错、硬刷新自愈，表现为「偶发一次、无法复现」
（对应当天上午内容仓 pack v1.1.0 重编译窗口的真机目击）。

**改法**：取图 URL 挂 `?v=<contentHash>` —— 包变则地址变、必然回源；包没变照旧
命中缓存。空串/`'placeholder'` 不挂参（占位包无此图，404 是常态）。

### 回归测试

- 新增 `MapPanel.marker-anchor.test.ts`（?raw 源码断言：根元素无 transform /
  尺寸恒等图标 / 两处 `Placement.CENTER`）
- `MapPanel.test.ts` 新增「取图 URL 挂着 contentHash —— 换包后重建必然绕开 HTTP 缓存」

### 验证

- 真机（dev + 内容仓 overlay）：标记探针多档缩放零漂移；网络面板确认
  `provinces.png?v=<真实hash>` 回源 200，势力地图渲染/标签锚定/棋子正常
- 全量 vitest 绿；eslint / prettier / tsc --noEmit 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)