### PR TITLE
fix(prompt): 快照回退/重开战斗后失效 prompt session 防旧分支正文残留

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ## 进行中 / 近期交付（按交付时间倒序）
 
+### Delta 会话 v1 真机 bug：快照回退/重开战斗未失效 prompt session 致旧分支正文残留｜ ✅ 已修复（2026-08-23）
+
+主人在真机验收 delta 会话时发现：同一轮 roll 出不满意的分支后回退快照再重新 roll，新正文里残留上一分支的台词（22:44 分支幻说「天亮前到东门等我」，回退到 15:17 再 roll 的 22:50 分支里妲丽安复述「她只说了天亮前到东门等她」）。根因两层：
+
+1. **回退不清 session**：`game-store.ts` 的 `rollbackOneTurn` / `restoreToSnapshot` / `restartCombat` 恢复快照只还原 Dexie 权威状态，但 delta session 的 transcript 是跨轮累积的**内存态**，仍躺着被回退掉那轮的 user/assistant —— 重新发送时 `preparePromptSession` 复用旧 transcript，把「上一分支」的正文当上下文喂给模型。T4 的清理只挂在 `GamePage.onUnmounted`（离开游戏页才清），回退不离开页面。
+2. **NARRATIVE append cursor 恰好检测不到**：每轮投影在 `buildContext` 时构建（先于 `emitMessage`，不含本轮 user 消息），回退后重新 roll 的投影与上一轮记录的投影完全一致 → `diffNarrative` 判「无变化」→ 不触发 rebase。
+
+**修复**：三个回退点成功恢复后调 `invalidatePromptSession(saveId)`（传 string = 清该存档全部 session），下一轮 `prepare` 发现 session 已删 → 走 `missing_session` 重基线，从当前权威状态完整重建，不留尾巴。补三个断言测试。
+
+**验证**：`npm run gates` 八道全绿，**355 文件 9169 tests 通过 + 8 skipped**。
+
 ### LLM 组装层 Delta 会话 v1｜ ✅ 已实施，真机运营验收待执行（2026-08-23）
 
 主 DAG 普通 chat/chatStream 接入 **delta session**：七个主 DAG Agent（memory_recall 聊天路径 / plot_pre_check / story / request_dispatcher / memory_summary / vars_update / plot_post_check）首轮沿用现有完整 prompt 渲染（首轮 user 消息保留「继续」触发 + code 固定增量协议说明 + 可选 `tailPrompt`），后续成功轮复用该 Agent 的实际 wire transcript，只追加一条 user 增量消息（`<context_delta>` + `<turn_context>` + 可选 `tailPrompt`）；目标是把多个 Agent 各自重复携带的动态后缀从每轮成本里拆掉，预热后主 DAG 每回合 `prompt_cache_miss_tokens` 控制在 30,000 以内（真机验收项）。

--- a/src/ui/stores/game-store.test.ts
+++ b/src/ui/stores/game-store.test.ts
@@ -42,6 +42,13 @@ vi.mock('@engine/attribute-allocation', () => ({
   allocateAttributePoint: allocateAttributePointMock,
 }));
 
+// 🔴 2026-08-23 真机 bug：快照回退/重开战斗后必须失效 prompt session（delta transcript
+// 残留旧分支正文）。这里替身掉 invalidatePromptSession，断言三个回退点都把它叫到。
+const invalidatePromptSessionMock = vi.hoisted(() => vi.fn());
+vi.mock('@engine/prompt-session-assembler', () => ({
+  invalidatePromptSession: invalidatePromptSessionMock,
+}));
+
 // ===== 辅助 =====
 
 const SAVE_ID = 'save-refresh-test';
@@ -349,6 +356,7 @@ describe('rollbackOneTurn / restoreToSnapshot', () => {
     }
     await initializeDatabase();
     store = makeStore();
+    invalidatePromptSessionMock.mockClear();
   });
 
   /** 种入两回合：存档当前在 turn2，并有一张 turn1 快照(上一轮状态) */
