### PR TITLE
feat(events): DebugPanel 随机事件调试分区 —— 可用事件表 + MTTH 因子 + 下回合强制触发

### DIFF
--- a/.claude/agent-memory/code-writer/content-registry-not-reactive.md
+++ b/.claude/agent-memory/code-writer/content-registry-not-reactive.md
@@ -28,6 +28,12 @@ computed 里都不许直接 `getContentRegistry().<face>`** —— 必须先落�
   一个字都没说。`await contentReadyPromise` 之后重取注册表 = 又读到一次空目录，
   和不写这段代码等价。2026-08-08 在 `ImagePresetList.vue` 上逮到一次（C15 那句
   「缺少形态提示」因此在组件整个生命周期里是死的）。
+- **同族的模块级非响应式缝还有两条**：`random-event-runtime.getRandomEventPack()` 与
+  `engine-settings.getEngineSettings()`。2026-08-16 给 DebugPanel 加随机事件区块时踩到：
+  它们同样要落 `ref`。**取快照写在 `<script setup>` 顶层同步调，别放 `onMounted`** ——
+  onMounted 里改 ref 是下一拍才渲染，真机上首帧闪一下「未装载事件包」，而组件测试里
+  `mount(...).text()` 是同步读的，读到的全是 ref 初值（症状：断言全红，但功能其实是对的，
+  很容易误判成模块被加载了两份）。
 - 测试里给 store 喂内容：先 `setContentRegistry({...})` **再** `useCreateStore()`。
   组件测试里 mock content-store 时**别把注册表 mock 成一开始就满的** —— 那样「组件等的
   是哪个 promise」这个问题根本没被问到，接错 promise 照样全绿。要留一个「加载门兑现后

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## 进行中 / 近期交付（按交付时间倒序）
 
+### 随机事件调试分区（DebugPanel）｜ ✅ 已实施，真机走查过（2026-08-16）
+
+游戏页调试面板（开发者模式 + Alt+Shift+D）新增「随机事件」分区，按主人裁定**只做三样**：①当前 `available` 门槛通过的事件表（名字/触发/权重连乘/日概率，含「在池」标）；②MTTH 因子活体求值（读侧全部复用生产 `evaluateEventCondition` / `computeEventWeight`，零第二实现）；③每行「下回合触发」按钮 → `game-store.devArmRandomEvent` → StateManager 具名 dev 方法 `devForceArmRandomEvent`（ADR-21，不进工具表 AI 不可见），真实槽位采样固化 brief、`forced: true` 免疫淘汰与 TTL，渲染层复用既有 forced 必演指令行（零改动）。调度器新增纯函数 `armRandomEventForced`（同名先撤再入池）。新增 39 测试。真机走查：分区渲染 / available 过滤（夜半叩门被门槛拦下）/ 按钮入池 + 落库 + 在池标全过。已知行为：dev 入池条目带当前地点键，触发前离开该地点会被「离开即撤」规则撤下（与首访 forced 同规则，调试旅途回合先按按钮再动身）。
+
 ### 随机事件系统 v1 ｜ ✅ 已实施（待真机）（2026-08-15）
 
 剧情系统旗下的支线/遭遇子系统，**可独立于剧情系统本体开关**。一句话机制：Code 端种子化确定性调度（每条事件独立 MTTH × 声明式权重链、`available` 硬门槛、共享全局冷却、点名地点首访强制）逐天掷骰产出跨回合驻留的**候选池** → `{{RANDOM_EVENTS}}` 注入 story（不新开 Agent、战斗会话活跃时静默零 token）→ AI 有空时演绎一条并以 `<event_trigger name>` 回执 → Code 按名字结算（清非强制池 / 起冷却 / 记足迹）。触发**纯叙事零副作用**，状态变化仍由既有 dispatcher/vars_update 管线捕获（ADR-32，见 `AGENTS.md` 设计约定）。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 随机事件调试分区（DebugPanel）｜ ✅ 已实施，真机走查过（2026-08-16）
 
-游戏页调试面板（开发者模式 + Alt+Shift+D）新增「随机事件」分区，按主人裁定**只做三样**：①当前 `available` 门槛通过的事件表（名字/触发/权重连乘/日概率，含「在池」标）；②MTTH 因子活体求值（读侧全部复用生产 `evaluateEventCondition` / `computeEventWeight`，零第二实现）；③每行「下回合触发」按钮 → `game-store.devArmRandomEvent` → StateManager 具名 dev 方法 `devForceArmRandomEvent`（ADR-21，不进工具表 AI 不可见），真实槽位采样固化 brief、`forced: true` 免疫淘汰与 TTL，渲染层复用既有 forced 必演指令行（零改动）。调度器新增纯函数 `armRandomEventForced`（同名先撤再入池）。新增 39 测试。真机走查：分区渲染 / available 过滤（夜半叩门被门槛拦下）/ 按钮入池 + 落库 + 在池标全过。已知行为：dev 入池条目带当前地点键，触发前离开该地点会被「离开即撤」规则撤下（与首访 forced 同规则，调试旅途回合先按按钮再动身）。
+游戏页调试面板（开发者模式 + Alt+Shift+D）新增「随机事件」分区，按主人裁定**只做三样**：①当前 `available` 门槛通过的事件表（名字/触发/权重连乘/日概率，含「在池」标）；②MTTH 因子活体求值（读侧全部复用生产 `evaluateEventCondition` / `computeEventWeight`，零第二实现）；③每行「下回合触发」按钮 → `game-store.devArmRandomEvent` → StateManager 具名 dev 方法 `devForceArmRandomEvent`（ADR-21，不进工具表 AI 不可见），真实槽位采样固化 brief、`forced: true` 免疫淘汰与 TTL，渲染层复用既有 forced 必演指令行（零改动）。调度器新增纯函数 `armRandomEventForced`（同名先撤再入池）。新增 39 测试。真机走查：分区渲染 / available 过滤（夜半叩门被门槛拦下）/ 按钮入池 + 落库 + 在池标全过。审查修复三条（合入前）：① **dev 条目不带地点键** —— 带键会让 `settleRandomEventTrigger` 把当前地点记进 `visited`（在某座城里给一条无关事件按按钮 = 永久烧掉这座城的首访足迹，而 `visited` 是事实、无自愈路径），也会被「离开即撤」在下一个旅途回合悄悄撤下；现在它跨地点存活、触发不记足迹（`{{place}}` 仍按当前地点固化进 brief，那是快照语义）。② 「离开即撤」判据补 `placeKey === undefined` 一支（不带键的 forced 条目与地点无关，撤它没有依据）。③ `devForceArmRandomEvent` 补 `randomEventsEnabled` 闸（与另外四条钩子同档）：关闭时零写入 + warn，面板同步禁用按钮 —— 否则会写进一个注入侧永远返空串的池子，还 toast 成功。
 
 ### 随机事件系统 v1 ｜ ✅ 已实施（待真机）（2026-08-15）
 

--- a/src/sillytavern/random-event-scheduler.test.ts
+++ b/src/sillytavern/random-event-scheduler.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, it } from 'vitest';
 import { splitLocationSegments } from './map-index';
 import {
   armFirstVisitEvent,
+  armRandomEventForced,
   buildRandomEventSeed,
   computeEventWeight,
   evaluateEventCondition,
@@ -760,6 +761,101 @@ describe('armFirstVisitEvent —— 点名地点首访必入池（§4.2）', () 
     });
     const first = arm([def], {}, 'Harbor');
     expect(arm([def], {}, 'Harbor')).toEqual(first);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// 调试强制入池
