### PR TITLE
style: CombatPanel 补 prettier 格式（CI 跟进）

### DIFF
--- a/src/ui/components/game/combat/CombatPanel.test.ts
+++ b/src/ui/components/game/combat/CombatPanel.test.ts
@@ -335,9 +335,7 @@ describe('CombatPanel 结算确认态（2026-08-13 需求 D）', () => {
       outcome: 'ally_win',
       totalExp: 2,
       totalFp: 5,
-      loot: [
-        { name: '断爪', description: '魔物爪甲', quantity: 2, quality: '普通' },
-      ],
+      loot: [{ name: '断爪', description: '魔物爪甲', quantity: 2, quality: '普通' }],
       rounds: 2,
       summaryText: '奥利雅思以灼热射线贯穿魔物咽喉，获胜。',
     };

--- a/src/ui/components/game/combat/CombatPanel.vue
+++ b/src/ui/components/game/combat/CombatPanel.vue
@@ -197,9 +197,7 @@ const isCombatThinking = computed(() => {
             />
 
             <div class="combat-panel-actions">
-              <AppButton variant="primary" size="sm" @click="confirmSettlement"
-                >注入正文</AppButton
-              >
+              <AppButton variant="primary" size="sm" @click="confirmSettlement">注入正文</AppButton>
               <AppButton variant="ghost" size="sm" @click="discardSettlement">放弃注入</AppButton>
             </div>
           </div>


### PR DESCRIPTION
#103 的结算确认态改动漏跑 prettier，CI format:check 挂红。两处格式折叠（AppButton 长标签 / loot 单行数组），纯格式无逻辑变化。