@@ -435,6 +443,8 @@ describe('rollbackOneTurn / restoreToSnapshot', () => {
     expect(store.saveProfile?.fp).toBe(5);
     // totalTurns 对齐到快照 turn
     expect(store.activeSave?.metadata?.totalTurns).toBe(1);
+    // 🔴 2026-08-23 bug：回退后必须失效该存档 prompt session（防 delta transcript 残留旧分支）
+    expect(invalidatePromptSessionMock).toHaveBeenCalledWith(SAVE_ID);
   });
 
   it('rollbackOneTurn: 战斗中拒绝回退', async () => {
@@ -486,6 +496,8 @@ describe('rollbackOneTurn / restoreToSnapshot', () => {
     // 状态恢复到 turn1 快照
     expect(store.characters.find((c) => c.id === 'hero')?.hp).toBe(80);
     expect(store.activeSave?.metadata?.totalTurns).toBe(1);
+    // 🔴 2026-08-23 bug：恢复快照后必须失效该存档 prompt session
+    expect(invalidatePromptSessionMock).toHaveBeenCalledWith(SAVE_ID);
   });
 
   // 🔴 2026-08-08 真机：恢复后内存角色必须**整表替换**。refreshFromDb 的角色同步是
@@ -813,6 +825,7 @@ describe('M2 v3 战斗接线', () => {
     );
 
     let restarted = false;
+    invalidatePromptSessionMock.mockClear();
     store.setCombatCoordinator({
       abandon: () => {},
       preSnapshotId: 'snap-pre-combat',
@@ -830,6 +843,8 @@ describe('M2 v3 战斗接线', () => {
     expect(store.isInCombat).toBe(false);
     expect(store.characters.find((c) => c.id === 'hero')?.hp).toBe(80); // 快照恢复
     expect(store.activeSave?.metadata?.totalTurns).toBe(2); // totalTurns 对齐快照 turn
+    // 🔴 2026-08-23 bug：重开战斗（恢复开战前快照）后必须失效该存档 prompt session
+    expect(invalidatePromptSessionMock).toHaveBeenCalledWith(SAVE_ID);
   });
 
   it('restartCombat：没有 pre-combat 快照时拒绝（不静默）', async () => {

--- a/src/ui/stores/game-store.ts
+++ b/src/ui/stores/game-store.ts
@@ -27,6 +27,7 @@ import {
 } from '@engine/database';
 import { saveMessage, getMessages, saveSaveSlot } from '@engine/database';
 import { createStateManager } from '@engine/state-manager';
+import { invalidatePromptSession } from '@engine/prompt-session-assembler';
 import { allocateAttributePoint } from '@engine/attribute-allocation';
 import type { AllocatableAttr } from '@engine/attribute-allocation';
 import { detach } from './db-write';
@@ -372,6 +373,10 @@ export const useGameStore = defineStore('game', () => {
     await restoreMessages();
     const lastMsg = messages.value.filter((m) => m.role === 'user' || m.role === 'assistant').pop();
     turnCounter = lastMsg?.turn ?? 0;
+
+    // 🔴 同 rollbackOneTurn：重开战斗 = 恢复到开战前快照，权威状态回退。战斗结束后
+    //    回归普通回合的主 DAG session 必须失效重建，否则残留开战前/上一轮分支正文。
+    invalidatePromptSession(activeSaveId.value);
 
     // ③ 重触发 combat_trigger（pipeline 持 marker；异常不阻断恢复本身）
     if (restartFn) {
@@ -1121,6 +1126,13 @@ export const useGameStore = defineStore('game', () => {
     await restoreMessages();
     const lastMsg = messages.value.filter((m) => m.role === 'user' || m.role === 'assistant').pop();
     turnCounter = lastMsg?.turn ?? 0;
+
+    // 🔴 2026-08-23 真机 bug：回退快照后**必须失效 prompt session**。delta 会话的
+    // transcript 是跨轮累积的内存态，回退只恢复了 Dexie 里的权威状态，session 里
+    // 仍躺着被回退掉那轮的 user/assistant —— 重新发送会复用旧 transcript，把
+    // 「上一分支」的正文当上下文喂给模型（症状：重 roll 出的正文残留旧分支台词）。
+    // 失效后下一轮 prepare 发现 session 已删 → 从当前权威状态重基线，不留尾巴。
+    invalidatePromptSession(activeSaveId.value);
     return { ok: true };
   }
 
@@ -1137,6 +1149,10 @@ export const useGameStore = defineStore('game', () => {
     await restoreMessages();
     const lastMsg = messages.value.filter((m) => m.role === 'user' || m.role === 'assistant').pop();
     turnCounter = lastMsg?.turn ?? 0;
+
+    // 🔴 2026-08-23 真机 bug（同 rollbackOneTurn）：恢复到历史快照 = 权威状态回退，
+    //    必须失效该存档全部 prompt session，否则 delta transcript 残留旧分支正文。
+    invalidatePromptSession(activeSaveId.value);
     return { ok: true };
   }
 


### PR DESCRIPTION
## 变更说明

**真机 bug**：快照回退后重新 roll，新正文残留上一分支台词。回退点 [52] 处幻只问「你叫什么？」，但 22:50 分支里妲丽安却复述 22:44 分支才有的「天亮前到东门等她」。

**根因**：
1. delta session 的 transcript 是跨轮累积的**内存态**，快照回退只还原 Dexie 权威状态，session 里仍躺着被回退掉那轮的 user/assistant —— 重新发送复用旧 transcript，把旧分支正文喂给模型
2. NARRATIVE append cursor 恰好检测不到这次回退（每轮投影在 buildContext 时构建、不含本轮 user，回退后投影与上一轮记录完全一致 → 不触发 rebase）
3. T4 的清理只挂 GamePage onUnmounted（离开游戏页才清），回退不离开页面

**修复**：三个回退点（rollbackOneTurn / restoreToSnapshot / restartCombat）成功恢复后调 \invalidatePromptSession(saveId)\，下一轮 prepare 走 missing_session 重基线，从当前权威状态完整重建。

## 检查清单

- [x] \
pm run typecheck\ + \
pm run test:run\ 本地通过
- [x] 文档同步检查：CHANGELOG 已追加条目
- [x] 新修复已配套断言测试（三个回退点各一条 invalidate 断言）
- [x] \
pm run gates\ 八道全绿：355 文件 9169 tests 通过 + 8 skipped

## Agent 产出

- 工具：opencode
- 人工复核：主人
- 验证方式：全量 gates + 测试断言（未真机重走，属同一逻辑路径的回归修复）