+// ═══════════════════════════════════════════════════════════
+
+describe('armRandomEventForced —— 开发者面板的「下回合触发」', () => {
+  const devArm = (
+    def: RandomEventDef,
+    flags: RandomEventSaveFlags = {},
+    ctx: RandomEventRollContext = CTX,
+    currentDay = 10,
+  ) => armRandomEventForced(def, flags, ctx, { currentDay, saveSeed: SEED });
+
+  it('按 forced 入池 —— 池满淘汰与过期都动不了它', () => {
+    const entry = devArm(mtth('Dev', NEVER))?.pending?.[0];
+    expect(entry?.name).toBe('Dev');
+    expect(entry?.forced).toBe(true);
+    expect(entry?.armedDay).toBe(10);
+    // forced 条目不设过期（`expiresDay` 缺席 = 永不过期，见类型分册那条注释）
+    expect(entry?.expiresDay).toBeUndefined();
+  });
+
+  it('🔴 绕过 available / 权重 ×0 / 冷却 / once —— 这就是这个按钮的全部意义', () => {
+    const blocked = mtth('Dev', NEVER, {
+      available: { journey: true }, // ctx.journeyActive 缺席 → 硬门槛不满足
+      weights: [{ when: {}, multiply: 0 }],
+      once: true,
+      cooldownDays: 999,
+    });
+    const flags: RandomEventSaveFlags = {
+      fired: { Dev: { count: 1, lastDay: 9 } },
+      lastTriggerDay: 10,
+    };
+    expect(names(devArm(blocked, flags))).toEqual(['Dev']);
+  });
+
+  it('简报走真实入池那条路（槽位采样 + {{place}} 固化），不是把模板原样搬过去', () => {
+    const def = mtth('Dev', NEVER, {
+      brief: 'a {{goods}} at {{place}}',
+      slots: { goods: { pick: ['relic'] } },
+    });
+    expect(devArm(def)?.pending?.[0].brief).toBe('a relic at Harbor');
+  });
+
+  it('确定性：同 (saveSeed, name, day) 同结果；换日换结果（多行槽位）', () => {
+    const def = mtth('Dev', NEVER, {
+      brief: '{{mood}}',
+      slots: { mood: { pick: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] } },
+    });
+    expect(devArm(def)?.pending?.[0].brief).toBe(devArm(def)?.pending?.[0].brief);
+    const briefs = new Set<string>();
+    for (let day = 1; day <= 40; day++) {
+      briefs.add(devArm(def, {}, CTX, day)?.pending?.[0].brief ?? '-');
+    }
+    expect(briefs.size).toBeGreaterThan(1);
+  });
+
+  it('同名旧条目先撤再入 —— 池里绝不出现两行同名候选', () => {
+    const flags: RandomEventSaveFlags = {
+      pending: [{ name: 'Dev', armedDay: 1, expiresDay: 6, priority: 0, brief: 'stale' }],
+    };
+    const next = devArm(mtth('Dev', NEVER), flags);
+    expect(names(next)).toEqual(['Dev']);
+    expect(next?.pending?.[0].forced).toBe(true);
+  });
+
+  it('不做池满淘汰 —— 别人正在等的候选不该被一次调试挤掉（同 armFirstVisitEvent）', () => {
+    const flags: RandomEventSaveFlags = {
+      pending: [
+        { name: 'A', armedDay: 1, expiresDay: 6, priority: 5, brief: 'a' },
+        { name: 'B', armedDay: 1, expiresDay: 6, priority: 4, brief: 'b' },
+        { name: 'C', armedDay: 1, expiresDay: 6, priority: 3, brief: 'c' },
+      ],
+    };
+    expect(names(devArm(mtth('Dev', NEVER), flags))).toEqual(['A', 'B', 'C', 'Dev']);
+  });
+
+  it('地点键写进条目（离开即撤那条过滤按它比对）', () => {
+    expect(devArm(mtth('Dev', NEVER))?.pending?.[0].placeKey).toBe('Harbor');
+  });
+
+  it('日子非有穷 / 名字为空 → null（不拿假日子往下算）', () => {
+    expect(devArm(mtth('Dev', NEVER), {}, CTX, Number.NaN)).toBeNull();
+    expect(devArm({ ...mtth('X', NEVER), name: '' })).toBeNull();
+  });
+
+  it('不改入参', () => {
+    const flags: RandomEventSaveFlags = {
+      pending: [{ name: 'A', armedDay: 1, expiresDay: 6, priority: 5, brief: 'a' }],
+    };
+    const snapshot = JSON.stringify(flags);
+    devArm(mtth('Dev', NEVER), flags);
+    expect(JSON.stringify(flags)).toBe(snapshot);
   });
 });
 

--- a/src/sillytavern/random-event-scheduler.test.ts
+++ b/src/sillytavern/random-event-scheduler.test.ts
@@ -840,8 +840,32 @@ describe('armRandomEventForced —— 开发者面板的「下回合触发」', 
     expect(names(devArm(mtth('Dev', NEVER), flags))).toEqual(['A', 'B', 'C', 'Dev']);
   });
 
