### PR TITLE
feat(debug): persist and export ten-turn agent history

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## 进行中 / 近期交付（按交付时间倒序）
 
+### DebugPanel 最近 10 回合完整调用历史｜ ✅ 已实施，待真机（2026-08-25）
+
+修复 debug 导出只剩当前回合、同名 `char_gen` / `item_gen` 侧链互相覆盖的问题：每次 Agent 调用改以回合活动 ID + Agent + 序号组成 `invocationId`，Dexie v24 新增 `debugTurns` 按存档持久化并原子淘汰到最近 10 回合，删存档时级联删除且不进入日常 FullBackup。`chatWithTools` 额外保留每轮真实 provider usage，主 DAG 的 Delta revision / 重基线原因也贯通到面板与 JSON。DebugPanel 可切换 10 回合查看，汇总纳入 `memory_recall`；导出新增 `agentHistory`，同时保留最新回合 `agentLog` 兼容旧分析脚本。
+
 ### 重铸系统：单条目物品/技能/装备主动重写｜ ✅ 已实施（2026-08-24）
 
 主人需求：玩家主动重新生成角色的物品/技能（给定已知条目 + 可选用户描述做 debug 线索，如「火球术伤害不对，应该 400 能量伤害却只有 200 物理伤害」）。三处既有疑点一并查证/修复：**NPC 角色面板（CharacterListPanel）确实缺背包 tab**（CharacterViewerModal 有）、**查看脚本是旧版**（只取第一个条目的 scripts，主角 ItemsPanel 是新版 scripts + modifiers/automata JSON）、CharacterViewerModal 完全没有脚本查看。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,9 +9,11 @@
 
 ## 进行中 / 近期交付（按交付时间倒序）
 
-### DebugPanel 最近 10 回合完整调用历史｜ ✅ 已实施，待真机（2026-08-25）
+### DebugPanel 最近 10 回合完整调用历史｜ ✅ 已实施，真机通过（2026-08-25）
 
 修复 debug 导出只剩当前回合、同名 `char_gen` / `item_gen` 侧链互相覆盖的问题：每次 Agent 调用改以回合活动 ID + Agent + 序号组成 `invocationId`，Dexie v24 新增 `debugTurns` 按存档持久化并原子淘汰到最近 10 回合，删存档时级联删除且不进入日常 FullBackup。`chatWithTools` 额外保留每轮真实 provider usage，主 DAG 的 Delta revision / 重基线原因也贯通到面板与 JSON。DebugPanel 可切换 10 回合查看，汇总纳入 `memory_recall`；导出新增 `agentHistory`，同时保留最新回合 `agentLog` 兼容旧分析脚本。
+
+PR 审查补强：失败回调现在携带完整 `AgentResult`，不会再用空响应与零 usage 覆盖已计费调用；Embedding 召回和记忆向量化均记录请求、模型、耗时及 provider token usage，其中向量响应只导出维度与 usage 摘要、不落整段向量。`debugTurns` 写入纳入 `withSaveWriteLock`，回合选择器补可访问名称并统一使用主题间距 token。
 
 ### 重铸系统：单条目物品/技能/装备主动重写｜ ✅ 已实施（2026-08-24）
 

--- a/docs/reference/debug-loop-handbook.md
+++ b/docs/reference/debug-loop-handbook.md
@@ -25,7 +25,7 @@
 
 | 文件 | 说明 | 来源 |
 |------|------|------|
-| `fated-poem-debug-*.json` | Agent 日志导出（`agentHistory` 含当前存档最近 **10 回合**的每次调用：messages、rawResponse、duration、usage、工具轮次与 Delta 诊断；`agentLog` 兼容指向最新回合；另含整张 `agents` 设置表与 EJS 三类诊断） | 游戏页 DebugPanel 导出按钮（`src/ui/components/game/DebugPanel.vue`） |
+| `fated-poem-debug-*.json` | Agent 日志导出（`agentHistory` 含当前存档最近 **10 回合**的每次调用：messages、rawResponse、duration、usage、工具轮次与 Delta 诊断，并单列 `memory_embedding` 与 `memory_recall` 的 Embedding provider usage；`agentLog` 兼容指向最新回合；另含整张 `agents` 设置表与 EJS 三类诊断） | 游戏页 DebugPanel 导出按钮（`src/ui/components/game/DebugPanel.vue`） |
 | `log.txt` | 浏览器 Console 日志（含 console.log/error/warn） | 浏览器 F12 Console 复制 |
 
 **命名约定**：保持 debug JSON 自动生成的文件名不变，方便追溯。

--- a/docs/reference/debug-loop-handbook.md
+++ b/docs/reference/debug-loop-handbook.md
@@ -25,7 +25,7 @@
 
 | 文件 | 说明 | 来源 |
 |------|------|------|
-| `fated-poem-debug-*.json` | Agent 日志导出（含本局跑过的**全部** Agent 的 messages、rawResponse、duration、tokensUsed；另含整张 `agents` 设置表与 EJS 三类诊断） | 游戏页 DebugPanel 导出按钮（`src/ui/components/game/DebugPanel.vue`） |
+| `fated-poem-debug-*.json` | Agent 日志导出（`agentHistory` 含当前存档最近 **10 回合**的每次调用：messages、rawResponse、duration、usage、工具轮次与 Delta 诊断；`agentLog` 兼容指向最新回合；另含整张 `agents` 设置表与 EJS 三类诊断） | 游戏页 DebugPanel 导出按钮（`src/ui/components/game/DebugPanel.vue`） |
 | `log.txt` | 浏览器 Console 日志（含 console.log/error/warn） | 浏览器 F12 Console 复制 |
 
 **命名约定**：保持 debug JSON 自动生成的文件名不变，方便追溯。

--- a/src/sillytavern/AGENTS.md
+++ b/src/sillytavern/AGENTS.md
@@ -89,6 +89,7 @@ src/sillytavern/                    ← 核心引擎
   │          设置元数据（Agent 配置/主题/`beautifierBuiltinDisabled` 等）
   │   └── v24+: debugTurns（每存档最近 10 回合完整 Agent 调试历史）——按 invocationId
   │              保留同名侧链的每次调用、agentic provider 往返 usage 与 Delta 重基线诊断；
+  │              Embedding 召回/记忆向量化也记录真实 provider usage；写入服从 withSaveWriteLock；
   │              删存档级联删，不进 FullBackup（调试提示词/响应不混入日常备份）
   │
   ├── session-backup.ts             ← 单存档导出/导入：每存档表整取（清单同 deleteSaveSlot，字节不随行）+ 内容依赖清单（世界书 token / 工坊项目 / 内容包 / story 预设，导入前只读体检）+ 导入**一律重发 id**（不重发 = 第二次导入静默覆盖第一次），全局表一行不改

--- a/src/sillytavern/AGENTS.md
+++ b/src/sillytavern/AGENTS.md
@@ -25,7 +25,7 @@ src/sillytavern/                    ← 核心引擎
   │   │    `database.ts` 曾为标这一个类型反向 import 前端 store。create-store 侧 re-export 同名
   │   └── 辅助: createDefaultCharacterState() / resolvePlotTree()
   │
-  ├── database.ts                   ← Dexie/IndexedDB v23
+  ├── database.ts                   ← Dexie/IndexedDB v24
   │       🔴 `DB_VERSION` 常量必须等于最后一个 `this.version(n)`。它只出现在
   │          `FullBackup.version` 上、导入侧不拿它做判断，所以**对不上不会有任何报错**，
   │          只是每份导出的备份都盖了过期的戳。它曾经落后两版（v18/v19 忘了改），
@@ -82,11 +82,14 @@ src/sillytavern/                    ← 核心引擎
   │                 判据是载荷字段在不在、**不是版本号**。
   │              🔴 `preview` 不是第二个真源，只喂快照面板那一行字（主角 HP / 游戏内日期）；
   │                 任何逻辑一律读载荷。旧行缺席 = 那一行不显示，v22 升版时从载荷回填
-  │   └── v23+: apiRateLimitPolicies（全局 API RPM 策略）——按
+  │   ├── v23+: apiRateLimitPolicies（全局 API RPM 策略）——按
   │              `SHA-256(归一化 baseUrl + API Key)` 指纹存上限，不落明文密钥；进 FullBackup
   │       🔴 **世界书、美化规则与 API Key 现居应用 Dexie，不再在 localStorage**。正则 iframe
   │          只能经同步镜像访问 `regexStorage`，不能访问任何应用表；应用 localStorage 只存无密钥
   │          设置元数据（Agent 配置/主题/`beautifierBuiltinDisabled` 等）
+  │   └── v24+: debugTurns（每存档最近 10 回合完整 Agent 调试历史）——按 invocationId
+  │              保留同名侧链的每次调用、agentic provider 往返 usage 与 Delta 重基线诊断；
+  │              删存档级联删，不进 FullBackup（调试提示词/响应不混入日常备份）
   │
   ├── session-backup.ts             ← 单存档导出/导入：每存档表整取（清单同 deleteSaveSlot，字节不随行）+ 内容依赖清单（世界书 token / 工坊项目 / 内容包 / story 预设，导入前只读体检）+ 导入**一律重发 id**（不重发 = 第二次导入静默覆盖第一次），全局表一行不改
   │

--- a/src/sillytavern/agent-client.test.ts
+++ b/src/sillytavern/agent-client.test.ts
@@ -345,6 +345,64 @@ describe('AgentClient', () => {
     });
   });
 
