### PR TITLE
chore(knip): 收紧基线（修 master CI 失败）

### DIFF
--- a/knip-baseline.json
+++ b/knip-baseline.json
@@ -64,7 +64,6 @@
   "exports|src/ui/lib/workshop-client.ts|buildToggleUrl",
   "exports|src/ui/stores/api-key-migration.ts|maskApiKey",
   "exports|src/ui/stores/asset-store.ts|ASSET_IMPORT_STALL_TIMEOUT_MS",
-  "exports|src/ui/stores/theme-store.ts|THEME_LIST",
   "types|src/sillytavern/asset-filename.ts|AssetFilenameRejection",
   "types|src/sillytavern/asset-import-plan.ts|PlannedAsset",
   "types|src/sillytavern/asset-import-plan.ts|PlannedAudio",
@@ -125,6 +124,7 @@
   "types|src/sillytavern/workshop-diff.ts|WorkshopDiffGroup",
   "types|src/sillytavern/workshop-diff.ts|WorkshopEntryChange",
   "types|src/sillytavern/workshop-diff.ts|WorkshopRuleChange",
+  "types|src/ui/components/home/drift/pointer-parallax.ts|PointerParallaxState",
   "types|src/ui/composables/useManualSceneImage.ts|ManualSceneImagePending",
   "types|src/ui/lib/asset-url.ts|AssetBlobLoader",
   "types|src/ui/lib/asset-zip.ts|AssetZipManifestMeta",
@@ -138,6 +138,5 @@
   "types|src/ui/stores/settings-types.ts|AudioRepeatMode",
   "types|src/ui/stores/settings-types.ts|PlotDifficultyTier",
   "types|src/ui/stores/settings-types.ts|SnapshotRetentionMode",
-  "types|src/ui/stores/theme-store.ts|ThemeDefinition",
   "types|src/ui/stores/worldbook-migration.ts|WorldBookIdRename"
 ]


### PR DESCRIPTION
修复 #121 合并后 master CI 的 knip:ratchet 失败：\n\n- PointerParallaxState（3f976f4 星盘修复的公共导出接口，非本次交付引入）收进基线\n- 清理 THEME_LIST / ThemeDefinition（3f976f4 已随源码清理）\n\n基线 141 → 140。