-  it('地点键写进条目（离开即撤那条过滤按它比对）', () => {
-    expect(devArm(mtth('Dev', NEVER))?.pending?.[0].placeKey).toBe('Harbor');
+  it('🔴 **不带地点键** —— 否则触发时会把当前地点的首访足迹烧掉（visited 无自愈）', () => {
+    const entry = devArm(mtth('Dev', NEVER))?.pending?.[0];
+    expect(entry?.placeKey).toBeUndefined();
+    // {{place}} 仍按当前地点固化进 brief（那是快照语义，与条目归属无关）
+    expect(devArm(mtth('Dev', NEVER, { brief: 'at {{place}}' }))?.pending?.[0].brief).toBe(
+      'at Harbor',
+    );
+  });
+
+  it('🔴 跨地点存活 —— 到一个新地方不该把调试条目「离开即撤」掉', () => {
+    const armed = devArm(mtth('Dev', NEVER)) ?? {};
+    const moved = armFirstVisitEvent(
+      [firstVisit('Arrival', ['Keep'])],
+      armed,
+      { placeKey: 'Keep' },
+      { placeKey: 'Keep', currentDay: 11, saveSeed: SEED },
+    );
+    expect(names(moved)).toContain('Dev');
+  });
+
+  it('🔴 触发它不记足迹；而真首访条目（带地点键）照样记 —— 两个方向都钉住', () => {
+    const dev = settleRandomEventTrigger(devArm(mtth('Dev', NEVER)) ?? {}, 'Dev', 10);
+    expect(dev?.flags.visited).toBeUndefined();
+
+    const real = arm([firstVisit('Arrival', ['Harbor'])], {}, 'Harbor', 10);
+    expect(settleRandomEventTrigger(real ?? {}, 'Arrival', 10)?.flags.visited).toEqual(['Harbor']);
   });
 
   it('日子非有穷 / 名字为空 → null（不拿假日子往下算）', () => {

--- a/src/sillytavern/random-event-scheduler.ts
+++ b/src/sillytavern/random-event-scheduler.ts
@@ -543,6 +543,50 @@ function selectFirstVisitDef(
 }
 
 // ═══════════════════════════════════════════════════════════
+// 调试强制入池（开发者面板专用）
+// ═══════════════════════════════════════════════════════════
+
+/**
+ * 把**任意一条**定义按 forced 入池。无变化返回 `null`。
+ *
+ * 唯一的调用方是 StateManager 的 `devForceArmRandomEvent`（开发者调试面板的「下回合触发」）。
+ * 它**刻意绕过** MTTH 掷骰 / `available` / 权重链 / 冷却与 `once` —— 那是一个开发者按钮的
+ * 全部意义：我现在就要看这条事件被演绎出来。
+ *
+ * 🔴 为什么是这里而不是在接线层现拼一个条目：槽位采样与简报固化（`armEntry` → `sampleSlots`
+ *    → `renderBrief`）是**入池语义的一部分**。在别处手搓一个 `{ name, brief: def.brief }`
+ *    会把 `{{槽名}}` / `{{place}}` 原样喂给 AI —— 看着像功能正常，只是调试出来的那一次
+ *    与真实入池长得不一样，于是调试本身失去意义。
+ *
+ * 🔴 **不调 `enforcePoolCap`**（同 `armFirstVisitEvent`）：forced 条目本来就免疫淘汰，
+ *    在这里挨个撤别人只会把玩家正在等的候选挤掉。宁可短暂超上限。
+ *
+ * 🔴 同名旧条目**先撤再入**：池里可能已经有一条非 forced 的它。留着就是两行同名候选 ——
+ *    注入块里出现两次，而 `settleRandomEventTrigger` 只认第一条。
+ */
+export function armRandomEventForced(
+  def: RandomEventDef,
+  flags: RandomEventSaveFlags,
+  ctx: RandomEventRollContext,
+  args: { currentDay: number; saveSeed: string },
+): RandomEventSaveFlags | null {
+  const currentDay = toDay(args.currentDay);
+  const name = typeof def?.name === 'string' ? def.name : '';
+  if (currentDay === null || name.length === 0) return null;
+
+  const before = normalizeFlags(flags);
+  const next = normalizeFlags(flags);
+  next.pending = next.pending.filter((entry) => entry.name !== name);
+
+  const rng = createEjsRng(buildRandomEventSeed(args.saveSeed, name, currentDay));
+  next.pending.push(
+    armEntry(def, ctx, rng, { armedDay: currentDay, forced: true, placeKey: ctx.placeKey }),
+  );
+
+  return finalize(next, before);
+}
+
+// ═══════════════════════════════════════════════════════════
 // 池子保洁（§4.3）
 // ═══════════════════════════════════════════════════════════
 

--- a/src/sillytavern/random-event-scheduler.ts
+++ b/src/sillytavern/random-event-scheduler.ts
@@ -492,8 +492,12 @@ export function armFirstVisitEvent(
   const next = normalizeFlags(flags);
 
   // 1. 离开即撤
+  //
+  // 🔴 判据里那句 `entry.placeKey === undefined` 是承重的：**不带地点键的 forced 条目
+  //    与地点无关**（调试入池的产物就是这一种），撤它没有任何依据 —— 而少了这一句，
+  //    `undefined === placeKey` 恒假，它会在玩家一动身时被无声地清掉。
   next.pending = next.pending.filter(
-    (entry) => entry.forced !== true || entry.placeKey === placeKey,
+    (entry) => entry.forced !== true || entry.placeKey === undefined || entry.placeKey === placeKey,
   );
 
   // 2. 已访问 / 已有本地 forced
@@ -563,6 +567,15 @@ function selectFirstVisitDef(
  *
  * 🔴 同名旧条目**先撤再入**：池里可能已经有一条非 forced 的它。留着就是两行同名候选 ——
  *    注入块里出现两次，而 `settleRandomEventTrigger` 只认第一条。
+ *
+ * 🔴 **绝不写 `placeKey`**（2026-08-16 审查修复，两条后果各自独立地坏）：
+ *    ① `settleRandomEventTrigger` 见 forced 条目就把它的 `placeKey` 记进 `visited` ——
+ *      在某座城里给一条**无关的** MTTH 事件按下按钮，会把这座城的首访足迹永久烧掉，
+ *      于是作者为它写的 first_visit 事件此生不再强制入池。`visited` 是**事实**、没有自愈路径，
+ *      这是真的数据损坏。
+ *    ② 上面那条「离开即撤」会在下一个旅途回合把它悄悄撤下 —— 面板刚 toast 过入池成功。
+ *    不带键的代价只有一个：`{{place}}` 仍按**当前**地点固化进 brief（那是快照语义，对的），
+ *    但条目本身与地点无关 —— 跨地点存活、触发不记足迹。调试条目本来就该是这样。
  */
 export function armRandomEventForced(
   def: RandomEventDef,
@@ -579,9 +592,7 @@ export function armRandomEventForced(
   next.pending = next.pending.filter((entry) => entry.name !== name);
 
   const rng = createEjsRng(buildRandomEventSeed(args.saveSeed, name, currentDay));
-  next.pending.push(
-    armEntry(def, ctx, rng, { armedDay: currentDay, forced: true, placeKey: ctx.placeKey }),
-  );
+  next.pending.push(armEntry(def, ctx, rng, { armedDay: currentDay, forced: true }));
 
   return finalize(next, before);
 }

--- a/src/sillytavern/state-manager.random-events.test.ts
+++ b/src/sillytavern/state-manager.random-events.test.ts
@@ -752,6 +752,56 @@ describe('devForceArmRandomEvent —— 开发者面板专用的强制入池', (
     expect(flags.pending?.[0].forced).toBe(true);
   });
 
+  it('🔴 系统关掉时零写入 + warn（注入侧返空串，写进去的候选谁也看不见）', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    setEngineSettingsProvider(() => ({ randomEventsEnabled: false }));
+    installRandomEventPack(buildPack([alwaysDef('Encounter')]));
+    await seedProfile();
+    await seedPlayer('Camp');
+
+    const result = await createStateManager(SAVE_ID).devForceArmRandomEvent('Encounter');
+
+    expect(result.ok).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    expect(await readRawFlags()).toBeUndefined();
+  });
+
+  it('🔴 条目不带地点键 —— 换地方它照样在池里（离开即撤只管真首访条目）', async () => {
+    installRandomEventPack(
+      buildPack([alwaysDef('Dev', { trigger: { type: 'mtth', mtthDays: 1e12 } })]),
+    );
+    await seedProfile();
+    await seedPlayer('Outpost');
+
+    await createStateManager(SAVE_ID).devForceArmRandomEvent('Dev');
+    expect((await readFlags()).pending?.[0].placeKey).toBeUndefined();
+
+    await setLocation('Hero', 'Bravo');
+    expect(await pendingNames()).toEqual(['Dev']);
+  });
+
+  it('🔴 触发它不烧当前地点的首访足迹（visited 是事实、没有自愈路径）', async () => {
+    installRandomEventPack(
+      buildPack([
+        alwaysDef('Dev', { trigger: { type: 'mtth', mtthDays: 1e12 } }),
+        firstVisitDef('Arrival', ['Alpha']),
+      ]),
+    );
+    installMapPack(buildMapPack());
+    await seedProfile();
+    await seedPlayer('Outpost');
+
+    // 站在 Alpha（它的首访事件还没被演绎）时，给一条无关的 MTTH 事件按下调试按钮
+    await setLocation('Hero', 'Alpha');
+    await createStateManager(SAVE_ID).devForceArmRandomEvent('Dev');
+    await createStateManager(SAVE_ID).confirmRandomEventTrigger('Dev');
+
+    const flags = await readFlags();
+    expect(flags.visited).toBeUndefined();
+    // 足迹没被烧 → 作者为 Alpha 写的首访事件仍在池里（离开再回来也还会强制入池）
+    expect(await pendingNames()).toEqual(['Arrival']);
+  });
+
   it('入池后进得了注入块，且带 forced 标（下一回合 story 真看得见）', async () => {
     installRandomEventPack(
       buildPack([alwaysDef('Encounter', { trigger: { type: 'mtth', mtthDays: 1e12 } })]),

--- a/src/sillytavern/state-manager.random-events.test.ts
+++ b/src/sillytavern/state-manager.random-events.test.ts
@@ -21,6 +21,7 @@
  * - NPC 换位置 → 一个字节都不写（player only，同地图落位钩子）
  * - 结算：清全部非 forced / forced 留在池里 / 记档案 / 起全局冷却 / emit `random_event`
  * - 结算的两条 warn-noop：名字不在池中（AI 幻觉不奖励）、系统关闭
+ * - 调试入池（`devForceArmRandomEvent`）：绕过硬门槛与权重、免疫池满与保洁、名字认不出就 no-op
  *
  * 🔴 夹具零真实地名与零真实事件名（承 D25①）：事件定义是**内容包数据**，
  *    夹具里写真名会让人误以为引擎认识它们。
@@ -32,7 +33,13 @@ import { clearAllData, getCharacters, initializeDatabase, saveCharacter } from '
 import { getProfile, getRandomEventFlags, updateProfile } from './save-profile';
 import { createStateManager } from './state-manager';
 import { setEngineSettingsProvider } from './engine-settings';
-import { installRandomEventPack, resetRandomEventRuntime } from './random-event-runtime';
+import {
+  getRandomEventPack,
+  installRandomEventPack,
+  resetRandomEventRuntime,
+} from './random-event-runtime';
+import { buildRandomEventOffer } from './random-event-context';
+import { buildRandomEventRollContext } from './random-event-snapshot';
 import { installMapPack, resetMapRuntime } from './map-runtime';
 import type { RandomEventPack } from './random-event-pack';
 import { DEFAULT_RANDOM_EVENT_CONFIG } from './types-random-events';
@@ -617,5 +624,151 @@ describe('syncRandomEventsForTurn —— 每回合的轻量保洁', () => {
     installRandomEventPack(buildPack([alwaysDef('Encounter')]));
     await createStateManager(SAVE_ID).syncRandomEventsForTurn();
     expect(await readRawFlags()).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// 调试入池（开发者面板「下回合触发」）
+// ═══════════════════════════════════════════════════════════
+
+describe('devForceArmRandomEvent —— 开发者面板专用的强制入池', () => {
+  it('按 forced 入池并落库，简报按真实入池那条路固化（槽位采样 + {{place}}）', async () => {
+    installRandomEventPack(
+      buildPack([
+        alwaysDef('Encounter', {
+          // `mtthDays` 大到实质掷不中：入池只可能来自这个按钮
+          trigger: { type: 'mtth', mtthDays: 1e12 },
+          brief: 'a {{goods}} at {{place}}',
+          slots: { goods: { pick: ['relic'] } },
+        }),
+      ]),
+    );
+    await seedProfile();
+    await seedPlayer('Camp');
+
+    const result = await createStateManager(SAVE_ID).devForceArmRandomEvent('Encounter');
+
+    expect(result).toEqual({ ok: true });
+    const flags = await readFlags();
+    expect(flags.pending).toHaveLength(1);
+    expect(flags.pending?.[0]).toMatchObject({
+      name: 'Encounter',
+      forced: true,
+      armedDay: START_DAY,
+      brief: 'a relic at Camp',
+    });
+    // forced 条目不设过期（撤池条件是离开 / available 不再满足，不是时间）
+    expect(flags.pending?.[0].expiresDay).toBeUndefined();
+  });
+
+  it('🔴 绕过 available 硬门槛与权重 ×0 —— 这就是这个按钮存在的理由', async () => {
+    installRandomEventPack(
+      buildPack([
+        alwaysDef('Blocked', {
+          available: { playerLevel: { gte: 99 } },
+          weights: [{ when: {}, multiply: 0 }],
+        }),
+      ]),
+    );
+    await seedProfile();
+    await seedPlayer('Camp', 3);
+
+    expect(await createStateManager(SAVE_ID).devForceArmRandomEvent('Blocked')).toEqual({
+      ok: true,
+    });
+    expect(await pendingNames()).toEqual(['Blocked']);
+  });
+
+  it('名字不在事件包里 → warn + 一个字节都不写（换包 / 手滑都走这一条）', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    installRandomEventPack(buildPack([alwaysDef('Encounter')]));
+    await seedProfile();
+    await seedPlayer('Camp');
+
+    const result = await createStateManager(SAVE_ID).devForceArmRandomEvent('Ghost');
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(warn).toHaveBeenCalled();
+    expect(await readRawFlags()).toBeUndefined();
+  });
+
+  it('空名字 / 没装包 → 同样 no-op（不建 flags 袋子）', async () => {
+    await seedProfile();
+    await seedPlayer('Camp');
+
+    expect((await createStateManager(SAVE_ID).devForceArmRandomEvent('   ')).ok).toBe(false);
+    expect((await createStateManager(SAVE_ID).devForceArmRandomEvent('Encounter')).ok).toBe(false);
+    expect(await readRawFlags()).toBeUndefined();
+  });
+
+  it('🔴 池满时也进得去，且随后的保洁不把它撤掉（forced 免疫淘汰与过期）', async () => {
+    installRandomEventPack(
+      buildPack(
+        [
+          alwaysDef('Dev', { trigger: { type: 'mtth', mtthDays: 1e12 } }),
+          alwaysDef('A'),
+          alwaysDef('B'),
+        ],
+        { maxPending: 2 },
+      ),
+    );
+    await seedProfile({
+      pending: [
+        { name: 'A', armedDay: START_DAY, expiresDay: START_DAY + 5, priority: 5, brief: 'a' },
+        { name: 'B', armedDay: START_DAY, expiresDay: START_DAY + 5, priority: 4, brief: 'b' },
+      ],
+      lastRollDay: START_DAY,
+    });
+    await seedPlayer('Camp');
+
+    await createStateManager(SAVE_ID).devForceArmRandomEvent('Dev');
+    expect(await pendingNames()).toEqual(['A', 'B', 'Dev']);
+
+    // 每回合保洁跑一遍：forced 条目必须还在（撤掉的话「下回合触发」就是一句空话）
+    await createStateManager(SAVE_ID).syncRandomEventsForTurn();
+    expect(await pendingNames()).toContain('Dev');
+  });
+
+  it('同名条目已在池 → 换成 forced，绝不出现两行同名候选', async () => {
+    installRandomEventPack(buildPack([alwaysDef('Encounter')]));
+    await seedProfile({
+      pending: [
+        {
+          name: 'Encounter',
+          armedDay: START_DAY,
+          expiresDay: START_DAY + 5,
+          priority: 0,
+          brief: 'stale',
+        },
+      ],
+    });
+    await seedPlayer('Camp');
+
+    await createStateManager(SAVE_ID).devForceArmRandomEvent('Encounter');
+
+    const flags = await readFlags();
+    expect(flags.pending).toHaveLength(1);
+    expect(flags.pending?.[0].forced).toBe(true);
+  });
+
+  it('入池后进得了注入块，且带 forced 标（下一回合 story 真看得见）', async () => {
+    installRandomEventPack(
+      buildPack([alwaysDef('Encounter', { trigger: { type: 'mtth', mtthDays: 1e12 } })]),
+    );
+    await seedProfile();
+    await seedPlayer('Camp');
+
+    await createStateManager(SAVE_ID).devForceArmRandomEvent('Encounter');
+
+    const profile = await getProfile(SAVE_ID);
+    const offer = buildRandomEventOffer(
+      getRandomEventPack().defs,
+      getRandomEventPack().config,
+      getRandomEventFlags(profile),
+      buildRandomEventRollContext(profile, (await getCharacters(SAVE_ID))[0]),
+      START_DAY,
+    );
+    expect(offer.map((e) => [e.name, e.forced])).toEqual([['Encounter', true]]);
   });
 });

--- a/src/sillytavern/state-manager.ts
+++ b/src/sillytavern/state-manager.ts
@@ -1966,6 +1966,14 @@ export class StateManager {
     const wanted = typeof name === 'string' ? name.trim() : '';
     if (wanted.length === 0) return { ok: false, error: '事件名为空' };
 
+    // 🔴 关掉时**一个字节都不写**（与另外四条钩子同一道闸）：注入侧此时返回空串，
+    //    写进去的候选谁也看不见 —— 而按钮会照常 toast 成功。「入了池但永远不出现」
+    //    是这个子系统里最难查的一种假象，宁可在这里说清楚。
+    if (!getEngineSettings().randomEventsEnabled) {
+      console.warn(`[StateManager] 随机事件已关闭，忽略调试入池: ${wanted}`);
+      return { ok: false, error: '随机事件系统已关闭（设置 → 剧情）' };
+    }
+
     const pack = getRandomEventPack();
     const def = pack.defs.find((d) => d?.name === wanted);
     if (def === undefined) {

--- a/src/sillytavern/state-manager.ts
+++ b/src/sillytavern/state-manager.ts
@@ -82,6 +82,7 @@ import { getRandomEventPack } from './random-event-runtime';
 import { isEmptyRandomEventPack } from './random-event-pack';
 import {
   armFirstVisitEvent,
+  armRandomEventForced,
   pruneRandomEvents,
   rollRandomEvents,
   settleRandomEventTrigger,
@@ -1944,6 +1945,48 @@ export class StateManager {
     } catch (err) {
       // 事件系统只记「触发过」这一事实（铁则 5）；记不上不该让这一回合的正文崩掉
       console.warn('[StateManager] 随机事件触发结算失败（不影响正文）:', err);
+    }
+  }
+
+  /**
+   * 调试入池：把一条事件按 forced 塞进候选池，让它在**下一回合**的 `{{RANDOM_EVENTS}}` 里
+   * 带 `[!]`（= 必须尽快触发）出现。开发者调试面板专用。
+   *
+   * 🔴 **命名方法，不是 `StatePatchOp`**（同 `confirmRandomEventTrigger` 那条理由）：
+   *    做成 op 就等于把「凭空点燃一个事件」这个能力交给了 AI。它也**不进任何 Agent 工具表**。
+   * 🔴 **刻意绕过 `available` / 权重 / 冷却 / `once`**：这就是一个开发者按钮的意义。
+   *    调用方（调试面板）只列 `available` 通过的事件，但这一层不替它把关 ——
+   *    在这里加闸门会让「为什么按了没反应」变成一道要读三个纯函数才答得上的谜题。
+   * 🔴 槽位采样与简报固化整份走 `armRandomEventForced`（= 真实入池那条路），
+   *    不在这里手搓条目：手搓出来的候选带着未替换的 `{{槽名}}`，调试的就不是真实形态了。
+   *
+   * 结果交回调用方转 toast（本层不弹提示，同 `allocateAttributePoint` 的口径）。
+   */
+  async devForceArmRandomEvent(name: string): Promise<{ ok: boolean; error?: string }> {
+    const wanted = typeof name === 'string' ? name.trim() : '';
+    if (wanted.length === 0) return { ok: false, error: '事件名为空' };
+
+    const pack = getRandomEventPack();
+    const def = pack.defs.find((d) => d?.name === wanted);
+    if (def === undefined) {
+      // 幻觉名字与「换包后名字对不上」共用这一条 warn（铁则 4：认不出就静默跳过，不抛）
+      console.warn(`[StateManager] 随机事件定义不存在，忽略调试入池: ${wanted}`);
+      return { ok: false, error: '事件定义不存在（可能换过内容包）' };
+    }
+
+    try {
+      const profile = await getProfile(this.saveId);
+      const ctx = await this.buildRandomEventContext(profile);
+      const armed = armRandomEventForced(def, getRandomEventFlags(profile), ctx, {
+        currentDay: this.gameDayOf(profile),
+        saveSeed: this.saveId,
+      });
+      // `null` = 池里已经有一条一模一样的（同日同名同简报）→ 已经armed，无需再写库
+      if (armed !== null) await updateRandomEventFlags(profile, armed);
+      return { ok: true };
+    } catch (err) {
+      console.warn('[StateManager] 随机事件调试入池失败（不影响正文与已落库状态）:', err);
+      return { ok: false, error: '调试入池失败（详见控制台）' };
     }
   }
 

--- a/src/ui/components/game/DebugPanel.random-events.test.ts
+++ b/src/ui/components/game/DebugPanel.random-events.test.ts
@@ -1,0 +1,181 @@
+/**
+ * DebugPanel.vue — 随机事件区块
+ * @vitest-environment jsdom
+ *
+ * ## 为什么这个区块值得测
+ * 随机事件在真机上是**一块黑盒**：候选池住在 `worldFlags` 里、掷骰只发生在时间推进那一刻、
+ * 权重链的乘积谁也看不见。这块表就是唯一的窗口，所以它自己必须诚实：
+ *
+ * - **数字来自生产函数**（`evaluateEventCondition` / `computeEventWeight` / 快照组装）。
+ *   照抄一份判据的下场是面板在真机上说谎 —— 而说谎的正是用来查真相的那块面板。
+ * - **「下回合触发」真的走引擎写入口**（`game.devArmRandomEvent` → StateManager）。
+ *   按钮画出来了但没接线，症状是「按了没反应」，没有任何一处会报错。
+ * - **取快照在挂载时**：事件包与引擎设置都是模块级非响应式状态，写成 computed 会把
+ *   「当时装的是空包」永久缓存住（先例：内容注册表那次）。
+ *
+ * 纯判定（谁进表 / 各列的数）在 `random-event-debug.test.ts`，这里只钉**接线**。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import DebugPanel from './DebugPanel.vue';
+import { useGameStore } from '../../stores/game-store';
+import { installRandomEventPack, resetRandomEventRuntime } from '@engine/random-event-runtime';
+import { setEngineSettingsProvider } from '@engine/engine-settings';
+import { createDefaultTime } from '@engine/time-system';
+import { createDefaultCharacterState, type SaveProfile } from '@engine/types';
+import {
+  DEFAULT_RANDOM_EVENT_CONFIG,
+  type RandomEventDef,
+  type RandomEventSaveFlags,
+} from '@engine/types-random-events';
+
+function buildProfile(flags?: RandomEventSaveFlags): SaveProfile {
+  return {
+    saveId: 'save-debug',
+    fp: 0,
+    fpHistory: [],
+    contracts: [],
+    achievements: [],
+    news: [],
+    quests: {},
+    focusQuest: '',
+    affections: {},
+    gameTime: createDefaultTime(),
+    variables: {},
+    worldFlags: flags === undefined ? {} : { randomEvents: flags },
+    updatedAt: 0,
+  };
+}
+
+function installPack(defs: RandomEventDef[]): void {
+  installRandomEventPack({ config: { ...DEFAULT_RANDOM_EVENT_CONFIG }, defs });
+}
+
+/** 面板整块由 AppModal 的 `v-if` 托管 —— 每次打开都是一次新挂载，这里照做 */
+function mountPanel() {
+  return mount(DebugPanel);
+}
+
+function seedSave(game: ReturnType<typeof useGameStore>, flags?: RandomEventSaveFlags): void {
+  game.saveProfile = buildProfile(flags);
+  game.characters = [
+    createDefaultCharacterState({
+      id: 'hero-1',
+      saveId: 'save-debug',
+      name: 'Hero',
+      type: 'player',
+      location: 'Harbor',
+      level: 5,
+    }),
+  ];
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  resetRandomEventRuntime();
+  setEngineSettingsProvider(undefined);
+});
+
+afterEach(() => {
+  resetRandomEventRuntime();
+  setEngineSettingsProvider(undefined);
+  vi.restoreAllMocks();
+});
+
+describe('DebugPanel · 随机事件区块', () => {
+  it('没装事件包时明说 no-op，不摆一张空表', () => {
+    const text = mountPanel().text();
+    expect(text).toContain('随机事件');
+    expect(text).toContain('未装载事件包');
+  });
+
+  it('列出通过 available 的事件：触发列 / 权重 / 日概率四样都在', () => {
+    installPack([
+      { name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } },
+      {
+        name: 'Gated',
+        brief: 'g',
+        trigger: { type: 'mtth', mtthDays: 4 },
+        available: { playerLevel: { gte: 99 } },
+      },
+    ]);
+    const game = useGameStore();
+    seedSave(game);
+
+    const text = mountPanel().text();
+    expect(text).toContain('Rumor');
+    // available 不满足的那条根本不进表（调度器也不会考虑它）
+    expect(text).not.toContain('Gated');
+    expect(text).toContain('4 天');
+    expect(text).toContain('25.0%'); // min(1, 1/4)
+  });
+
+  it('首访事件也列出来，并报出作者点名的地点', () => {
+    installPack([
+      {
+        name: 'Arrival',
+        brief: 'a',
+        trigger: { type: 'first_visit', scope: { anyOf: ['Harbor', 'Keep'] } },
+      },
+    ]);
+    const game = useGameStore();
+    seedSave(game);
+
+    const text = mountPanel().text();
+    expect(text).toContain('Arrival');
+    expect(text).toContain('首访');
+    expect(text).toContain('Harbor / Keep');
+  });
+
+  it('已在池中的条目带「在池」标（否则按完按钮看不出发生了什么）', () => {
+    installPack([{ name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } }]);
+    const game = useGameStore();
+    seedSave(game, {
+      pending: [{ name: 'Rumor', armedDay: 0, expiresDay: 5, priority: 0, brief: 'r' }],
+    });
+
+    expect(mountPanel().text()).toContain('在池');
+  });
+
+  it('频率系数真的乘进日概率（设置读了没往下传是看不出来的）', () => {
+    installPack([{ name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } }]);
+    setEngineSettingsProvider(() => ({ randomEventsFrequency: 2 }));
+    const game = useGameStore();
+    seedSave(game);
+
+    const text = mountPanel().text();
+    expect(text).toContain('×2');
+    expect(text).toContain('50.0%'); // min(1, 2/4)
+  });
+
+  it('系统关掉时区块照常显示，但明说已关闭（不是静默给一张会骗人的表）', () => {
+    installPack([{ name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } }]);
+    setEngineSettingsProvider(() => ({ randomEventsEnabled: false }));
+    const game = useGameStore();
+    seedSave(game);
+
+    const text = mountPanel().text();
+    expect(text).toContain('Rumor');
+    expect(text).toContain('系统已关闭');
+  });
+
+  it('🔴「下回合触发」按钮真的调到引擎写入口（按名字，逐字）', async () => {
+    installPack([{ name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } }]);
+    const game = useGameStore();
+    seedSave(game);
+    const spy = vi.spyOn(game, 'devArmRandomEvent').mockResolvedValue({ ok: true });
+
+    const wrapper = mountPanel();
+    const buttons = wrapper.findAll('.debug-re-table button');
+    expect(buttons).toHaveLength(1);
+    await buttons[0].trigger('click');
+
+    expect(spy).toHaveBeenCalledWith('Rumor');
+  });
+
+  it('无活跃存档时不炸、也不摆一张假表', () => {
+    installPack([{ name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } }]);
+    expect(mountPanel().text()).toContain('无活跃存档');
+  });
+});

--- a/src/ui/components/game/DebugPanel.random-events.test.ts
+++ b/src/ui/components/game/DebugPanel.random-events.test.ts
@@ -20,6 +20,7 @@ import { mount } from '@vue/test-utils';
 import { setActivePinia, createPinia } from 'pinia';
 import DebugPanel from './DebugPanel.vue';
 import { useGameStore } from '../../stores/game-store';
+import { useUIStore } from '../../stores/ui-store';
 import { installRandomEventPack, resetRandomEventRuntime } from '@engine/random-event-runtime';
 import { setEngineSettingsProvider } from '@engine/engine-settings';
 import { createDefaultTime } from '@engine/time-system';
@@ -149,15 +150,30 @@ describe('DebugPanel · 随机事件区块', () => {
     expect(text).toContain('50.0%'); // min(1, 2/4)
   });
 
-  it('系统关掉时区块照常显示，但明说已关闭（不是静默给一张会骗人的表）', () => {
+  it('🔴 系统关掉时区块照常显示、明说已关闭，且按钮禁用（入池了也不会注入）', () => {
     installPack([{ name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } }]);
     setEngineSettingsProvider(() => ({ randomEventsEnabled: false }));
     const game = useGameStore();
     seedSave(game);
 
-    const text = mountPanel().text();
-    expect(text).toContain('Rumor');
-    expect(text).toContain('系统已关闭');
+    const wrapper = mountPanel();
+    expect(wrapper.text()).toContain('Rumor');
+    expect(wrapper.text()).toContain('系统已关闭');
+    const button = wrapper.find('.debug-re-table button');
+    expect(button.attributes('disabled')).toBeDefined();
+  });
+
+  it('入池失败按错误播报，绝不报成功（「按了说好了、其实没写」最难查）', async () => {
+    installPack([{ name: 'Rumor', brief: 'r', trigger: { type: 'mtth', mtthDays: 4 } }]);
+    const game = useGameStore();
+    const ui = useUIStore();
+    seedSave(game);
+    vi.spyOn(game, 'devArmRandomEvent').mockResolvedValue({ ok: false, error: '系统已关闭' });
+
+    await mountPanel().find('.debug-re-table button').trigger('click');
+    await Promise.resolve();
+
+    expect(ui.toasts.map((t) => [t.type, t.message])).toEqual([['error', '系统已关闭']]);
   });
 
   it('🔴「下回合触发」按钮真的调到引擎写入口（按名字，逐字）', async () => {

--- a/src/ui/components/game/DebugPanel.vue
+++ b/src/ui/components/game/DebugPanel.vue
@@ -365,10 +365,15 @@ function formatJson(value: unknown): string {
             </td>
             <td>{{ formatDailyProbability(row.dailyProbability) }}</td>
             <td>
+              <!-- 系统关掉时禁用：引擎那一层同样会拒（零写入），这里只是别让人白按一次 -->
               <button
                 class="debug-btn debug-btn-sm"
-                :disabled="arming.length > 0"
-                title="按 forced 塞进候选池，下回合注入给正文（绕过掷骰/冷却/权重）"
+                :disabled="arming.length > 0 || !eventsEnabled"
+                :title="
+                  eventsEnabled
+                    ? '按 forced 塞进候选池，下回合注入给正文（绕过掷骰/冷却/权重）'
+                    : '随机事件系统已关闭：入池了也不会注入给正文'
+                "
                 @click="armEvent(row.name)"
               >
                 下回合触发

--- a/src/ui/components/game/DebugPanel.vue
+++ b/src/ui/components/game/DebugPanel.vue
@@ -1,11 +1,103 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useGameStore, type DebugAgentEntry } from '../../stores/game-store';
 import { useSettingsStore } from '../../stores/settings-store';
+import { useUIStore } from '../../stores/ui-store';
 import { getEjsBackend } from '@engine/ejs-backend';
+import { getEngineSettings } from '@engine/engine-settings';
+import { getRandomEventPack } from '@engine/random-event-runtime';
+import { buildRandomEventRollContext } from '@engine/random-event-snapshot';
+import { getRandomEventFlags } from '@engine/save-profile';
+import { toEpochMinutes } from '@engine/time-system';
+import {
+  buildRandomEventDebugRows,
+  formatDailyProbability,
+  formatEventWeight,
+  type RandomEventDebugRow,
+} from './random-event-debug';
 
 const game = useGameStore();
 const settings = useSettingsStore();
+const ui = useUIStore();
+
+// ═══════════════════════════════════════════════════════════
+// 随机事件（随机事件 v1 §4）
+// ═══════════════════════════════════════════════════════════
+
+/** 一个游戏日的分钟数（口径同 `state-manager` / `game-pipeline`，那份常量未导出） */
+const MINUTES_PER_GAME_DAY = 1440;
+
+/**
+ * 候选表**用 `ref` 不用 `computed`**。
+ *
+ * 事件包（`getRandomEventPack()`）与引擎设置（`getEngineSettings()`）都是**模块级非响应式
+ * 状态**：computed 会在第一次求值后把结果连同「当时装的是空包」一起缓存住，此后换存档、
+ * 装内容包都不会让它重算 —— 症状是面板永远显示「没装事件包」。所以显式取快照：
+ * setup 里同步取一次（面板整块由 AppModal 的 `v-if` 托管，每次打开都是新挂载 = 一次刷新），
+ * 入池按钮按完再取一次。
+ */
+const eventRows = ref<RandomEventDebugRow[]>([]);
+const eventPackEmpty = ref(true);
+const eventFrequency = ref(1);
+const eventsEnabled = ref(true);
+const arming = ref('');
+
+function refreshRandomEvents(): void {
+  const engine = getEngineSettings();
+  eventsEnabled.value = engine.randomEventsEnabled;
+  eventFrequency.value = engine.randomEventsFrequency;
+
+  const pack = getRandomEventPack();
+  eventPackEmpty.value = pack.defs.length === 0;
+
+  const profile = game.saveProfile;
+  if (!profile) {
+    eventRows.value = [];
+    return;
+  }
+  try {
+    const player = game.characters.find((c) => c.type === 'player');
+    eventRows.value = buildRandomEventDebugRows(
+      pack.defs,
+      getRandomEventFlags(profile),
+      // 上下文快照与入池侧、注入侧**共用同一份实现**（`random-event-snapshot`）——
+      // 调试面板照抄一份判据的下场是：它会在真机上说谎，而说谎的正是用来查真相的那块面板
+      buildRandomEventRollContext(profile, player),
+      engine.randomEventsFrequency,
+    );
+  } catch (err) {
+    console.warn('[DebugPanel] 随机事件候选表构建失败:', err);
+    eventRows.value = [];
+  }
+}
+
+// 挂载即取一次（**setup 里同步调，不用 onMounted**：refs 在 onMounted 里改是下一拍才渲染，
+// 首帧会闪一下「未装载事件包」；这一层没有任何异步，没理由让用户先看见一个假答案）
+refreshRandomEvents();
+
+/** 当前游戏日（表头显示；与调度器的 gameDay 同口径） */
+const currentGameDay = computed(() => {
+  const profile = game.saveProfile;
+  if (!profile) return null;
+  return Math.floor(toEpochMinutes(profile.gameTime) / MINUTES_PER_GAME_DAY);
+});
+
+/** 「下回合触发」：按 forced 入池 → 下一轮 `{{RANDOM_EVENTS}}` 里带 `[!]` 出现 */
+async function armEvent(name: string): Promise<void> {
+  if (arming.value.length > 0) return;
+  arming.value = name;
+  try {
+    const result = await game.devArmRandomEvent(name);
+    if (result.ok) {
+      ui.toast(`已强制入池：${name}（下回合注入给正文）`, 'success');
+    } else {
+      ui.toast(result.error ?? '入池失败', 'error');
+    }
+  } finally {
+    arming.value = '';
+    refreshRandomEvents();
+  }
+}
 
 /** 本轮 token 汇总（排除 memory_recall 记忆召回，只看正文链路的缓存效率） */
 const tokenSummary = computed(() => {
@@ -228,6 +320,65 @@ function formatJson(value: unknown): string {
       </div>
     </div>
 
+    <!-- 随机事件：当前「调度器会考虑」的定义 + 各自的 MTTH 因子 -->
+    <div class="debug-section">
+      <h4>
+        随机事件 ({{ eventRows.length }})
+        <span class="debug-re-meta">
+          第 {{ currentGameDay ?? '—' }} 日 · 频率 ×{{ eventFrequency }}
+          <template v-if="!eventsEnabled"> · <span class="debug-warn">系统已关闭</span></template>
+        </span>
+      </h4>
+      <div v-if="eventPackEmpty" class="debug-empty">未装载事件包（本子系统整段 no-op）</div>
+      <div v-else-if="!game.saveProfile" class="debug-empty">无活跃存档</div>
+      <div v-else-if="eventRows.length === 0" class="debug-empty">
+        当前上下文下没有事件通过 available 硬门槛（或已被 once 消耗）
+      </div>
+      <table v-else class="debug-re-table">
+        <thead>
+          <tr>
+            <th>名字</th>
+            <th>触发</th>
+            <th>权重</th>
+            <th>日概率</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in eventRows" :key="row.name">
+            <td>
+              {{ row.name }}
+              <span v-if="row.inPool" class="debug-re-pill">在池</span>
+              <span v-if="row.priority !== 0" class="debug-re-dim">P{{ row.priority }}</span>
+            </td>
+            <td>
+              <template v-if="row.kind === 'mtth'">{{ row.mtthDays }} 天</template>
+              <template v-else>
+                首访
+                <span class="debug-re-dim">{{
+                  (row.places ?? []).join(' / ') || '（无地点）'
+                }}</span>
+              </template>
+            </td>
+            <td :class="{ 'debug-warn': row.weight === 0 }">
+              ×{{ formatEventWeight(row.weight) }}
+            </td>
+            <td>{{ formatDailyProbability(row.dailyProbability) }}</td>
+            <td>
+              <button
+                class="debug-btn debug-btn-sm"
+                :disabled="arming.length > 0"
+                title="按 forced 塞进候选池，下回合注入给正文（绕过掷骰/冷却/权重）"
+                @click="armEvent(row.name)"
+              >
+                下回合触发
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
     <!-- Agent 调用日志 -->
     <div class="debug-section">
       <h4>本轮 Agent 调用 ({{ game.agentLog.length }})</h4>
@@ -320,9 +471,54 @@ function formatJson(value: unknown): string {
 .debug-btn:hover {
   background: var(--theme-card-bg);
 }
+.debug-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.debug-btn-sm {
+  padding: 2px 8px;
+  font-size: 0.6875rem;
+}
 .debug-section {
   border-bottom: 1px solid var(--theme-card-border);
   padding-bottom: 12px;
+}
+/* 随机事件表：一屏能扫完的密度，宽了就自己横滚（不许把面板撑破） */
+.debug-re-meta {
+  font-weight: 400;
+  color: var(--theme-text-muted);
+  font-size: 0.6875rem;
+  margin-left: 6px;
+}
+.debug-re-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.6875rem;
+  color: var(--theme-text-secondary);
+}
+.debug-re-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--theme-text-muted);
+  padding: 2px 6px 4px 0;
+  border-bottom: 1px solid var(--theme-card-border);
+}
+.debug-re-table td {
+  padding: 3px 6px 3px 0;
+  vertical-align: middle;
+}
+.debug-re-pill {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 5px;
+  border-radius: 8px;
+  font-size: 0.5625rem;
+  background: color-mix(in srgb, var(--theme-primary) 18%, transparent);
+  color: var(--theme-primary);
+}
+.debug-re-dim {
+  margin-left: 4px;
+  color: var(--theme-text-muted);
 }
 .debug-section h4 {
   font-size: 0.8125rem;

--- a/src/ui/components/game/random-event-debug.test.ts
+++ b/src/ui/components/game/random-event-debug.test.ts
@@ -1,0 +1,156 @@
+/**
+ * random-event-debug.test.ts — 调试面板随机事件表的展示层判定
+ *
+ * 为什么值得单独测：这块表的**全部价值**是「面板上的数字与调度器真的会做的事一致」。
+ * 它算错了不报错、也不会让任何功能失灵 —— 只会让人拿着一份错数字去怀疑调度器，
+ * 或者反过来放过一条本来就不该出现的事件。所以三件事逐条钉住：
+ *   · 日概率与 `rollRandomEvents` **同式同顺序**（频率在 `min` 里面）
+ *   · `available` 与 `once` 是调度器真正的早退条件 → 表里也必须过滤掉
+ *   · 权重 ×0 原样报出（不是「过滤掉」）—— 「事件存在但此时此地不可触发」是要看得见的
+ *
+ * 夹具全用中性英文词（同 `random-event-scheduler.test.ts` 的口径）：事件名与地点名都是
+ * 内容包数据，写真名会让人误以为引擎认识它们。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRandomEventDebugRows,
+  formatDailyProbability,
+  formatEventWeight,
+} from './random-event-debug';
+import type {
+  RandomEventDef,
+  RandomEventRollContext,
+  RandomEventSaveFlags,
+} from '@engine/types-random-events';
+
+const CTX: RandomEventRollContext = { placeKey: 'Harbor', playerLevel: 5, journeyActive: false };
+
+function mtth(name: string, mtthDays: number, extra: Partial<RandomEventDef> = {}): RandomEventDef {
+  return { name, brief: `${name}.`, trigger: { type: 'mtth', mtthDays }, ...extra };
+}
+
+function firstVisit(name: string, places: string[]): RandomEventDef {
+  return { name, brief: `${name}.`, trigger: { type: 'first_visit', scope: { anyOf: places } } };
+}
+
+function rows(
+  defs: RandomEventDef[],
+  flags: RandomEventSaveFlags = {},
+  frequency = 1,
+  ctx: RandomEventRollContext = CTX,
+) {
+  return buildRandomEventDebugRows(defs, flags, ctx, frequency);
+}
+
+describe('buildRandomEventDebugRows —— 谁进表', () => {
+  it('available 不满足的定义不进表（调度器根本不会考虑它）', () => {
+    const defs = [mtth('Open', 10), mtth('Gated', 10, { available: { playerLevel: { gte: 99 } } })];
+    expect(rows(defs).map((r) => r.name)).toEqual(['Open']);
+  });
+
+  it('once 已烧掉的不进表（一条早就用过的独特事件不该挂在「可触发」里）', () => {
+    const defs = [mtth('Once', 10, { once: true }), mtth('Again', 10)];
+    const flags: RandomEventSaveFlags = { fired: { Once: { count: 1, lastDay: 3 } } };
+    expect(rows(defs, flags).map((r) => r.name)).toEqual(['Again']);
+  });
+
+  it('🔴 权重 ×0 的**要**进表并原样报 0 —— 「存在但此时此地不可触发」得看得见', () => {
+    const def = mtth('Zeroed', 10, { weights: [{ when: { journey: true }, multiply: 0 }] });
+    // journeyActive: false → 这条修正不命中 → 权重仍是 1
+    expect(rows([def])[0].weight).toBe(1);
+
+    const inJourney = rows([def], {}, 1, { ...CTX, journeyActive: true })[0];
+    expect(inJourney.weight).toBe(0);
+    expect(inJourney.dailyProbability).toBe(0);
+  });
+
+  it('个体冷却不作为过滤条件（它按天解开，藏起来会让人以为事件消失了）', () => {
+    const defs = [mtth('Cooling', 10, { cooldownDays: 30 })];
+    const flags: RandomEventSaveFlags = { fired: { Cooling: { count: 1, lastDay: 1 } } };
+    expect(rows(defs, flags).map((r) => r.name)).toEqual(['Cooling']);
+  });
+
+  it('坏定义整条跳过，不抛（定义来自第三方内容包）', () => {
+    const defs = [
+      { name: '', brief: 'x', trigger: { type: 'mtth', mtthDays: 5 } } as RandomEventDef,
+      { name: 'NoTrigger', brief: 'x' } as unknown as RandomEventDef,
+      mtth('Fine', 5),
+    ];
+    expect(rows(defs).map((r) => r.name)).toEqual(['Fine']);
+  });
+
+  it('顺序 = 包里的书写顺序（每次打开都重排的表读起来像在闪烁）', () => {
+    expect(rows([mtth('C', 1), mtth('A', 9), mtth('B', 3)]).map((r) => r.name)).toEqual([
+      'C',
+      'A',
+      'B',
+    ]);
+  });
+});
+
+describe('buildRandomEventDebugRows —— 各列的数', () => {
+  it('🔴 日概率与 rollRandomEvents 同式：频率先乘进权重，再夹上界', () => {
+    // w=1, mtth=10, freq=2 → min(1, 2/10) = 0.2（若写成 min(1, 1/10)×2 也是 0.2，故再取一组）
+    expect(rows([mtth('A', 10)], {}, 2)[0].dailyProbability).toBeCloseTo(0.2, 10);
+    // w=1, mtth=2, freq=4 → min(1, 4/2) = 1；错式 min(1, 1/2)×4 = 2（还越了界）
+    expect(rows([mtth('B', 2)], {}, 4)[0].dailyProbability).toBe(1);
+  });
+
+  it('权重列**不含**频率系数（那是全局旋钮，不是这条事件的情境权重）', () => {
+    const def = mtth('A', 10, { weights: [{ when: {}, multiply: 3 }] });
+    const row = rows([def], {}, 2)[0];
+    expect(row.weight).toBe(3);
+    expect(row.dailyProbability).toBeCloseTo(0.6, 10);
+  });
+
+  it('first_visit：报地点、日概率不适用（null，不是 0）', () => {
+    const row = rows([firstVisit('Arrival', ['Harbor', 'Keep'])])[0];
+    expect(row.kind).toBe('first_visit');
+    expect(row.places).toEqual(['Harbor', 'Keep']);
+    expect(row.dailyProbability).toBeNull();
+  });
+
+  it('mtthDays 认不出（0 / 负数）→ 概率 null：调度器对它整条 continue', () => {
+    expect(rows([mtth('A', 0)])[0].dailyProbability).toBeNull();
+    expect(rows([mtth('B', -1)])[0].dailyProbability).toBeNull();
+  });
+
+  it('inPool 原样报告池里有没有这个名字（不替它判活）', () => {
+    const flags: RandomEventSaveFlags = {
+      pending: [{ name: 'A', armedDay: 0, expiresDay: 1, priority: 0, brief: 'x' }],
+    };
+    const out = rows([mtth('A', 10), mtth('B', 10)], flags);
+    expect(out.map((r) => [r.name, r.inPool])).toEqual([
+      ['A', true],
+      ['B', false],
+    ]);
+  });
+
+  it('priority 缺席读作 0（§3.1 默认值）', () => {
+    expect(rows([mtth('A', 10), mtth('B', 10, { priority: 7 })]).map((r) => r.priority)).toEqual([
+      0, 7,
+    ]);
+  });
+});
+
+describe('格式化', () => {
+  it('权重：整数直出、小数留两位（浮点尾巴会把表挤歪）', () => {
+    expect(formatEventWeight(1)).toBe('1');
+    expect(formatEventWeight(0)).toBe('0');
+    expect(formatEventWeight(0.7200000000000001)).toBe('0.72');
+  });
+
+  it('🔴 极小概率报 `<0.1%` 而不是 0.0% —— 与「权重 ×0 根本不掷」必须分得开', () => {
+    expect(formatDailyProbability(0)).toBe('0%');
+    expect(formatDailyProbability(1e-9)).toBe('<0.1%');
+    expect(formatDailyProbability(0.25)).toBe('25.0%');
+    expect(formatDailyProbability(1)).toBe('100.0%');
+  });
+
+  it('不适用 / 非有穷 → 破折号', () => {
+    expect(formatDailyProbability(null)).toBe('—');
+    expect(formatEventWeight(Number.NaN)).toBe('—');
+  });
+});

--- a/src/ui/components/game/random-event-debug.ts
+++ b/src/ui/components/game/random-event-debug.ts
@@ -1,0 +1,117 @@
+/**
+ * random-event-debug.ts — 调试面板「随机事件」区块的**展示层判定**（纯函数，不 mount 可测）
+ *
+ * 装什么: 「现在有哪些事件是调度器会考虑的，各自多大概率」这一个问题的投影 ——
+ *         `buildRandomEventDebugRows` 把内容包定义 + 存档 flags + 只读上下文压成一张表，
+ *         外加两个数字格式化器。
+ * 不装什么: **任何判据的第二实现**。硬门槛走 `evaluateEventCondition`、权重走
+ *           `computeEventWeight`、上下文走 `buildRandomEventRollContext`（组件里调）——
+ *           全是生产函数。调试面板照抄一份判据是最坏的一种重复：它会在真机上**说谎**，
+ *           而说谎的正是那块用来查真相的面板。
+ *
+ * 🔴 日概率必须与 `rollRandomEvents` **同一个算式同一个顺序**：
+ *    `p = min(1, computeEventWeight(def, ctx, frequency) / mtthDays)`。
+ *    频率系数在 `min` **里面**（先乘进权重再夹上界），写成 `min(1, w/mtth) × freq` 在
+ *    高权重事件上会给出不同的数 —— 那种误差不报错，只是让人拿着面板上的数字去怀疑调度器。
+ *
+ * 🔴 这一层**不做过期/权重 0 的撤池判定**（`isPendingStillValid` 那一套）：本区块回答的是
+ *    「调度器会不会考虑它」，不是「池里那条还活着吗」。`inPool` 只是原样报告池里有没有这个
+ *    名字，不替它判活。
+ */
+
+import { computeEventWeight, evaluateEventCondition } from '@engine/random-event-scheduler';
+import type {
+  RandomEventDef,
+  RandomEventRollContext,
+  RandomEventSaveFlags,
+} from '@engine/types-random-events';
+
+/** 表里的一行。中文措辞全在组件模板里，本层只出结构与数字 */
+export interface RandomEventDebugRow {
+  name: string;
+  priority: number;
+  kind: 'mtth' | 'first_visit';
+  /** 仅 mtth */
+  mtthDays?: number;
+  /** 仅 first_visit：作者点名的地点键 */
+  places?: string[];
+  /** 权重链乘积，**不含频率系数**（×0 原样报出：那正是「此时此地不可触发」） */
+  weight: number;
+  /** 每日触发概率；`first_visit` 与 mtthDays 不可用时为 `null`（不适用，不是 0） */
+  dailyProbability: number | null;
+  /** 名字现在在候选池里（原样报告，不判活） */
+  inPool: boolean;
+}
+
+/**
+ * 「调度器现在会考虑的事件」= 通过 `available` 硬门槛、且没被 `once` 消耗掉的全部定义。
+ *
+ * 顺序 = 包里的书写顺序（稳定；每次打开面板都重排的表读起来像在闪烁）。
+ *
+ * 🔴 `available` 与 `once` 这两条**是调度器真正的早退条件**（`rollRandomEvents` 里那两个
+ *    `continue` / `selectFirstVisitDef` 里那两条），所以两者都要过 —— 只过 `available`
+ *    会让一条早就烧掉的独特事件永远挂在「可触发」里。
+ * 🔴 个体冷却（`cooldownDays`）**刻意不作为过滤条件**：它是按天算的、随下一次时间推进就
+ *    会解开，把它做成「不显示」会让人以为事件消失了。它属于「现在掷不中」，与 ×0 同类。
+ */
+export function buildRandomEventDebugRows(
+  defs: readonly RandomEventDef[],
+  flags: RandomEventSaveFlags,
+  ctx: RandomEventRollContext,
+  frequency: number,
+): RandomEventDebugRow[] {
+  const pending = new Set((flags?.pending ?? []).map((entry) => entry?.name));
+  const fired = flags?.fired ?? {};
+  const rows: RandomEventDebugRow[] = [];
+
+  for (const def of defs) {
+    if (!def || typeof def.name !== 'string' || def.name.length === 0) continue;
+    if (!def.trigger) continue;
+    if (def.once === true && fired[def.name] !== undefined) continue;
+    if (def.available !== undefined && !evaluateEventCondition(def.available, ctx)) continue;
+
+    const row: RandomEventDebugRow = {
+      name: def.name,
+      priority:
+        typeof def.priority === 'number' && Number.isFinite(def.priority) ? def.priority : 0,
+      kind: def.trigger.type,
+      weight: computeEventWeight(def, ctx, 1),
+      dailyProbability: null,
+      inPool: pending.has(def.name),
+    };
+
+    if (def.trigger.type === 'mtth') {
+      const mtthDays = def.trigger.mtthDays;
+      row.mtthDays = mtthDays;
+      if (typeof mtthDays === 'number' && Number.isFinite(mtthDays) && mtthDays > 0) {
+        // 与 rollRandomEvents 逐字同式：频率先乘进权重，再夹上界
+        row.dailyProbability = Math.min(1, computeEventWeight(def, ctx, frequency) / mtthDays);
+      }
+    } else {
+      row.places = Array.isArray(def.trigger.scope?.anyOf) ? def.trigger.scope.anyOf : [];
+    }
+
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+/** 权重：整数直出，小数留两位（一串 `0.7200000000000001` 会把表挤歪） */
+export function formatEventWeight(weight: number): string {
+  if (!Number.isFinite(weight)) return '—';
+  return Number.isInteger(weight) ? String(weight) : weight.toFixed(2);
+}
+
+/**
+ * 日概率百分比。
+ *
+ * 🔴 极小值报 `<0.1%` 而不是四舍五入成 `0.0%`：后者与「权重 ×0 = 根本不掷」长得一模一样，
+ *    而这两件事在排查时要分得开。
+ */
+export function formatDailyProbability(probability: number | null): string {
+  if (probability === null || !Number.isFinite(probability)) return '—';
+  if (probability <= 0) return '0%';
+  if (probability < 0.001) return '<0.1%';
+  return `${(probability * 100).toFixed(1)}%`;
+}

--- a/src/ui/stores/game-store.ts
+++ b/src/ui/stores/game-store.ts
@@ -1202,6 +1202,26 @@ export const useGameStore = defineStore('game', () => {
     return result.success ? { ok: true } : { ok: false, error: result.errors.join('; ') };
   }
 
+  /**
+   * 调试面板「下回合触发」：把一条随机事件按 forced 塞进候选池（开发者模式专用）。
+   *
+   * 校验与落库全在引擎的 `devForceArmRandomEvent`（ADR-21 唯一写入口）；本层只解析「谁」
+   * 并回读 —— 不回读的话调试面板上那条「在池」标记要等下一次时间推进才亮，
+   * 而这个按钮的全部价值就是**立刻**看到它进池了。
+   */
+  async function devArmRandomEvent(name: string): Promise<{ ok: boolean; error?: string }> {
+    if (!activeSaveId.value) return { ok: false, error: '无活跃存档' };
+    try {
+      const sm = createStateManager(activeSaveId.value);
+      const result = await sm.devForceArmRandomEvent(name);
+      if (result.ok) await refreshFromDb();
+      return result;
+    } catch (err) {
+      console.error('[game-store] 随机事件调试入池失败:', err);
+      return { ok: false, error: '调试入池失败' };
+    }
+  }
+
   return {
     saves,
     activeSaveId,
@@ -1295,5 +1315,6 @@ export const useGameStore = defineStore('game', () => {
     removeSkill,
     removeCharacter,
     setPlayerLocation,
+    devArmRandomEvent,
   };
 });


### PR DESCRIPTION
## 概要

游戏页调试面板（开发者模式 + Alt+Shift+D）新增「随机事件」分区。范围经主人裁定收窄到三样，别的都不做：

1. **可用事件表**：只列当前 `available` 硬门槛通过的事件 —— 名字 / 触发（mtth 天数或首访）/ 当前权重连乘 / 日概率（`min(1, w/mtth) × 频率档`），已入池的带「在池」标
2. **MTTH 因子活体求值**：读侧全部复用生产 `evaluateEventCondition` / `computeEventWeight`（零第二实现）
3. **「下回合触发」按钮**：`game-store.devArmRandomEvent` → StateManager 具名 dev 方法 `devForceArmRandomEvent`（ADR-21，不进工具表、AI 不可见）→ 调度器新纯函数 `armRandomEventForced`（真实槽位采样固化 brief / `forced: true` 免疫淘汰与 TTL / 同名先撤再入池 / 种子随机零时钟）。渲染层复用既有 forced 必演指令行，零改动

## 验证

- 新增 39 测试（调度器 9 / state-manager 7 / 行构建纯函数 15 / 面板组件 8），全量 **335 文件 / 8575 tests / 0 失败**
- typecheck / typecheck:vue / typecheck:tools / build / lint 全过
- **真机走查过**（Vite dev + 真 IndexedDB 测试存档）：分区渲染与四列数值 ✅ / available 过滤（占位包两条事件，夜半叩门被 `sys.安顿下来` 门槛拦下只列一条）✅ / 按钮入池 → `worldFlags.randomEvents.pending` 落库（forced: true + 槽位已采样固化 + 无过期日）+ 「在池」标 ✅

## 已知行为（有意，非缺陷）

dev 入池条目带当前地点键，触发前离开该地点会被「离开即撤」规则撤下（与首访 forced 同规则）—— 调试旅途回合先按按钮再动身。

🤖 Generated with [Claude Code](https://claude.com/claude-code)