+  describe('chatWithTools — provider 往返诊断', () => {
+    it('保留每一轮独立 usage，不只留下合计', async () => {
+      const responses = [
+        {
+          choices: [
+            {
+              message: {
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'lookup', arguments: '{"name":"Luna"}' },
+                  },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+          usage: {
+            total_tokens: 110,
+            prompt_tokens: 100,
+            prompt_cache_hit_tokens: 80,
+            prompt_cache_miss_tokens: 20,
+            completion_tokens: 10,
+          },
+        },
+        {
+          choices: [{ message: { content: 'done' }, finish_reason: 'stop' }],
+          usage: {
+            total_tokens: 215,
+            prompt_tokens: 200,
+            prompt_cache_hit_tokens: 150,
+            prompt_cache_miss_tokens: 50,
+            completion_tokens: 15,
+          },
+        },
+      ];
+      globalThis.fetch = vi.fn().mockImplementation(() => mockFetch(responses.shift())());
+
+      const result = await client.chatWithTools(
+        {
+          messages: [{ role: 'user', content: 'test' }],
+          tools: [
+            { type: 'function', function: { name: 'lookup', description: '', parameters: {} } },
+          ],
+        },
+        async () => ({ found: true }),
+      );
+
+      expect(result.tokensUsed).toBe(325);
+      expect(result.providerRounds).toEqual([
+        expect.objectContaining({ round: 1, tokensUsed: 110, cacheHitTokens: 80 }),
+        expect.objectContaining({ round: 2, tokensUsed: 215, cacheHitTokens: 150 }),
+      ]);
+    });
+  });
+
   describe('chat — 重试', () => {
     it('应在重试后成功', async () => {
       const retryClient = new AgentClient({

--- a/src/sillytavern/agent-client.ts
+++ b/src/sillytavern/agent-client.ts
@@ -10,7 +10,7 @@
  * - 🆕 Phase 8.5: chatWithTools() 多轮工具调用
  */
 
-import type { ApiEndpoint, AgentResult, ToolDefinition } from './types';
+import type { AgentProviderRound, ApiEndpoint, AgentResult, ToolDefinition } from './types';
 import { scheduleApiRequest } from './api-rpm-limiter';
 
 /** 内部扩展 — 包含原始 tool_calls 数据 */
@@ -247,6 +247,7 @@ export class AgentClient {
     let totalCacheMissTokens = 0;
     let totalCompletionTokens = 0;
     const allReasoning: string[] = []; // 跨轮次收集 reasoning
+    const providerRounds: AgentProviderRound[] = [];
 
     for (let round = 0; round < maxRounds; round++) {
       const roundRequest: ChatRequest = {
@@ -261,6 +262,18 @@ export class AgentClient {
       totalCacheHitTokens += innerResult.cacheHitTokens ?? 0;
       totalCacheMissTokens += innerResult.cacheMissTokens ?? 0;
       totalCompletionTokens += innerResult.completionTokens ?? 0;
+      providerRounds.push({
+        round: round + 1,
+        tokensUsed: innerResult.tokensUsed,
+        cacheHit: innerResult.cacheHit,
+        cacheHitTokens: innerResult.cacheHitTokens,
+        cacheMissTokens: innerResult.cacheMissTokens,
+        completionTokens: innerResult.completionTokens,
+        promptTokens: innerResult.promptTokens,
+        finishReason: innerResult.finishReason,
+        duration: innerResult.duration,
+        error: innerResult.error,
+      });
 
       // 收集每轮的 reasoning（不会被子调用覆盖）
       if (innerResult.reasoning) {
@@ -277,6 +290,7 @@ export class AgentClient {
           cacheMissTokens: totalCacheMissTokens,
           completionTokens: totalCompletionTokens,
           duration: Date.now() - startTime,
+          providerRounds,
         };
       }
 
@@ -343,6 +357,7 @@ export class AgentClient {
         completionTokens: totalCompletionTokens,
         duration: Date.now() - startTime,
         toolCalls: toolCallHistory,
+        providerRounds,
       };
     }
 
@@ -360,6 +375,7 @@ export class AgentClient {
       duration: Date.now() - startTime,
       error: `Exceeded max tool-calling rounds (${maxRounds})`,
       toolCalls: toolCallHistory,
+      providerRounds,
     };
   }
 

--- a/src/sillytavern/agent-orchestrator.test.ts
+++ b/src/sillytavern/agent-orchestrator.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentOrchestrator } from './agent-orchestrator';
 import type { AgentContext, AgentConfig, ApiEndpoint, Pipeline } from './types';
+import { deleteMemory, saveMemory } from './database';
 // T3: Delta 会话 module 的测试可观测入口（reset 保证每用例从干净 session 开始，
 // 不污染现有用例；activePromptSessionCount 断言「不创建 session」类排除路径）
 import { activePromptSessionCount, resetPromptSessionsForTest } from './prompt-session-assembler';
@@ -2684,6 +2685,19 @@ describe('AgentOrchestrator — Delta 会话接线（T3）', () => {
   });
 
   it('focused: memory_recall embedding 不创建 session（原路径）', async () => {
+    await saveMemory({
+      id: 'MEM-DEBUG-USAGE',
+      saveId: 'save_delta_embed',
+      createdAt: 1,
+      realTimestamp: 1,
+      timeRange: { start: '001-01-01', end: '001-01-01' },
+      content: '用于验证 embedding usage 进入调试历史的记忆。',
+      hiddenLine: '',
+      keywords: ['usage'],
+      relatedCharacterIds: [],
+      importance: 5,
+      embedding: [0.1, 0.2, 0.3],
+    });
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -2691,6 +2705,7 @@ describe('AgentOrchestrator — Delta 会话接线（T3）', () => {
       json: async () => ({
         data: [{ object: 'embedding', index: 0, embedding: [0.1, 0.2, 0.3] }],
         model: 'text-embedding-3-small',
+        usage: { prompt_tokens: 8, total_tokens: 8 },
       }),
       text: async () => '',
     });
@@ -2710,6 +2725,12 @@ describe('AgentOrchestrator — Delta 会话接线（T3）', () => {
     expect(r.error).toBeUndefined();
     expect(activePromptSessionCount()).toBe(0);
     expect(r.promptSessionRevision).toBeUndefined();
+    expect(r.tokensUsed).toBe(8);
+    expect(r.promptTokens).toBe(8);
+    expect(r.providerRounds).toEqual([
+      expect.objectContaining({ round: 1, tokensUsed: 8, promptTokens: 8 }),
+    ]);
+    await deleteMemory('MEM-DEBUG-USAGE');
   });
 
   it('focused: toolsEnabled 不创建 session（原路径）', async () => {

--- a/src/sillytavern/agent-orchestrator.ts
+++ b/src/sillytavern/agent-orchestrator.ts
@@ -822,6 +822,7 @@ export class AgentOrchestrator {
     );
 
     result.duration = Date.now() - startTime;
+    result.requestMessages = messages;
     return result;
   }
 

--- a/src/sillytavern/agent-orchestrator.ts
+++ b/src/sillytavern/agent-orchestrator.ts
@@ -33,7 +33,7 @@ import { AgentClient } from './agent-client';
 import type { ChatRequest } from './agent-client';
 import { buildAgentMessagesAsync } from './agent-templates';
 import { scanMarkers } from './marker-protocol';
-import { recallMemories } from './memory-store';
+import { recallMemories, type EmbeddingRequestTrace } from './memory-store';
 import { buildZoneContext } from './context-visibility';
 import { getToolsForAgent, executeToolCall } from './agent-tools';
 import { rescueStoryOutput } from './story-rescue';
@@ -76,7 +76,7 @@ export interface OrchestratorEvents {
   onStageStart?: (stageIndex: number, agents: string[]) => void;
   onAgentStart?: (agentId: string, config: AgentConfig) => void;
   onAgentComplete?: (result: AgentResult) => void | Promise<void>;
-  onAgentError?: (agentId: string, error: string) => void;
+  onAgentError?: (agentId: string, error: string, result?: AgentResult) => void;
   onStageComplete?: (stageIndex: number) => void;
   /** StatePatch 提交后存在失败项时触发（source = 'request_dispatcher' | 'vars_update' 等） */
   onStateCommitError?: (source: string, errors: string[]) => void;
@@ -397,7 +397,7 @@ export class AgentOrchestrator {
     this.results.set(agentId, result);
 
     if (result.error) {
-      this.events.onAgentError?.(agentId, result.error);
+      this.events.onAgentError?.(agentId, result.error, result);
     } else {
       await this.publishAgentCompletion(result);
     }
@@ -434,7 +434,7 @@ export class AgentOrchestrator {
         if (!result.error) {
           hasSuccess = (await this.publishAgentCompletion(result)) || hasSuccess;
         } else {
-          this.events.onAgentError?.(agentId, result.error);
+          this.events.onAgentError?.(agentId, result.error, result);
         }
       } else {
         const result: AgentResult = {
@@ -447,7 +447,7 @@ export class AgentOrchestrator {
           error: settled.reason?.message ?? String(settled.reason),
         };
         this.results.set(agentId, result);
-        this.events.onAgentError?.(agentId, result.error!);
+        this.events.onAgentError?.(agentId, result.error!, result);
       }
     }
 
@@ -839,13 +839,23 @@ export class AgentOrchestrator {
     const startTime = Date.now();
     const topK = 20; // 使用合理默认值，与 settings-store 的 memoryRecallCount 默认对齐
     const query = this.context.userInput || '';
+    let embeddingTrace: EmbeddingRequestTrace | undefined;
 
     try {
-      const recalled = await recallMemories(this.saveId, query, topK, {
-        baseUrl: endpoint.baseUrl,
-        apiKey: endpoint.apiKey,
-        defaultModel: config.model || endpoint.defaultModel,
-      });
+      const recalled = await recallMemories(
+        this.saveId,
+        query,
+        topK,
+        {
+          baseUrl: endpoint.baseUrl,
+          apiKey: endpoint.apiKey,
+          defaultModel: config.model || endpoint.defaultModel,
+        },
+        undefined,
+        (trace) => {
+          embeddingTrace = trace;
+        },
+      );
 
       // 格式化为与 LLM 路径兼容的输出结构
       const memories = recalled.map((r) => ({
@@ -862,8 +872,26 @@ export class AgentOrchestrator {
         agentId: config.agentId,
         output,
         rawResponse: JSON.stringify(output),
-        tokensUsed: 0, // Embedding API 按 token 计费但在 /chat/completions 口径下为 0
+        tokensUsed: embeddingTrace?.totalTokens ?? 0,
         cacheHit: false,
+        cacheMissTokens: embeddingTrace?.promptTokens,
+        promptTokens: embeddingTrace?.promptTokens,
+        completionTokens: 0,
+        requestMessages: [{ role: 'user', content: query }],
+        providerRounds: embeddingTrace
+          ? [
+              {
+                round: 1,
+                tokensUsed: embeddingTrace.totalTokens ?? 0,
+                cacheHit: false,
+                cacheMissTokens: embeddingTrace.promptTokens,
+                promptTokens: embeddingTrace.promptTokens,
+                completionTokens: 0,
+                duration: embeddingTrace.completedAt - embeddingTrace.startedAt,
+                error: embeddingTrace.error,
+              },
+            ]
+          : undefined,
         duration,
       };
     } catch (err) {
@@ -1000,7 +1028,7 @@ export class AgentOrchestrator {
       }`;
       result.error = message;
       this.context.agentOutputs!.delete(result.agentId);
-      this.events.onAgentError?.(result.agentId, message);
+      this.events.onAgentError?.(result.agentId, message, result);
       return false;
     }
   }

--- a/src/sillytavern/database.test.ts
+++ b/src/sillytavern/database.test.ts
@@ -60,6 +60,8 @@ import {
   getMessages,
   deleteMessagesBySaveId,
   deleteMessagesAfterTurn,
+  getDebugTurns,
+  saveDebugTurn,
   // Audio (v11)
   getAudioTracks,
   getAudioTrack,
@@ -104,6 +106,7 @@ import type {
   AssetMetaRecord,
   WorkshopProject,
   WorldBook,
+  DebugTurnRecord,
 } from './types';
 import { DEFAULT_SETTINGS } from './types';
 import Dexie from 'dexie';
@@ -1109,7 +1112,7 @@ describe('exportAllData / importAllData', () => {
     // v21：地图字节本地缓存 mapBlobs（2026-08-07，D23 补强；字节同不进备份）。
     // v22：快照拆表（snapshots 只留元数据 + snapshotPayloads 存整档载荷，两者都进备份）。
     // v23：API 凭据级 RPM 策略表。
-    expect(backup.version).toBe(23);
+    expect(backup.version).toBe(24);
     expect(Array.isArray(backup.lorebooks)).toBe(true);
     expect(Array.isArray(backup.presets)).toBe(true);
     expect(Array.isArray(backup.settings)).toBe(true);
@@ -2124,6 +2127,56 @@ describe('Messages CRUD (Phase 10h)', () => {
   });
 });
 
+describe('Debug turn history (v24)', () => {
+  const makeTurn = (saveId: string, turn: number): DebugTurnRecord => ({
+    id: `${saveId}:debug:${turn}`,
+    saveId,
+    turn,
+    status: 'completed',
+    startedAt: 1_800_000_000_000 + turn,
+    completedAt: 1_800_000_000_100 + turn,
+    entries: [
+      {
+        invocationId: `${saveId}:story:${turn}`,
+        turnId: `${saveId}:debug:${turn}`,
+        agentId: 'story',
+        label: '正文',
+        endpointId: 'ep',
+        endpointName: 'DeepSeek',
+        baseUrl: 'https://api.example.test',
+        model: 'model',
+        messages: [{ role: 'system', content: `prompt-${turn}` }],
+        rawResponse: `response-${turn}`,
+        tokensUsed: turn,
+        cacheHit: false,
+        duration: 10,
+        startedAt: 1_800_000_000_000 + turn,
+        completedAt: 1_800_000_000_010 + turn,
+      },
+    ],
+  });
+
+  it('持久化完整调用内容，并只保留每存档最近 10 回合', async () => {
+    for (let turn = 1; turn <= 12; turn++) await saveDebugTurn(makeTurn('save-debug', turn));
+    await saveDebugTurn(makeTurn('other-save', 1));
+
+    const rows = await getDebugTurns('save-debug');
+    expect(rows.map((row) => row.turn)).toEqual([3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    expect(rows[9].entries[0]).toEqual(
+      expect.objectContaining({
+        invocationId: 'save-debug:story:12',
+        messages: [{ role: 'system', content: 'prompt-12' }],
+        rawResponse: 'response-12',
+      }),
+    );
+    expect(await getDebugTurns('other-save')).toHaveLength(1);
+
+    await deleteSaveSlot('save-debug');
+    expect(await getDebugTurns('save-debug')).toHaveLength(0);
+    expect(await getDebugTurns('other-save')).toHaveLength(1);
+  });
+});
+
 // ========== v9: characters saveId 一等索引 (M1 #43) ==========
 
 describe('v9: characters saveId 一等索引', () => {
@@ -2759,8 +2812,8 @@ describe('Asset CRUD (v13)', () => {
     // ---- 以当前版 (AppDatabase) 打开：触发升版 ----
     await initializeDatabase();
     const db = getDatabase();
-    // v20=D18 contentPacks 表; v21=地图字节缓存; v22=快照拆表; v23=API RPM 策略
-    expect(db.verno).toBe(23);
+    // v20=D18 contentPacks; v21=地图字节; v22=快照拆表; v23=API RPM; v24=调试历史
+    expect(db.verno).toBe(24);
 
     // 表册齐全: v12 的 17 张 + 素材两张 + 工坊两张 + 美化规则一张 + 正则 KV 一张
     //           + 图像生成三张 + 角色外貌会话副本一张（v19/D56）
@@ -2783,6 +2836,7 @@ describe('Asset CRUD (v13)', () => {
       'mapBlobs',
       'snapshotPayloads',
       'apiRateLimitPolicies',
+      'debugTurns',
     ].sort();
     expect(db.tables.map((t) => t.name).sort()).toEqual(EXPECTED_TABLES);
 

--- a/src/sillytavern/database.test.ts
+++ b/src/sillytavern/database.test.ts
@@ -4,6 +4,7 @@
  * Uses fake-indexeddb (injected via src/test-setup.ts).
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { withSaveWriteLock } from './state-write-queue';
 import {
   getDatabase,
   initializeDatabase,
@@ -2174,6 +2175,23 @@ describe('Debug turn history (v24)', () => {
     await deleteSaveSlot('save-debug');
     expect(await getDebugTurns('save-debug')).toHaveLength(0);
     expect(await getDebugTurns('other-save')).toHaveLength(1);
+  });
+
+  it('与同存档的其他写入共用 withSaveWriteLock 队列', async () => {
+    let release!: () => void;
+    const held = withSaveWriteLock(
+      'save-locked-debug',
+      () => new Promise<void>((resolve) => (release = resolve)),
+    );
+    const pending = saveDebugTurn(makeTurn('save-locked-debug', 1));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(await getDebugTurns('save-locked-debug')).toHaveLength(0);
+
+    release();
+    await held;
+    await pending;
+    expect(await getDebugTurns('save-locked-debug')).toHaveLength(1);
   });
 });
 

--- a/src/sillytavern/database.ts
+++ b/src/sillytavern/database.ts
@@ -7,6 +7,7 @@
  */
 
 import Dexie, { Table } from 'dexie';
+import { withSaveWriteLock } from './state-write-queue';
 import type {
   Lorebook,
   ChatPreset,
@@ -2061,15 +2062,17 @@ export async function getDebugTurns(saveId: string): Promise<DebugTurnRecord[]> 
 
 /** 保存一回合的最新快照，并在同一事务内淘汰该存档最旧的超额记录。 */
 export async function saveDebugTurn(record: DebugTurnRecord): Promise<void> {
-  const db = getDatabase();
-  await db.transaction('rw', db.debugTurns, async () => {
-    await db.debugTurns.put(record);
-    const keys = await db.debugTurns
-      .where('[saveId+startedAt]')
-      .between([record.saveId, Dexie.minKey], [record.saveId, Dexie.maxKey], true, true)
-      .primaryKeys();
-    const overflow = keys.length - DEBUG_TURN_HISTORY_LIMIT;
-    if (overflow > 0) await db.debugTurns.bulkDelete(keys.slice(0, overflow));
+  await withSaveWriteLock(record.saveId, async () => {
+    const db = getDatabase();
+    await db.transaction('rw', db.debugTurns, async () => {
+      await db.debugTurns.put(record);
+      const keys = await db.debugTurns
+        .where('[saveId+startedAt]')
+        .between([record.saveId, Dexie.minKey], [record.saveId, Dexie.maxKey], true, true)
+        .primaryKeys();
+      const overflow = keys.length - DEBUG_TURN_HISTORY_LIMIT;
+      if (overflow > 0) await db.debugTurns.bulkDelete(keys.slice(0, overflow));
+    });
   });
 }
 

--- a/src/sillytavern/database.ts
+++ b/src/sillytavern/database.ts
@@ -35,6 +35,7 @@ import type {
   BeautifierRule,
   RegexStorageRecord,
   CreatePreset,
+  DebugTurnRecord,
 } from './types';
 import type {
   SceneImageRecord,
@@ -102,7 +103,7 @@ const DB_NAME = 'SillyTavernWebDB';
  * 而 `database.test.ts` 里那条断言跟着写了 17，于是漂移被测试**固定**下来而不是拦下来。
  * 升版时这两处一起改。
  */
-export const DB_VERSION = 23;
+export const DB_VERSION = 24;
 
 // ═══════════════════════════════════════════════════════════
 // Schema 声明（Q-26）
@@ -259,6 +260,9 @@ class AppDatabase extends Dexie {
   //   这两个只需要 turn/createdAt 的动作，每次都要把 ~30 份整档历史反序列化到主线程。
   //   索引 `saveId` 供 deleteSaveSlot / 单存档导出按存档整批取删（照 characterAppearances 的先例）。
   snapshotPayloads!: Table<SnapshotPayload>;
+
+  // v24: 每存档最近 10 回合的完整 Agent 调试历史；不进日常备份。
+  debugTurns!: Table<DebugTurnRecord>;
 
   constructor() {
     super(DB_NAME);
@@ -660,6 +664,7 @@ class AppDatabase extends Dexie {
       });
 
     this.version(23).stores({ apiRateLimitPolicies: 'credentialId, updatedAt' });
+    this.version(24).stores({ debugTurns: 'id, saveId, [saveId+startedAt]' });
   }
 }
 
@@ -1805,6 +1810,7 @@ export async function deleteSaveSlot(id: string): Promise<void> {
       db.sceneImages,
       db.sceneImageBlobs,
       db.characterAppearances,
+      db.debugTurns,
     ],
     async () => {
       // v22 拆表：元数据与载荷各有 saveId 索引，两张表各删各的（载荷表不必先查 id）
@@ -1826,6 +1832,7 @@ export async function deleteSaveSlot(id: string): Promise<void> {
       await db.sceneImages.where('saveId').equals(id).delete();
       // v19 (D56): 会话外貌随存档走 —— 与 imagePresets（全局基线）刻意相反
       await db.characterAppearances.where('saveId').equals(id).delete();
+      await db.debugTurns.where('saveId').equals(id).delete();
       await db.saves.delete(id);
     },
   );
@@ -2035,6 +2042,35 @@ export async function deleteMessagesAfterTurn(saveId: string, turn: number): Pro
     .messages.where('[saveId+turn]')
     .between([saveId, turn], [saveId, Dexie.maxKey], false, true)
     .delete();
+}
+
+// ═══════════════════════════════════════════════════════════
+// Debug turn history (v24)
+// ═══════════════════════════════════════════════════════════
+
+export const DEBUG_TURN_HISTORY_LIMIT = 10;
+
+/** 读取最近 10 回合，按时间升序返回。 */
+export async function getDebugTurns(saveId: string): Promise<DebugTurnRecord[]> {
+  const rows = await getDatabase()
+    .debugTurns.where('[saveId+startedAt]')
+    .between([saveId, Dexie.minKey], [saveId, Dexie.maxKey], true, true)
+    .toArray();
+  return rows.slice(-DEBUG_TURN_HISTORY_LIMIT);
+}
+
+/** 保存一回合的最新快照，并在同一事务内淘汰该存档最旧的超额记录。 */
+export async function saveDebugTurn(record: DebugTurnRecord): Promise<void> {
+  const db = getDatabase();
+  await db.transaction('rw', db.debugTurns, async () => {
+    await db.debugTurns.put(record);
+    const keys = await db.debugTurns
+      .where('[saveId+startedAt]')
+      .between([record.saveId, Dexie.minKey], [record.saveId, Dexie.maxKey], true, true)
+      .primaryKeys();
+    const overflow = keys.length - DEBUG_TURN_HISTORY_LIMIT;
+    if (overflow > 0) await db.debugTurns.bulkDelete(keys.slice(0, overflow));
+  });
 }
 
 // ========== Audio (v11) ==========

--- a/src/sillytavern/memory-store.test.ts
+++ b/src/sillytavern/memory-store.test.ts
@@ -227,6 +227,30 @@ describe('computeEmbedding', () => {
     expect(fetchUrl).toBe('/api/embeddings');
   });
 
+  it('reports provider usage and request metadata to the debug observer', async () => {
+    mockFetchResolved([0.1, 0.2, 0.3]);
+    const observe = vi.fn();
+
+    await (computeEmbedding as any)(
+      'billable input',
+      makeEndpoint(),
+      undefined,
+      undefined,
+      observe,
+    );
+
+    expect(observe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: 'billable input',
+        model: 'deepseek-chat',
+        baseUrl: 'https://api.deepseek.com/v1',
+        promptTokens: 8,
+        totalTokens: 8,
+        dimensions: 3,
+      }),
+    );
+  });
+
   it('should use custom model when provided', async () => {
     mockFetchResolved([0.1, 0.2]);
 

--- a/src/sillytavern/memory-store.ts
+++ b/src/sillytavern/memory-store.ts
@@ -13,6 +13,22 @@ import { scheduleApiRequest } from './api-rpm-limiter';
 
 // ========== Embedding ==========
 
+/** 一次真实 Embedding Provider 请求的可导出诊断信息（不包含 API Key 或向量字节）。 */
+export interface EmbeddingRequestTrace {
+  input: string;
+  model: string;
+  baseUrl: string;
+  startedAt: number;
+  completedAt: number;
+  promptTokens?: number;
+  totalTokens?: number;
+  dimensions?: number;
+  responseSummary?: string;
+  error?: string;
+}
+
+export type EmbeddingRequestObserver = (trace: EmbeddingRequestTrace) => void;
+
 /**
  * 调用 OpenAI 兼容的 /embeddings 端点计算向量
  * 直接使用 fetch（浏览器/Node 18+ 均可用）
@@ -22,44 +38,85 @@ export async function computeEmbedding(
   endpoint: { baseUrl: string; apiKey: string; defaultModel: string; name?: string },
   model?: string,
   signal?: AbortSignal,
+  onRequest?: EmbeddingRequestObserver,
 ): Promise<number[]> {
   const baseUrl = endpoint.baseUrl.replace(/\/+$/, '');
+  const resolvedModel = model || endpoint.defaultModel;
+  const startedAt = Date.now();
   const body = JSON.stringify({
-    model: model || endpoint.defaultModel,
+    model: resolvedModel,
     input: text,
   });
-
-  const res = await scheduleApiRequest(
-    { baseUrl, apiKey: endpoint.apiKey, label: endpoint.name || baseUrl },
-    signal,
-    () =>
-      fetch('/api/embeddings', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Target-Base-URL': baseUrl,
-          Authorization: `Bearer ${endpoint.apiKey}`,
-        },
-        body,
-        signal,
-      }),
-  );
-
-  if (!res.ok) {
-    const errBody = await res.text().catch(() => '');
-    throw new Error(`Embedding API ${res.status}: ${errBody.slice(0, 200)}`);
-  }
-
-  const json = (await res.json()) as {
-    data: Array<{ embedding: number[]; index: number }>;
+  let observed = false;
+  const observe = (extra: Partial<EmbeddingRequestTrace>) => {
+    if (observed) return;
+    observed = true;
+    try {
+      onRequest?.({
+        input: text,
+        model: resolvedModel,
+        baseUrl,
+        startedAt,
+        completedAt: Date.now(),
+        ...extra,
+      });
+    } catch (error) {
+      console.warn('[memory-store] Embedding 调试观察器失败（不影响请求）:', error);
+    }
   };
 
-  const embedding = json.data?.[0]?.embedding;
-  if (!embedding || !Array.isArray(embedding)) {
-    throw new Error('Embedding API 返回数据格式异常');
-  }
+  try {
+    const res = await scheduleApiRequest(
+      { baseUrl, apiKey: endpoint.apiKey, label: endpoint.name || baseUrl },
+      signal,
+      () =>
+        fetch('/api/embeddings', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Target-Base-URL': baseUrl,
+            Authorization: `Bearer ${endpoint.apiKey}`,
+          },
+          body,
+          signal,
+        }),
+    );
 
-  return embedding;
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => '');
+      throw new Error(`Embedding API ${res.status}: ${errBody.slice(0, 200)}`);
+    }
+
+    const json = (await res.json()) as {
+      object?: string;
+      model?: string;
+      data: Array<{ embedding: number[]; index: number }>;
+      usage?: { prompt_tokens?: number; total_tokens?: number };
+    };
+
+    const embedding = json.data?.[0]?.embedding;
+    if (!embedding || !Array.isArray(embedding)) {
+      throw new Error('Embedding API 返回数据格式异常');
+    }
+
+    const responseSummary = JSON.stringify({
+      object: json.object,
+      model: json.model,
+      dataCount: json.data.length,
+      dimensions: embedding.length,
+      usage: json.usage,
+    });
+    observe({
+      promptTokens: json.usage?.prompt_tokens,
+      totalTokens: json.usage?.total_tokens,
+      dimensions: embedding.length,
+      responseSummary,
+    });
+    return embedding;
+  } catch (error) {
+    observe({ error: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
 }
 
 // ========== 相似度 ==========
@@ -110,6 +167,7 @@ export async function recallMemories(
   topK: number,
   endpoint: { baseUrl: string; apiKey: string; defaultModel: string },
   signal?: AbortSignal,
+  onEmbeddingRequest?: EmbeddingRequestObserver,
 ): Promise<RecalledMemory[]> {
   const allMemories = await getMemories(saveId);
   if (allMemories.length === 0) return [];
@@ -117,7 +175,7 @@ export async function recallMemories(
   // 计算查询向量
   let queryEmbedding: number[];
   try {
-    queryEmbedding = await computeEmbedding(query, endpoint, undefined, signal);
+    queryEmbedding = await computeEmbedding(query, endpoint, undefined, signal, onEmbeddingRequest);
   } catch {
     // Embedding API 失败 → 回退到按重要度 + 时间排序
     return allMemories

--- a/src/sillytavern/memory-summarizer.ts
+++ b/src/sillytavern/memory-summarizer.ts
@@ -11,7 +11,7 @@
 
 import type { MemoryRecord } from './types';
 import { getAllMemoryIds, saveMemory } from './database';
-import { computeEmbedding } from './memory-store';
+import { computeEmbedding, type EmbeddingRequestObserver } from './memory-store';
 // Q-05：从模型输出抢救 JSON 的唯一入口
 import { parseModelJson } from './model-json';
 // 并行化改造：MEM 编号是全库分配（跨存档），「分配 + 落库」必须同段互斥，
@@ -140,7 +140,9 @@ export interface SummarizeAndSaveOptions {
   /** 关联的角色 ID 列表 */
   relatedCharacterIds?: string[];
   /** Embedding API 端点（可选，不提供则不计算 embedding） */
-  embeddingEndpoint?: { baseUrl: string; apiKey: string; defaultModel: string };
+  embeddingEndpoint?: { baseUrl: string; apiKey: string; defaultModel: string; name?: string };
+  /** 调试旁路：每个真实 Embedding 请求完成后回传 usage，不接触 API Key。 */
+  onEmbeddingRequest?: EmbeddingRequestObserver;
   /** 游戏时间 */
   gameTimeRange?: { start: string; end: string };
 }
@@ -161,6 +163,7 @@ export async function summarizeAndSave(
     agentRawOutput,
     relatedCharacterIds = [],
     embeddingEndpoint,
+    onEmbeddingRequest,
     gameTimeRange,
   } = options;
 
@@ -206,7 +209,13 @@ export async function summarizeAndSave(
     if (embeddingEndpoint) {
       try {
         const embeddingText = `[${parsed.keywords.join(', ')}] ${parsed.content}`;
-        memory.embedding = await computeEmbedding(embeddingText, embeddingEndpoint);
+        memory.embedding = await computeEmbedding(
+          embeddingText,
+          embeddingEndpoint,
+          undefined,
+          undefined,
+          onEmbeddingRequest,
+        );
       } catch {
         // Embedding 不可用 — 保存无 embedding 的记忆
         memory.embedding = undefined;

--- a/src/sillytavern/types.ts
+++ b/src/sillytavern/types.ts
@@ -1897,6 +1897,7 @@ export interface DebugAgentEntry {
   cacheHitTokens?: number;
   cacheMissTokens?: number;
   completionTokens?: number;
+  promptTokens?: number;
   duration: number;
   startedAt: number;
   completedAt?: number;

--- a/src/sillytavern/types.ts
+++ b/src/sillytavern/types.ts
@@ -1853,8 +1853,65 @@ export interface AgentResult {
   error?: string;
   /** 🆕 Agentic: 本 Agent 产生的所有工具调用记录 */
   toolCalls?: Array<{ name: string; arguments: any; result: any }>;
+  /** Agentic 多轮调用中，每次真实 provider 响应的 usage。普通 chat 不填。 */
+  providerRounds?: AgentProviderRound[];
   /** 🆕 Debug: 发送给 AI 的完整请求消息（含系统提示词+上下文），用于调试面板导出 */
   requestMessages?: Array<{ role: string; content: string | null }>;
+}
+
+/** 一次 agentic provider 往返的计量快照。 */
+export interface AgentProviderRound {
+  round: number;
+  tokensUsed: number;
+  cacheHit: boolean;
+  cacheHitTokens?: number;
+  cacheMissTokens?: number;
+  completionTokens?: number;
+  promptTokens?: number;
+  finishReason?: string;
+  duration: number;
+  error?: string;
+}
+
+/** 单次 Agent 调用的完整调试记录。 */
+export interface DebugAgentEntry {
+  invocationId: string;
+  turnId: string;
+  agentId: string;
+  label: string;
+  endpointId: string;
+  endpointName: string;
+  baseUrl: string;
+  model: string;
+  messages: Array<{ role: string; content: string | null }>;
+  rawResponse: string;
+  reasoning?: string;
+  toolCalls?: AgentResult['toolCalls'];
+  providerRounds?: AgentProviderRound[];
+  promptSessionRevision?: number;
+  promptRebased?: boolean;
+  promptRebaseReason?: string;
+  error?: string;
+  tokensUsed: number;
+  cacheHit: boolean;
+  cacheHitTokens?: number;
+  cacheMissTokens?: number;
+  completionTokens?: number;
+  duration: number;
+  startedAt: number;
+  completedAt?: number;
+}
+
+/** 每存档持久化的单回合调试历史；只保留最近 10 条。 */
+export interface DebugTurnRecord {
+  id: string;
+  saveId: string;
+  turn: number;
+  sourceMessageId?: string;
+  status: 'running' | 'completed' | 'failed' | 'cancelled';
+  startedAt: number;
+  completedAt?: number;
+  entries: DebugAgentEntry[];
 }
 
 /** 玩家可见的单次 Agent 工具活动；只保留语义化文案，不携带原始参数或响应。 */

--- a/src/ui/components/game/DebugPanel.history.test.ts
+++ b/src/ui/components/game/DebugPanel.history.test.ts
@@ -1,0 +1,73 @@
+/**
+ * DebugPanel.vue — 最近 10 回合 Agent 调试历史
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import DebugPanel from './DebugPanel.vue';
+import { useGameStore } from '../../stores/game-store';
+import type { DebugAgentEntry, DebugTurnRecord } from '@engine/types';
+
+beforeEach(() => setActivePinia(createPinia()));
+
+function entry(turnId: string, agentId: string, hit: number): DebugAgentEntry {
+  return {
+    invocationId: `${turnId}:${agentId}:1`,
+    turnId,
+    agentId,
+    label: agentId,
+    endpointId: 'ep',
+    endpointName: 'DeepSeek',
+    baseUrl: 'https://api.example.test',
+    model: 'model',
+    messages: [{ role: 'system', content: `${agentId}-prompt` }],
+    rawResponse: `${agentId}-response`,
+    providerRounds: [
+      { round: 1, tokensUsed: hit + 2, cacheHit: hit > 0, cacheHitTokens: hit, duration: 12 },
+    ],
+    promptSessionRevision: agentId === 'story' ? 2 : undefined,
+    promptRebased: false,
+    tokensUsed: hit + 2,
+    cacheHit: hit > 0,
+    cacheHitTokens: hit,
+    cacheMissTokens: 1,
+    completionTokens: 1,
+    duration: 12,
+    startedAt: 100,
+    completedAt: 112,
+  };
+}
+
+function turn(id: string, number: number, entries: DebugAgentEntry[]): DebugTurnRecord {
+  return {
+    id,
+    saveId: 'save-debug',
+    turn: number,
+    status: 'completed',
+    startedAt: number * 100,
+    completedAt: number * 100 + 20,
+    entries,
+  };
+}
+
+describe('DebugPanel · Agent 历史', () => {
+  it('可切换最近回合，且汇总包含 memory_recall', async () => {
+    const game = useGameStore();
+    game.agentLogHistory.push(
+      turn('run-1', 1, [entry('run-1', 'story', 3)]),
+      turn('run-2', 2, [entry('run-2', 'memory_recall', 7)]),
+    );
+
+    const wrapper = mount(DebugPanel);
+    expect(wrapper.text()).toContain('Agent 调用历史 (2/10 回合)');
+    expect(wrapper.findAll('.debug-turn-select option')).toHaveLength(2);
+    expect(wrapper.text()).toContain('含记忆召回 · 1 次调用');
+    expect(wrapper.text()).toContain('命中 7');
+
+    await wrapper.find('.debug-turn-select').setValue('run-1');
+    expect(wrapper.text()).toContain('story');
+    expect(wrapper.text()).toContain('Delta revision 2');
+    expect(wrapper.text()).toContain('Provider 往返 (1)');
+  });
+});

--- a/src/ui/components/game/DebugPanel.history.test.ts
+++ b/src/ui/components/game/DebugPanel.history.test.ts
@@ -60,6 +60,10 @@ describe('DebugPanel · Agent 历史', () => {
     );
 
     const wrapper = mount(DebugPanel);
+
+    expect(wrapper.get('select.debug-turn-select').attributes('aria-label')).toBe(
+      '选择调试历史回合',
+    );
     expect(wrapper.text()).toContain('Agent 调用历史 (2/10 回合)');
     expect(wrapper.findAll('.debug-turn-select option')).toHaveLength(2);
     expect(wrapper.text()).toContain('含记忆召回 · 1 次调用');

--- a/src/ui/components/game/DebugPanel.vue
+++ b/src/ui/components/game/DebugPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useGameStore, type DebugAgentEntry } from '../../stores/game-store';
 import { useSettingsStore } from '../../stores/settings-store';
 import { useUIStore } from '../../stores/ui-store';
@@ -19,6 +19,23 @@ import {
 const game = useGameStore();
 const settings = useSettingsStore();
 const ui = useUIStore();
+const selectedTurnId = ref('');
+
+const selectedTurn = computed(() => {
+  return (
+    game.agentLogHistory.find((turn) => turn.id === selectedTurnId.value) ??
+    game.agentLogHistory[game.agentLogHistory.length - 1] ??
+    null
+  );
+});
+const displayedAgentLog = computed(() => selectedTurn.value?.entries ?? []);
+watch(
+  () => game.agentLogHistory[game.agentLogHistory.length - 1]?.id,
+  (id) => {
+    if (id && !selectedTurnId.value) selectedTurnId.value = id;
+  },
+  { immediate: true },
+);
 
 // ═══════════════════════════════════════════════════════════
 // 随机事件（随机事件 v1 §4）
@@ -99,9 +116,9 @@ async function armEvent(name: string): Promise<void> {
   }
 }
 
-/** 本轮 token 汇总（排除 memory_recall 记忆召回，只看正文链路的缓存效率） */
+/** 所选回合全部真实 Agent 调用的 token 汇总（含 memory_recall）。 */
 const tokenSummary = computed(() => {
-  const entries = game.agentLog.filter((e) => !e.agentId.startsWith('memory_recall'));
+  const entries = displayedAgentLog.value;
   const sum = (sel: (e: DebugAgentEntry) => number | undefined) =>
     entries.reduce((s, e) => s + (sel(e) ?? 0), 0);
   return {
@@ -139,7 +156,34 @@ async function buildExportData() {
   // 🆕 导出前先把 Dexie 最新的 characters / save.metadata / saveProfile 回读进内存，
   // 避免导出开局快照（inventory=[] / totalTurns=0 假象）
   await game.refreshFromDb();
+  await game.flushAgentLogWrites();
   const sysSettings = settings.settings;
+  const serializeAgentEntry = (e: DebugAgentEntry) => ({
+    invocationId: e.invocationId,
+    turnId: e.turnId,
+    agentId: e.agentId,
+    label: e.label,
+    model: e.model,
+    endpointName: e.endpointName,
+    baseUrl: e.baseUrl,
+    startedAt: e.startedAt,
+    completedAt: e.completedAt,
+    duration: e.duration,
+    tokensUsed: e.tokensUsed,
+    cacheHit: e.cacheHit,
+    cacheHitTokens: e.cacheHitTokens,
+    cacheMissTokens: e.cacheMissTokens,
+    completionTokens: e.completionTokens,
+    promptSessionRevision: e.promptSessionRevision,
+    promptRebased: e.promptRebased,
+    promptRebaseReason: e.promptRebaseReason,
+    providerRounds: e.providerRounds,
+    error: e.error,
+    rawResponse: e.rawResponse,
+    reasoning: e.reasoning,
+    toolCalls: e.toolCalls,
+    messages: e.messages,
+  });
   return {
     exportedAt: new Date().toISOString(),
     save: {
@@ -158,23 +202,16 @@ async function buildExportData() {
       timestamp: m.timestamp,
     })),
     saveProfile: game.saveProfile,
-    agentLog: game.agentLog.map((e) => ({
-      agentId: e.agentId,
-      label: e.label,
-      model: e.model,
-      endpointName: e.endpointName,
-      baseUrl: e.baseUrl,
-      duration: e.duration,
-      tokensUsed: e.tokensUsed,
-      cacheHit: e.cacheHit,
-      cacheHitTokens: e.cacheHitTokens,
-      cacheMissTokens: e.cacheMissTokens,
-      completionTokens: e.completionTokens,
-      error: e.error,
-      rawResponse: e.rawResponse,
-      reasoning: e.reasoning,
-      toolCalls: e.toolCalls,
-      messages: e.messages,
+    // 兼容既有分析脚本：agentLog 仍指最新回合；完整历史在 agentHistory。
+    agentLog: game.agentLog.map(serializeAgentEntry),
+    agentHistory: game.agentLogHistory.map((turn) => ({
+      id: turn.id,
+      turn: turn.turn,
+      sourceMessageId: turn.sourceMessageId,
+      status: turn.status,
+      startedAt: turn.startedAt,
+      completedAt: turn.completedAt,
+      entries: turn.entries.map(serializeAgentEntry),
     })),
     apiPool: (sysSettings.apiPool as any[]).map((ep: any) => ({
       id: ep.id,
@@ -386,18 +423,33 @@ function formatJson(value: unknown): string {
 
     <!-- Agent 调用日志 -->
     <div class="debug-section">
-      <h4>本轮 Agent 调用 ({{ game.agentLog.length }})</h4>
-      <div v-if="game.agentLog.length === 0" class="debug-empty">
+      <div class="debug-agent-title-row">
+        <h4>Agent 调用历史 ({{ game.agentLogHistory.length }}/10 回合)</h4>
+        <select
+          v-if="game.agentLogHistory.length"
+          v-model="selectedTurnId"
+          class="debug-turn-select"
+        >
+          <option
+            v-for="turn in [...game.agentLogHistory].reverse()"
+            :key="turn.id"
+            :value="turn.id"
+          >
+            第 {{ turn.turn }} 回合 · {{ turn.status }} · {{ turn.entries.length }} 次调用
+          </option>
+        </select>
+      </div>
+      <div v-if="displayedAgentLog.length === 0" class="debug-empty">
         暂无日志（等待下一轮管线触发）
       </div>
       <div v-else class="debug-token-summary">
-        本轮汇总（排除记忆召回 · {{ tokenSummary.count }} 个 Agent）: 命中
+        所选回合汇总（含记忆召回 · {{ tokenSummary.count }} 次调用）: 命中
         <strong>{{ tokenSummary.hit }}</strong> / 未命中 <strong>{{ tokenSummary.miss }}</strong> /
         输出 <strong>{{ tokenSummary.completion }}</strong>
       </div>
       <div
-        v-for="entry in game.agentLog"
-        :key="entry.agentId"
+        v-for="entry in displayedAgentLog"
+        :key="entry.invocationId"
         class="debug-agent-entry"
         :class="{ 'has-error': entry.error }"
       >
@@ -409,6 +461,10 @@ function formatJson(value: unknown): string {
             >命中 {{ entry.cacheHitTokens ?? 0 }} / 未命中 {{ entry.cacheMissTokens ?? 0 }} / 输出
             {{ entry.completionTokens ?? 0 }} · {{ entry.duration }}ms</span
           >
+        </div>
+        <div v-if="entry.promptSessionRevision" class="debug-agent-meta">
+          Delta revision {{ entry.promptSessionRevision }} · 重基线
+          {{ entry.promptRebased ? `是（${entry.promptRebaseReason ?? '未注明原因'}）` : '否' }}
         </div>
         <details class="debug-agent-details">
           <summary>请求 ({{ entry.messages.length }} 条消息) / 响应</summary>
@@ -442,6 +498,10 @@ function formatJson(value: unknown): string {
                   <pre>结果: {{ truncate(formatJson(tool.result), 1200) }}</pre>
                 </details>
               </template>
+              <template v-if="entry.providerRounds?.length">
+                <h6 class="debug-reasoning-h">Provider 往返 ({{ entry.providerRounds.length }})</h6>
+                <pre class="debug-provider-rounds">{{ formatJson(entry.providerRounds) }}</pre>
+              </template>
             </div>
           </div>
         </details>
@@ -462,6 +522,34 @@ function formatJson(value: unknown): string {
 .debug-actions {
   display: flex;
   gap: 8px;
+}
+.debug-agent-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--theme-spacing-sm, 8px);
+  flex-wrap: wrap;
+}
+.debug-agent-title-row h4 {
+  margin: 0;
+}
+.debug-turn-select {
+  min-width: 220px;
+  padding: 6px 10px;
+  border: 1px solid var(--theme-card-border);
+  border-radius: var(--theme-radius-sm, 4px);
+  background: var(--theme-surface-muted);
+  color: var(--theme-text-primary);
+  font: inherit;
+}
+.debug-agent-meta {
+  margin-top: 4px;
+  color: var(--theme-text-secondary);
+  font-size: 0.75rem;
+}
+.debug-provider-rounds {
+  max-height: 220px;
+  overflow: auto;
 }
 .debug-btn {
   padding: 6px 14px;

--- a/src/ui/components/game/DebugPanel.vue
+++ b/src/ui/components/game/DebugPanel.vue
@@ -158,32 +158,8 @@ async function buildExportData() {
   await game.refreshFromDb();
   await game.flushAgentLogWrites();
   const sysSettings = settings.settings;
-  const serializeAgentEntry = (e: DebugAgentEntry) => ({
-    invocationId: e.invocationId,
-    turnId: e.turnId,
-    agentId: e.agentId,
-    label: e.label,
-    model: e.model,
-    endpointName: e.endpointName,
-    baseUrl: e.baseUrl,
-    startedAt: e.startedAt,
-    completedAt: e.completedAt,
-    duration: e.duration,
-    tokensUsed: e.tokensUsed,
-    cacheHit: e.cacheHit,
-    cacheHitTokens: e.cacheHitTokens,
-    cacheMissTokens: e.cacheMissTokens,
-    completionTokens: e.completionTokens,
-    promptSessionRevision: e.promptSessionRevision,
-    promptRebased: e.promptRebased,
-    promptRebaseReason: e.promptRebaseReason,
-    providerRounds: e.providerRounds,
-    error: e.error,
-    rawResponse: e.rawResponse,
-    reasoning: e.reasoning,
-    toolCalls: e.toolCalls,
-    messages: e.messages,
-  });
+  const serializeAgentEntry = (entry: DebugAgentEntry): DebugAgentEntry =>
+    JSON.parse(JSON.stringify(entry)) as DebugAgentEntry;
   return {
     exportedAt: new Date().toISOString(),
     save: {
@@ -429,6 +405,7 @@ function formatJson(value: unknown): string {
           v-if="game.agentLogHistory.length"
           v-model="selectedTurnId"
           class="debug-turn-select"
+          aria-label="选择调试历史回合"
         >
           <option
             v-for="turn in [...game.agentLogHistory].reverse()"
@@ -535,7 +512,7 @@ function formatJson(value: unknown): string {
 }
 .debug-turn-select {
   min-width: 220px;
-  padding: 6px 10px;
+  padding: var(--theme-spacing-xs) var(--theme-spacing-sm);
   border: 1px solid var(--theme-card-border);
   border-radius: var(--theme-radius-sm, 4px);
   background: var(--theme-surface-muted);
@@ -543,7 +520,7 @@ function formatJson(value: unknown): string {
   font: inherit;
 }
 .debug-agent-meta {
-  margin-top: 4px;
+  margin-top: var(--theme-spacing-xs);
   color: var(--theme-text-secondary);
   font-size: 0.75rem;
 }

--- a/src/ui/lib/game-pipeline.test.ts
+++ b/src/ui/lib/game-pipeline.test.ts
@@ -51,6 +51,7 @@ const {
   createSnapshotSpy,
   runCombatV3Mock,
   callImagePromptAgentMock,
+  summarizeAndSaveMock,
 } = vi.hoisted(() => ({
   commitSpy: vi.fn(async () => ({
     success: true,
@@ -65,6 +66,7 @@ const {
   toastSpy: vi.fn(),
   runCombatV3Mock: vi.fn(),
   callImagePromptAgentMock: vi.fn(),
+  summarizeAndSaveMock: vi.fn(),
 }));
 
 vi.mock('@engine/state-manager', () => ({
@@ -83,6 +85,10 @@ vi.mock('@engine/combat-v3', () => ({
 
 vi.mock('@engine/image-prompt-agent', () => ({
   callImagePromptAgent: callImagePromptAgentMock,
+}));
+
+vi.mock('@engine/memory-summarizer', () => ({
+  summarizeAndSave: summarizeAndSaveMock,
 }));
 
 vi.mock('../stores/ui-store', () => ({
@@ -1494,6 +1500,83 @@ describe('runImagePromptAgent — activity ledger', () => {
       'activity-old',
     );
     expect(gameStore.clearAgentStatus).toHaveBeenCalledWith('story', '已取消', 'activity-old');
+  });
+
+  it('preserves the completed provider payload when completion handling later fails', () => {
+    const gameStore = makeGameStore();
+    const pipeline = new GamePipeline({
+      gameStore,
+      settingsStore: makeSettingsStore(),
+      saveId: 'save-test',
+    });
+    const events = (pipeline as any).buildEventHandlers('activity-failed');
+    const result = {
+      ...makeResult('story', 'billable response'),
+      requestMessages: [{ role: 'user', content: 'billable request' }],
+      tokensUsed: 73,
+      duration: 42,
+      error: 'completion handler failed',
+    };
+
+    events.onAgentStart('story', { apiEndpointId: 'ep-story', model: 'story-model' });
+    events.onAgentError('story', result.error, result);
+
+    expect(gameStore.addAgentLogEntry).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messages: result.requestMessages,
+        rawResponse: 'billable response',
+        tokensUsed: 73,
+        duration: 42,
+        error: 'completion handler failed',
+      }),
+    );
+  });
+
+  it('records memory-summary embedding usage as its own billable invocation', async () => {
+    const gameStore = makeGameStore();
+    const settingsStore = makeSettingsStore({
+      embeddingEndpointId: 'ep-embedding',
+      embeddingModel: 'embed-model',
+      apiPool: [
+        {
+          id: 'ep-embedding',
+          name: 'Embedding API',
+          baseUrl: 'https://api.example.test/v1',
+          apiKey: 'secret',
+          defaultModel: 'fallback-model',
+        },
+      ],
+    });
+    summarizeAndSaveMock.mockImplementationOnce(async (options: any) => {
+      options.onEmbeddingRequest({
+        input: 'summary embedding input',
+        model: 'embed-model',
+        baseUrl: 'https://api.example.test/v1',
+        startedAt: 100,
+        completedAt: 125,
+        promptTokens: 11,
+        totalTokens: 11,
+        dimensions: 1536,
+      });
+      return null;
+    });
+    const pipeline = new GamePipeline({ gameStore, settingsStore, saveId: 'save-test' });
+
+    await (pipeline as any).persistMemorySummary(
+      makeResult('memory_summary', '{"content":"summary"}'),
+      'activity-embedding',
+    );
+
+    expect(gameStore.addAgentLogEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        turnId: 'activity-embedding',
+        agentId: 'memory_embedding',
+        model: 'embed-model',
+        messages: [{ role: 'user', content: 'summary embedding input' }],
+        tokensUsed: 11,
+        promptTokens: 11,
+      }),
+    );
   });
 });
 

--- a/src/ui/lib/game-pipeline.test.ts
+++ b/src/ui/lib/game-pipeline.test.ts
@@ -5,7 +5,7 @@ import {
   GamePipeline,
   withImagePromptSystem,
 } from './game-pipeline';
-import type { AgentConfig } from '@engine/types';
+import type { AgentConfig, ApiEndpoint } from '@engine/types';
 import { patchAgentSettings } from '../stores/agent-settings';
 import type { AgentResult } from '@engine/types';
 
@@ -138,6 +138,10 @@ function makeGameStore(overrides: Record<string, any> = {}) {
     addSystemMessage: vi.fn(),
     setPendingOptions: vi.fn(),
     clearAgentLog: vi.fn(),
+    startAgentLogTurn: vi.fn(),
+    finishAgentLogTurn: vi.fn(),
+    flushAgentLogWrites: vi.fn(async () => {}),
+    agentLogHistory: [],
     clearAllAgentStatus: vi.fn(),
     startAgentActivityRun: vi.fn(() => 'activity-test'),
     finishAgentActivityRun: vi.fn(),
@@ -189,6 +193,50 @@ function makePipeline(
 function makeResult(agentId: string, rawResponse: string): AgentResult {
   return { agentId, output: rawResponse, rawResponse, tokensUsed: 0, cacheHit: false, duration: 0 };
 }
+
+describe('侧链 Agent 调试调用身份', () => {
+  it('同回合新建两个同名 client 时仍生成不同 invocationId', async () => {
+    const addAgentLogEntry = vi.fn();
+    const pipeline = makePipeline({ addAgentLogEntry });
+    const factory = (pipeline as any).getClientFactory('run-debug');
+    const endpoint: ApiEndpoint = {
+      id: 'ep',
+      name: 'DeepSeek',
+      provider: 'deepseek',
+      baseUrl: 'https://api.example.test/v1',
+      apiKey: 'key',
+      defaultModel: 'model',
+      models: ['model'],
+      timeout: 1000,
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: async () => ({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { total_tokens: 1 },
+      }),
+      text: async () => '',
+    } as Response);
+
+    try {
+      await factory('char_gen', endpoint, 'save-test').chat({
+        messages: [{ role: 'user', content: 'first' }],
+      });
+      await factory('char_gen', endpoint, 'save-test').chat({
+        messages: [{ role: 'user', content: 'second' }],
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(addAgentLogEntry).toHaveBeenCalledTimes(2);
+    const ids = addAgentLogEntry.mock.calls.map(([entry]) => entry.invocationId);
+    expect(ids).toEqual(['run-debug:char_gen:1', 'run-debug:char_gen:2']);
+  });
+});
 
 describe('sendOpeningPrompt', () => {
   it('two pipeline instances sharing one save generate the opening only once', async () => {

--- a/src/ui/lib/game-pipeline.ts
+++ b/src/ui/lib/game-pipeline.ts
@@ -30,6 +30,7 @@ import type {
   CharacterState,
   ChatMessage,
   SystemEvent,
+  DebugAgentEntry,
 } from '@engine/types';
 import type {
   ImageGenFailure,
@@ -194,6 +195,9 @@ export class GamePipeline {
    * 两件都只在「我还是当前那一轮」时才做。
    */
   private runSeq = 0;
+  /** 当前回合内按 Agent 递增，生成不会因同名 Agent 而覆盖的调试调用 ID。 */
+  private debugInvocationCounts = new Map<string, number>();
+  private mainInvocationIds = new Map<string, string>();
   /** 真机修(2026-07-17): run() 加载的配置/世界书/预设，供侧链 buildAgentMessages 使用（此前恒 undefined → systemPrompt 退化 stub + 世界书恒空） */
   private chainData: {
     agentConfigs: AgentConfig[];
@@ -348,8 +352,13 @@ export class GamePipeline {
         : existingSourceMessageId;
       activityRunId = this.game.startAgentActivityRun(boundSourceMessageId);
       this.activeRunId = activityRunId;
+      this.game.startAgentLogTurn({
+        id: activityRunId,
+        saveId: this.saveId,
+        turn: (this.game.activeSave?.metadata?.totalTurns ?? 0) + 1,
+        sourceMessageId: boundSourceMessageId,
+      });
       this.game.setPendingOptions([]); // 新一轮开始，清掉上一轮的行动选项
-      this.game.clearAgentLog();
 
       // 2. 构建 endpoints & context
       const endpoints = this.buildEndpoints();
@@ -473,6 +482,14 @@ export class GamePipeline {
       this.flushPendingAudio();
       if (activityRunId) {
         this.game.finishAgentActivityRun(activityRunId, activityOutcome, activityMessage);
+        this.game.finishAgentLogTurn(activityRunId, activityOutcome);
+        const debugPrefix = `${activityRunId}\u0000`;
+        for (const key of this.debugInvocationCounts.keys()) {
+          if (key.startsWith(debugPrefix)) this.debugInvocationCounts.delete(key);
+        }
+        for (const key of this.mainInvocationIds.keys()) {
+          if (key.startsWith(debugPrefix)) this.mainInvocationIds.delete(key);
+        }
       }
       if (this.activeRunId === activityRunId) {
         this.activeRunId = null;
@@ -1139,12 +1156,20 @@ export class GamePipeline {
     return apiPool.find((ep) => ep.id === poolId) || apiPool[0];
   }
 
+  private nextDebugInvocation(agentId: string, runId = this.activeRunId ?? 'detached') {
+    const key = `${runId}\u0000${agentId}`;
+    const ordinal = (this.debugInvocationCounts.get(key) ?? 0) + 1;
+    this.debugInvocationCounts.set(key, ordinal);
+    return { invocationId: `${runId}:${agentId}:${ordinal}`, ordinal };
+  }
+
   /** 创建 AgentClient 工厂 —— 供 craft_gen / char_gen / item_gen 链使用。
    *  🆕 包裹一层 LogClient：拦截 chat / chatWithTools，自动写 agentLog，
    *  让侧链 Agent 在 DebugPanel 可见（否则绕过 orchestrator 时无日志）。 */
   private getClientFactory(runActivityId = this.activeRunId ?? undefined) {
     const saveId = this.saveId;
     const game = this.game;
+    const debugTurnId = runActivityId ?? this.activeRunId ?? 'detached';
     // 🔴 侧链的取消信号（2026-08-10）。此前侧链**完全不响应 abort**：下面的包装层把
     // `signal` 当入参转发，而 char_gen / item_gen / craft_gen / 战斗的调用方一个都没传，
     // 于是 `abort()` 只掐得动 story（`callAgent` 显式传了 signal）。后果有两层：
@@ -1174,9 +1199,9 @@ export class GamePipeline {
         maxRetries: chainCfg?.maxRetries ?? 1,
       });
       const label = AGENT_LABELS[agentId] ?? agentId;
-      let callSeq = 0;
-
       const record = (
+        invocation: { invocationId: string; ordinal: number },
+        startedAt: number,
         messages: Array<{ role: string; content: string | null }>,
         result:
           | {
@@ -1189,19 +1214,21 @@ export class GamePipeline {
               cacheMissTokens?: number;
               completionTokens?: number;
               toolCalls?: AgentResult['toolCalls'];
+              providerRounds?: AgentResult['providerRounds'];
+              promptSessionRevision?: number;
+              promptRebased?: boolean;
+              promptRebaseReason?: string;
               error?: string;
               duration?: number;
             }
           | undefined,
         duration: number,
       ) => {
-        callSeq += 1;
-        // 同一 Agent 一轮内被多次调用时（如 2 个新角色 → char_gen 跑 2 次），
-        // addAgentLogEntry 按 agentId 覆盖同名条目，故给 agentId/label 加序号后缀避免互相覆盖。
-        const seqId = callSeq > 1 ? `${agentId}#${callSeq}` : agentId;
         game.addAgentLogEntry({
-          agentId: seqId,
-          label: callSeq > 1 ? `${label} #${callSeq}` : label,
+          invocationId: invocation.invocationId,
+          turnId: debugTurnId,
+          agentId,
+          label: invocation.ordinal > 1 ? `${label} #${invocation.ordinal}` : label,
           endpointId: endpoint.id,
           endpointName: endpoint.name || '',
           baseUrl: endpoint.baseUrl || '',
@@ -1210,6 +1237,10 @@ export class GamePipeline {
           rawResponse: result?.rawResponse ?? result?.output ?? '',
           reasoning: result?.reasoning,
           toolCalls: result?.toolCalls,
+          providerRounds: result?.providerRounds,
+          promptSessionRevision: result?.promptSessionRevision,
+          promptRebased: result?.promptRebased,
+          promptRebaseReason: result?.promptRebaseReason,
           error: result?.error,
           tokensUsed: result?.tokensUsed ?? 0,
           cacheHit: result?.cacheHit ?? false,
@@ -1217,6 +1248,8 @@ export class GamePipeline {
           cacheMissTokens: result?.cacheMissTokens,
           completionTokens: result?.completionTokens,
           duration: result?.duration ?? duration,
+          startedAt,
+          completedAt: Date.now(),
         });
       };
 
@@ -1237,23 +1270,27 @@ export class GamePipeline {
         },
         chat: async (request: any, signal?: any) => {
           const t0 = startTs();
+          const invocation = this.nextDebugInvocation(agentId, runActivityId);
           let result: any;
           try {
             // 调用方给了就用它的，没给才回落本轮信号（见 turnSignal 那段注释）
             result = await real.chat(request, signal ?? turnSignal);
           } catch (err: any) {
             record(
+              invocation,
+              t0,
               extractMessages(request),
               { error: String(err?.message ?? err) },
               Date.now() - t0,
             );
             throw err;
           }
-          record(extractMessages(request), result, Date.now() - t0);
+          record(invocation, t0, extractMessages(request), result, Date.now() - t0);
           return result;
         },
         chatWithTools: async (request: any, toolExecutor: any, options?: any) => {
           const t0 = startTs();
+          const invocation = this.nextDebugInvocation(agentId, runActivityId);
           let result: any;
           try {
             result = await real.chatWithTools(
@@ -1281,13 +1318,15 @@ export class GamePipeline {
             );
           } catch (err: any) {
             record(
+              invocation,
+              t0,
               extractMessages(request),
               { error: String(err?.message ?? err) },
               Date.now() - t0,
             );
             throw err;
           }
-          record(extractMessages(request), result, Date.now() - t0);
+          record(invocation, t0, extractMessages(request), result, Date.now() - t0);
           return result;
         },
         // chatStream 不常用（侧链不走流式），直接透传（信号回落同上）
@@ -1537,6 +1576,7 @@ export class GamePipeline {
   }
 
   private buildEventHandlers(runActivityId?: string): OrchestratorEvents {
+    const debugTurnId = runActivityId ?? this.activeRunId ?? 'detached';
     return {
       // 🎵 配乐：只暂存，**不在 Stage 1 就播** —— 见 run() 末尾的说明
       onPlayAudio: (marker) => {
@@ -1572,26 +1612,40 @@ export class GamePipeline {
       onAgentStart: (agentId, config) => {
         console.log(`[GamePipeline] Agent 开始: ${agentId}`);
         this.game.updateAgentStatus(agentId, runActivityId);
+        const invocation = this.nextDebugInvocation(agentId, runActivityId);
+        this.mainInvocationIds.set(`${debugTurnId}\u0000${agentId}`, invocation.invocationId);
+        const endpoint = this.buildEndpoints().find((item) => item.id === config.apiEndpointId);
         // 初始化日志空条目 (等 complete 时补全 messages + result)
         this.game.addAgentLogEntry({
+          invocationId: invocation.invocationId,
+          turnId: debugTurnId,
           agentId,
-          label: AGENT_LABELS[agentId] ?? agentId,
+          label:
+            invocation.ordinal > 1
+              ? `${AGENT_LABELS[agentId] ?? agentId} #${invocation.ordinal}`
+              : (AGENT_LABELS[agentId] ?? agentId),
           endpointId: config.apiEndpointId,
-          endpointName: '', // 暂不解析 endpoint name，后续从 buildEndpoints 传入时再补
-          baseUrl: '',
-          model: config.model,
+          endpointName: endpoint?.name ?? '',
+          baseUrl: endpoint?.baseUrl ?? '',
+          model: config.model || endpoint?.defaultModel || '',
           messages: [],
           rawResponse: '',
           tokensUsed: 0,
           cacheHit: false,
           duration: 0,
+          startedAt: Date.now(),
         });
       },
       onAgentComplete: async (result) => {
         this.game.clearAgentStatus(result.agentId, result.error, runActivityId);
         // 补全本轮已启动日志的剩余字段（保留 onAgentStart 写入的占位条目）
-        const prev = this.game.agentLog.find((e) => e.agentId === result.agentId);
+        const invocationId = this.mainInvocationIds.get(`${debugTurnId}\u0000${result.agentId}`);
+        const prev = this.game.agentLog.find(
+          (e: DebugAgentEntry) => e.invocationId === invocationId,
+        );
         this.game.addAgentLogEntry({
+          invocationId: invocationId ?? `${runActivityId}:${result.agentId}:unknown`,
+          turnId: debugTurnId,
           agentId: result.agentId,
           label: prev?.label ?? AGENT_LABELS[result.agentId] ?? result.agentId,
           endpointId: prev?.endpointId ?? '',
@@ -1602,6 +1656,10 @@ export class GamePipeline {
           rawResponse: result.rawResponse,
           reasoning: result.reasoning,
           toolCalls: result.toolCalls,
+          providerRounds: result.providerRounds,
+          promptSessionRevision: result.promptSessionRevision,
+          promptRebased: result.promptRebased,
+          promptRebaseReason: result.promptRebaseReason,
           error: result.error,
           tokensUsed: result.tokensUsed,
           cacheHit: result.cacheHit,
@@ -1609,6 +1667,8 @@ export class GamePipeline {
           cacheMissTokens: result.cacheMissTokens,
           completionTokens: result.completionTokens,
           duration: result.duration,
+          startedAt: prev?.startedAt ?? Date.now() - result.duration,
+          completedAt: Date.now(),
         });
         await this.handleAgentResult(result);
       },
@@ -1616,8 +1676,13 @@ export class GamePipeline {
         console.error(`[GamePipeline] Agent 错误: ${agentId}`, error);
         this.game.clearAgentStatus(agentId, error, runActivityId);
         // 补充错误日志
-        const prev = this.game.agentLog.find((e) => e.agentId === agentId);
+        const invocationId = this.mainInvocationIds.get(`${debugTurnId}\u0000${agentId}`);
+        const prev = this.game.agentLog.find(
+          (e: DebugAgentEntry) => e.invocationId === invocationId,
+        );
         this.game.addAgentLogEntry({
+          invocationId: invocationId ?? `${runActivityId}:${agentId}:unknown`,
+          turnId: debugTurnId,
           agentId,
           label: prev?.label ?? AGENT_LABELS[agentId] ?? agentId,
           endpointId: prev?.endpointId ?? '',
@@ -1630,6 +1695,8 @@ export class GamePipeline {
           tokensUsed: 0,
           cacheHit: false,
           duration: 0,
+          startedAt: prev?.startedAt ?? Date.now(),
+          completedAt: Date.now(),
         });
       },
 

--- a/src/ui/lib/game-pipeline.ts
+++ b/src/ui/lib/game-pipeline.ts
@@ -79,6 +79,7 @@ import { useUIStore } from '../stores/ui-store';
 import type { CombatCommand } from '@engine/combat-v3';
 import { rollDice } from '@engine/dice';
 import { getAgentSettings } from '../stores/agent-settings';
+import type { EmbeddingRequestTrace } from '@engine/memory-store';
 
 export interface GamePipelineDeps {
   gameStore: ReturnType<typeof useGameStore>;
@@ -98,6 +99,59 @@ export type StoryChunkCallback = (chunk: string, isComplete: boolean) => void;
  */
 function isAbortError(err: unknown): boolean {
   return (err as { name?: string } | null | undefined)?.name === 'AbortError';
+}
+
+interface DebugEntryInput {
+  invocationId: string;
+  turnId: string;
+  agentId: string;
+  label: string;
+  endpoint?: Partial<Pick<ApiEndpoint, 'id' | 'name' | 'baseUrl' | 'defaultModel'>>;
+  endpointId?: string;
+  endpointName?: string;
+  baseUrl?: string;
+  model?: string;
+  messages?: Array<{ role: string; content: string | null }>;
+  result?: Partial<AgentResult>;
+  startedAt: number;
+  completedAt?: number;
+  duration?: number;
+}
+
+/** Agent/Embedding 共用的结果→持久化调试记录投影，避免字段在多条调用路径间漂移。 */
+function buildDebugEntry(input: DebugEntryInput): DebugAgentEntry {
+  const { result } = input;
+  return {
+    invocationId: input.invocationId,
+    turnId: input.turnId,
+    agentId: input.agentId,
+    label: input.label,
+    endpointId: input.endpointId ?? input.endpoint?.id ?? '',
+    endpointName: input.endpointName ?? input.endpoint?.name ?? '',
+    baseUrl: input.baseUrl ?? input.endpoint?.baseUrl ?? '',
+    model: input.model ?? input.endpoint?.defaultModel ?? '',
+    messages: (input.messages ?? result?.requestMessages ?? []).map((message) => ({
+      role: message.role,
+      content: message.content,
+    })),
+    rawResponse: result?.rawResponse ?? '',
+    reasoning: result?.reasoning,
+    toolCalls: result?.toolCalls,
+    providerRounds: result?.providerRounds,
+    promptSessionRevision: result?.promptSessionRevision,
+    promptRebased: result?.promptRebased,
+    promptRebaseReason: result?.promptRebaseReason,
+    error: result?.error,
+    tokensUsed: result?.tokensUsed ?? 0,
+    cacheHit: result?.cacheHit ?? false,
+    cacheHitTokens: result?.cacheHitTokens,
+    cacheMissTokens: result?.cacheMissTokens,
+    completionTokens: result?.completionTokens,
+    promptTokens: result?.promptTokens,
+    duration: result?.duration ?? input.duration ?? 0,
+    startedAt: input.startedAt,
+    completedAt: input.completedAt,
+  };
 }
 
 /** 兼容旧调用名；正文、控制区块与 `<option(s)>` 统一由 story-output 投影。 */
@@ -1203,54 +1257,23 @@ export class GamePipeline {
         invocation: { invocationId: string; ordinal: number },
         startedAt: number,
         messages: Array<{ role: string; content: string | null }>,
-        result:
-          | {
-              rawResponse?: string;
-              output?: string | null;
-              reasoning?: string;
-              tokensUsed?: number;
-              cacheHit?: boolean;
-              cacheHitTokens?: number;
-              cacheMissTokens?: number;
-              completionTokens?: number;
-              toolCalls?: AgentResult['toolCalls'];
-              providerRounds?: AgentResult['providerRounds'];
-              promptSessionRevision?: number;
-              promptRebased?: boolean;
-              promptRebaseReason?: string;
-              error?: string;
-              duration?: number;
-            }
-          | undefined,
+        result: Partial<AgentResult> | undefined,
         duration: number,
       ) => {
-        game.addAgentLogEntry({
-          invocationId: invocation.invocationId,
-          turnId: debugTurnId,
-          agentId,
-          label: invocation.ordinal > 1 ? `${label} #${invocation.ordinal}` : label,
-          endpointId: endpoint.id,
-          endpointName: endpoint.name || '',
-          baseUrl: endpoint.baseUrl || '',
-          model: endpoint.defaultModel || '',
-          messages: (messages ?? []).map((m) => ({ role: m.role, content: m.content })),
-          rawResponse: result?.rawResponse ?? result?.output ?? '',
-          reasoning: result?.reasoning,
-          toolCalls: result?.toolCalls,
-          providerRounds: result?.providerRounds,
-          promptSessionRevision: result?.promptSessionRevision,
-          promptRebased: result?.promptRebased,
-          promptRebaseReason: result?.promptRebaseReason,
-          error: result?.error,
-          tokensUsed: result?.tokensUsed ?? 0,
-          cacheHit: result?.cacheHit ?? false,
-          cacheHitTokens: result?.cacheHitTokens,
-          cacheMissTokens: result?.cacheMissTokens,
-          completionTokens: result?.completionTokens,
-          duration: result?.duration ?? duration,
-          startedAt,
-          completedAt: Date.now(),
-        });
+        game.addAgentLogEntry(
+          buildDebugEntry({
+            invocationId: invocation.invocationId,
+            turnId: debugTurnId,
+            agentId,
+            label: invocation.ordinal > 1 ? `${label} #${invocation.ordinal}` : label,
+            endpoint,
+            messages,
+            result,
+            duration,
+            startedAt,
+            completedAt: Date.now(),
+          }),
+        );
       };
 
       const startTs = () => Date.now();
@@ -1616,25 +1639,21 @@ export class GamePipeline {
         this.mainInvocationIds.set(`${debugTurnId}\u0000${agentId}`, invocation.invocationId);
         const endpoint = this.buildEndpoints().find((item) => item.id === config.apiEndpointId);
         // 初始化日志空条目 (等 complete 时补全 messages + result)
-        this.game.addAgentLogEntry({
-          invocationId: invocation.invocationId,
-          turnId: debugTurnId,
-          agentId,
-          label:
-            invocation.ordinal > 1
-              ? `${AGENT_LABELS[agentId] ?? agentId} #${invocation.ordinal}`
-              : (AGENT_LABELS[agentId] ?? agentId),
-          endpointId: config.apiEndpointId,
-          endpointName: endpoint?.name ?? '',
-          baseUrl: endpoint?.baseUrl ?? '',
-          model: config.model || endpoint?.defaultModel || '',
-          messages: [],
-          rawResponse: '',
-          tokensUsed: 0,
-          cacheHit: false,
-          duration: 0,
-          startedAt: Date.now(),
-        });
+        this.game.addAgentLogEntry(
+          buildDebugEntry({
+            invocationId: invocation.invocationId,
+            turnId: debugTurnId,
+            agentId,
+            label:
+              invocation.ordinal > 1
+                ? `${AGENT_LABELS[agentId] ?? agentId} #${invocation.ordinal}`
+                : (AGENT_LABELS[agentId] ?? agentId),
+            endpoint,
+            endpointId: config.apiEndpointId,
+            model: config.model || endpoint?.defaultModel || '',
+            startedAt: Date.now(),
+          }),
+        );
       },
       onAgentComplete: async (result) => {
         this.game.clearAgentStatus(result.agentId, result.error, runActivityId);
@@ -1643,36 +1662,25 @@ export class GamePipeline {
         const prev = this.game.agentLog.find(
           (e: DebugAgentEntry) => e.invocationId === invocationId,
         );
-        this.game.addAgentLogEntry({
-          invocationId: invocationId ?? `${runActivityId}:${result.agentId}:unknown`,
-          turnId: debugTurnId,
-          agentId: result.agentId,
-          label: prev?.label ?? AGENT_LABELS[result.agentId] ?? result.agentId,
-          endpointId: prev?.endpointId ?? '',
-          endpointName: prev?.endpointName ?? '',
-          baseUrl: prev?.baseUrl ?? '',
-          model: prev?.model ?? '',
-          messages: result.requestMessages ?? prev?.messages ?? [],
-          rawResponse: result.rawResponse,
-          reasoning: result.reasoning,
-          toolCalls: result.toolCalls,
-          providerRounds: result.providerRounds,
-          promptSessionRevision: result.promptSessionRevision,
-          promptRebased: result.promptRebased,
-          promptRebaseReason: result.promptRebaseReason,
-          error: result.error,
-          tokensUsed: result.tokensUsed,
-          cacheHit: result.cacheHit,
-          cacheHitTokens: result.cacheHitTokens,
-          cacheMissTokens: result.cacheMissTokens,
-          completionTokens: result.completionTokens,
-          duration: result.duration,
-          startedAt: prev?.startedAt ?? Date.now() - result.duration,
-          completedAt: Date.now(),
-        });
-        await this.handleAgentResult(result);
+        this.game.addAgentLogEntry(
+          buildDebugEntry({
+            invocationId: invocationId ?? `${runActivityId}:${result.agentId}:unknown`,
+            turnId: debugTurnId,
+            agentId: result.agentId,
+            label: prev?.label ?? AGENT_LABELS[result.agentId] ?? result.agentId,
+            endpointId: prev?.endpointId,
+            endpointName: prev?.endpointName,
+            baseUrl: prev?.baseUrl,
+            model: prev?.model ?? '',
+            messages: result.requestMessages ?? prev?.messages,
+            result,
+            startedAt: prev?.startedAt ?? Date.now() - result.duration,
+            completedAt: Date.now(),
+          }),
+        );
+        await this.handleAgentResult(result, debugTurnId);
       },
-      onAgentError: (agentId, error) => {
+      onAgentError: (agentId, error, result) => {
         console.error(`[GamePipeline] Agent 错误: ${agentId}`, error);
         this.game.clearAgentStatus(agentId, error, runActivityId);
         // 补充错误日志
@@ -1680,24 +1688,22 @@ export class GamePipeline {
         const prev = this.game.agentLog.find(
           (e: DebugAgentEntry) => e.invocationId === invocationId,
         );
-        this.game.addAgentLogEntry({
-          invocationId: invocationId ?? `${runActivityId}:${agentId}:unknown`,
-          turnId: debugTurnId,
-          agentId,
-          label: prev?.label ?? AGENT_LABELS[agentId] ?? agentId,
-          endpointId: prev?.endpointId ?? '',
-          endpointName: prev?.endpointName ?? '',
-          baseUrl: prev?.baseUrl ?? '',
-          model: prev?.model ?? '',
-          messages: prev?.messages ?? [],
-          rawResponse: '',
-          error,
-          tokensUsed: 0,
-          cacheHit: false,
-          duration: 0,
-          startedAt: prev?.startedAt ?? Date.now(),
-          completedAt: Date.now(),
-        });
+        this.game.addAgentLogEntry(
+          buildDebugEntry({
+            invocationId: invocationId ?? `${runActivityId}:${agentId}:unknown`,
+            turnId: debugTurnId,
+            agentId,
+            label: prev?.label ?? AGENT_LABELS[agentId] ?? agentId,
+            endpointId: prev?.endpointId,
+            endpointName: prev?.endpointName,
+            baseUrl: prev?.baseUrl,
+            model: prev?.model ?? '',
+            messages: result?.requestMessages ?? prev?.messages,
+            result: result ? { ...result, error } : { error },
+            startedAt: prev?.startedAt ?? Date.now(),
+            completedAt: Date.now(),
+          }),
+        );
       },
 
       onToolCall: (agentId, toolName, args, result) => {
@@ -1726,7 +1732,7 @@ export class GamePipeline {
   }
 
   /** 处理单个 Agent 完成 */
-  private async handleAgentResult(result: AgentResult) {
+  private async handleAgentResult(result: AgentResult, debugTurnId?: string) {
     switch (result.agentId) {
       case 'story': {
         // rawResponse 直接就是 AI 返回的字符串正文（流式模式下也是完整文本）
@@ -1759,7 +1765,7 @@ export class GamePipeline {
         // persistMemorySummary 内部自带 try/catch 不会拒绝，这里再包一层防悬空。
         const task = (async () => {
           try {
-            await this.persistMemorySummary(result);
+            await this.persistMemorySummary(result, debugTurnId);
           } catch (err) {
             console.error('[GamePipeline] memory_summary 后台落库失败:', err);
           }
@@ -1887,7 +1893,7 @@ export class GamePipeline {
   /** 解析 memory_summary 输出并持久化到 IndexedDB
    *  Q-03：收回引擎 —— 解析/校验/id 生成/embedding 全走 memory-summarizer.summarizeAndSave，
    *  本方法只负责喂入 Agent 输出与 embedding 端点。门槛统一 MEMORY_MIN_CHARS（100 字）。 */
-  private async persistMemorySummary(result: AgentResult) {
+  private async persistMemorySummary(result: AgentResult, debugTurnId?: string) {
     try {
       const { summarizeAndSave } = await import('@engine/memory-summarizer');
       const raw = result.rawResponse || '';
@@ -1900,6 +1906,10 @@ export class GamePipeline {
         agentRawOutput: raw,
         gameTimeRange: this.currentContext?.gameTime ? { start: '未知', end: '未知' } : undefined,
         embeddingEndpoint,
+        onEmbeddingRequest: embeddingEndpoint
+          ? (trace: EmbeddingRequestTrace) =>
+              this.recordEmbeddingRequest(trace, embeddingEndpoint, debugTurnId)
+          : undefined,
       });
 
       // 更新本地 recentMemories 供下一轮召回
@@ -1914,17 +1924,65 @@ export class GamePipeline {
     }
   }
 
+  private recordEmbeddingRequest(
+    trace: EmbeddingRequestTrace,
+    endpoint: Pick<ApiEndpoint, 'id' | 'name' | 'baseUrl' | 'defaultModel'>,
+    debugTurnId?: string,
+  ): void {
+    const turnId = debugTurnId ?? this.activeRunId;
+    if (!turnId) return;
+    const invocation = this.nextDebugInvocation('memory_embedding', turnId);
+    const duration = trace.completedAt - trace.startedAt;
+    this.game.addAgentLogEntry(
+      buildDebugEntry({
+        invocationId: invocation.invocationId,
+        turnId,
+        agentId: 'memory_embedding',
+        label: invocation.ordinal > 1 ? `记忆向量化 #${invocation.ordinal}` : '记忆向量化',
+        endpoint,
+        model: trace.model,
+        messages: [{ role: 'user', content: trace.input }],
+        result: {
+          rawResponse: trace.responseSummary ?? '',
+          error: trace.error,
+          tokensUsed: trace.totalTokens ?? 0,
+          cacheHit: false,
+          cacheMissTokens: trace.promptTokens,
+          promptTokens: trace.promptTokens,
+          completionTokens: 0,
+          duration,
+          providerRounds: [
+            {
+              round: 1,
+              tokensUsed: trace.totalTokens ?? 0,
+              cacheHit: false,
+              cacheMissTokens: trace.promptTokens,
+              promptTokens: trace.promptTokens,
+              completionTokens: 0,
+              duration,
+              error: trace.error,
+            },
+          ],
+        },
+        startedAt: trace.startedAt,
+        completedAt: trace.completedAt,
+      }),
+    );
+  }
+
   /** 从设置构建 embedding 端点（Q-03 embedding 接线）。
    *  embeddingEndpointId → API 池对应 endpoint；embeddingModel 覆盖 defaultModel。
    *  未配置 embedding endpoint → 返回 undefined（summarizeAndSave 不计算向量，退化为重要度排序）。 */
   private buildEmbeddingEndpoint():
-    { baseUrl: string; apiKey: string; defaultModel: string } | undefined {
+    Pick<ApiEndpoint, 'id' | 'name' | 'baseUrl' | 'apiKey' | 'defaultModel'> | undefined {
     const s = this.settings.settings;
     const endpointId = s.embeddingEndpointId as string | null;
     if (!endpointId) return undefined;
     const ep = this.buildEndpoints().find((e) => e.id === endpointId);
     if (!ep) return undefined;
     return {
+      id: ep.id,
+      name: ep.name,
       baseUrl: ep.baseUrl,
       apiKey: ep.apiKey,
       defaultModel: s.embeddingModel || ep.defaultModel,

--- a/src/ui/stores/game-store.test.ts
+++ b/src/ui/stores/game-store.test.ts
@@ -1207,6 +1207,50 @@ describe('T15 v3 事件链路（真实 runCombatV3 → store）', () => {
   });
 });
 
+// ===== Agent 调试历史 =====
+
+describe('Agent 调试历史', () => {
+  it('同名 Agent 的不同 invocation 不覆盖，并可从 IndexedDB 恢复', async () => {
+    await saveSaveSlot(makeSaveSlot());
+    const game = makeStore();
+    await game.loadSave(SAVE_ID);
+    game.startAgentLogTurn({ id: 'run-1', saveId: SAVE_ID, turn: 1, sourceMessageId: 'msg-1' });
+
+    const makeEntry = (invocationId: string, rawResponse: string) => ({
+      invocationId,
+      turnId: 'run-1',
+      agentId: 'char_gen',
+      label: '角色生成',
+      endpointId: 'ep',
+      endpointName: 'DeepSeek',
+      baseUrl: 'https://api.example.test',
+      model: 'model',
+      messages: [{ role: 'system', content: 'prompt' }],
+      rawResponse,
+      tokensUsed: 10,
+      cacheHit: false,
+      duration: 20,
+      startedAt: 100,
+      completedAt: 120,
+    });
+
+    game.addAgentLogEntry(makeEntry('run-1:char_gen:1', 'first'));
+    game.addAgentLogEntry(makeEntry('run-1:char_gen:2', 'second'));
+    game.addAgentLogEntry({ ...makeEntry('run-1:char_gen:1', 'first-updated'), tokensUsed: 11 });
+    game.finishAgentLogTurn('run-1', 'completed');
+    await game.flushAgentLogWrites();
+
+    expect(game.agentLog).toHaveLength(2);
+    expect(game.agentLog.map((entry) => entry.rawResponse)).toEqual(['first-updated', 'second']);
+
+    const reloaded = makeStore();
+    await reloaded.loadSave(SAVE_ID);
+    expect(reloaded.agentLogHistory).toHaveLength(1);
+    expect(reloaded.agentLog).toHaveLength(2);
+    expect(reloaded.agentLogHistory[0].status).toBe('completed');
+  });
+});
+
 // ===== EJS 诊断（工坊 P2 / 能力面）=====
 
 /**

--- a/src/ui/stores/game-store.ts
+++ b/src/ui/stores/game-store.ts
@@ -10,10 +10,12 @@ import type {
   CombatState,
   CombatSummaryResult,
   SaveProfile,
-  AgentResult,
   AgentActivityRun,
   AgentActivityStep,
+  DebugAgentEntry,
+  DebugTurnRecord,
 } from '@engine/types';
+export type { DebugAgentEntry, DebugTurnRecord } from '@engine/types';
 import type { CombatView, CombatCommand } from '@engine/combat-v3';
 import {
   getSave,
@@ -24,6 +26,8 @@ import {
   getSaveProfile,
   getLatestPlotOutline,
   getSnapshots,
+  getDebugTurns,
+  saveDebugTurn,
 } from '@engine/database';
 import { saveMessage, getMessages, saveSaveSlot } from '@engine/database';
 // 旧档经验保底归一化（方案 A，2026-08-24）：加载时对主角自愈「等级与累计经验矛盾」
@@ -52,29 +56,6 @@ let rewriteLoadoutImpl: RewriteLoadoutImpl | null = null;
 /** 由 GamePage 在创建 GamePipeline 后调用，把引擎实现挂进 store（照 scene-image-seams 的缝模式） */
 export function setRewriteLoadoutImpl(impl: RewriteLoadoutImpl): void {
   rewriteLoadoutImpl = impl;
-}
-
-/** 单条 Agent 调试日志（含完整请求/响应上下文） */
-export interface DebugAgentEntry {
-  agentId: string;
-  label: string;
-  endpointId: string;
-  endpointName: string;
-  baseUrl: string;
-  model: string;
-  messages: Array<{ role: string; content: string | null }>;
-  rawResponse: string;
-  /** 🆕 DeepSeek 思维链（reasoning_content），可能为空 */
-  reasoning?: string;
-  /** Agentic 工具往返；只在开发调试面板展示。 */
-  toolCalls?: AgentResult['toolCalls'];
-  error?: string;
-  tokensUsed: number;
-  cacheHit: boolean;
-  cacheHitTokens?: number;
-  cacheMissTokens?: number;
-  completionTokens?: number;
-  duration: number;
 }
 
 /** 战斗消息流条目（CombatMessageFlow 渲染） */
@@ -635,22 +616,83 @@ export const useGameStore = defineStore('game', () => {
     return activeSave.value?.metadata?.openingPrompt ?? null;
   });
 
-  /** Agent 调用日志 — 每轮管线追加 */
-  const agentLog = ref<DebugAgentEntry[]>([]);
+  /** 最近 10 回合的 Agent 调试历史；当前回合永远是最后一条。 */
+  const agentLogHistory = ref<DebugTurnRecord[]>([]);
+  const agentLog = computed(
+    () => agentLogHistory.value[agentLogHistory.value.length - 1]?.entries ?? [],
+  );
+  let debugLogWriteQueue: Promise<void> = Promise.resolve();
 
-  /** 追加一条 Agent 调试日志 (idempotent: 同名 agent 替换) */
-  function addAgentLogEntry(entry: DebugAgentEntry) {
-    const existing = agentLog.value.findIndex((e) => e.agentId === entry.agentId);
-    if (existing >= 0) {
-      agentLog.value[existing] = entry;
-    } else {
-      agentLog.value.push(entry);
+  function queueDebugTurnWrite(turn: DebugTurnRecord): void {
+    let snapshot: DebugTurnRecord;
+    try {
+      // Pinia 把嵌套对象包成 Proxy，structuredClone 会直接抛 DataCloneError。
+      // 调试导出本来就是 JSON 契约，按同一口径取不可变快照最稳妥。
+      snapshot = JSON.parse(JSON.stringify(turn)) as DebugTurnRecord;
+    } catch (error) {
+      console.error('[game-store] 调试历史序列化失败:', error);
+      return;
     }
+    debugLogWriteQueue = debugLogWriteQueue
+      .then(() => saveDebugTurn(snapshot))
+      .catch((error) => console.error('[game-store] 调试历史持久化失败:', error));
   }
 
-  /** 清除本轮所有调试日志 (新一轮开始时调用) */
+  async function flushAgentLogWrites(): Promise<void> {
+    await debugLogWriteQueue;
+  }
+
+  function startAgentLogTurn(input: {
+    id: string;
+    saveId: string;
+    turn: number;
+    sourceMessageId?: string;
+    startedAt?: number;
+  }): void {
+    if (!activeSaveId.value || activeSaveId.value !== input.saveId) return;
+    const record: DebugTurnRecord = {
+      id: input.id,
+      saveId: input.saveId,
+      turn: input.turn,
+      sourceMessageId: input.sourceMessageId,
+      status: 'running',
+      startedAt: input.startedAt ?? Date.now(),
+      entries: [],
+    };
+    agentLogHistory.value.push(record);
+    if (agentLogHistory.value.length > 10) agentLogHistory.value.splice(0, 1);
+    queueDebugTurnWrite(record);
+  }
+
+  /** 追加或补全一次 Agent 调用；只按 invocationId 更新，不再覆盖同名 Agent 的其他调用。 */
+  function addAgentLogEntry(entry: DebugAgentEntry) {
+    const turn = agentLogHistory.value.find((candidate) => candidate.id === entry.turnId);
+    if (!turn) return;
+    const existing = turn.entries.findIndex(
+      (e: DebugAgentEntry) => e.invocationId === entry.invocationId,
+    );
+    if (existing >= 0) {
+      turn.entries[existing] = entry;
+    } else {
+      turn.entries.push(entry);
+    }
+    queueDebugTurnWrite(turn);
+  }
+
+  function finishAgentLogTurn(id: string, status: DebugTurnRecord['status']): void {
+    const turn = agentLogHistory.value.find((candidate) => candidate.id === id);
+    if (!turn || turn.status !== 'running') return;
+    turn.status = status;
+    turn.completedAt = Date.now();
+    queueDebugTurnWrite(turn);
+  }
+
+  /** 兼容手动清空当前回合；不会删除此前回合。 */
   function clearAgentLog() {
-    agentLog.value = [];
+    const turn = agentLogHistory.value[agentLogHistory.value.length - 1];
+    if (!turn) return;
+    turn.entries = [];
+    queueDebugTurnWrite(turn);
   }
 
   /**
@@ -999,12 +1041,13 @@ export const useGameStore = defineStore('game', () => {
     );
 
     // 加载关联数据（始终覆写，DB 返回 undefined 时写默认空值）
-    const [chars, mems, events, profile, outline] = await Promise.all([
+    const [chars, mems, events, profile, outline, debugTurns] = await Promise.all([
       getCharacters(saveId),
       getMemories(saveId),
       getPlotEvents(saveId),
       getSaveProfile(saveId),
       getLatestPlotOutline(saveId),
+      getDebugTurns(saveId),
     ]);
 
     characters.value = (await normalizePlayerProgression(chars as CharacterState[])) ?? [];
@@ -1013,6 +1056,7 @@ export const useGameStore = defineStore('game', () => {
     plotOutline.value = (outline as PlotOutline) ?? null;
     activeCombat.value = null;
     saveProfile.value = (profile as SaveProfile) ?? null;
+    agentLogHistory.value = debugTurns;
 
     // 快照恢复走 snapshots 表（规范 §11.2），机制在 M5 重建 (#2)
 
@@ -1080,6 +1124,7 @@ export const useGameStore = defineStore('game', () => {
     plotOutline.value = null;
     activeCombat.value = null;
     saveProfile.value = null;
+    agentLogHistory.value = [];
     combatReady.value = null;
   }
 
@@ -1382,7 +1427,11 @@ export const useGameStore = defineStore('game', () => {
     clearAgentStatus,
     clearAllAgentStatus,
     agentLog,
+    agentLogHistory,
+    startAgentLogTurn,
     addAgentLogEntry,
+    finishAgentLogTurn,
+    flushAgentLogWrites,
     clearAgentLog,
     ejsVarsRejections,
     recordEjsVarsRejection,


### PR DESCRIPTION
## Summary
- persist the latest 10 complete Agent debug turns per save
- retain every invocation and provider round with Delta diagnostics
- add turn selection and full agentHistory export while preserving agentLog compatibility

## Verification
- targeted: 359 tests passed
- full: 9255 passed, 8 skipped
- typecheck, vue typecheck, tools typecheck, format, lint, knip ratchet passed
- production build passed with isolated output after the normal dist-ui path was blocked by a Windows file lock
- debug modal visually checked at normal and 900x700 viewports