### PR TITLE
fix(plot): 大纲流式统计计入思维链 + 删除事件描述注入截断

### DIFF
--- a/src/sillytavern/agent-templates.test.ts
+++ b/src/sillytavern/agent-templates.test.ts
@@ -11,6 +11,7 @@ import {
   defaultHistoryLayers,
   defaultHistorySlice,
   buildEjsHistoryText,
+  buildPlotContextBlock,
 } from './agent-templates';
 import { getDefaultTemplate } from './placeholder-registry';
 import { hasDynamic } from './worldbook-loader';
@@ -43,6 +44,33 @@ function makeContext(overrides: Partial<AgentContext> = {}): AgentContext {
     ...overrides,
   };
 }
+
+describe('plot 事件描述注入不截断', () => {
+  it('超过 300 字的 description 完整进入 plot 上下文（不再 slice）', () => {
+    const longDesc = '事'.repeat(800);
+    const ctx = makeContext({
+      plotEvents: [
+        {
+          id: 'e1',
+          saveId: 's1',
+          title: '测试事件',
+          description: longDesc,
+          status: 'active',
+          childrenIds: [],
+          order: 0,
+          relatedCharacterIds: [],
+          worldLineChanged: false,
+          visibility: 'revealed',
+          depth: 0,
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ],
+    });
+    const block = buildPlotContextBlock('plot_pre_check', ctx);
+    expect(block).toContain(longDesc);
+  });
+});
 
 function makeCfg(agentId: string, overrides: Partial<AgentConfig> = {}): AgentConfig {
   return {

--- a/src/sillytavern/agent-templates.ts
+++ b/src/sillytavern/agent-templates.ts
@@ -398,7 +398,7 @@ function formatPlotEventsFull(ctx: AgentContext): string {
       // 大事件（depth 0）附带 NPC 议程 + 反事实基线，供 post_check 做议程级演化判断
       const agendas = e.depth === 0 && e.npcAgendas ? `\nNPC议程: ${e.npcAgendas}` : '';
       const absent = e.depth === 0 && e.ifAbsent ? `\n不介入演化: ${e.ifAbsent}` : '';
-      return `《${e.title}》(${e.status})\n${e.description.slice(0, 300)}${cond}${tw}${agendas}${absent}`;
+      return `《${e.title}》(${e.status})\n${e.description}${cond}${tw}${agendas}${absent}`;
     })
     .join('\n---\n');
 }

--- a/src/ui/components/create/PlotOutlinePreview.test.ts
+++ b/src/ui/components/create/PlotOutlinePreview.test.ts
@@ -1,0 +1,78 @@
+/**
+ * PlotOutlinePreview.vue — 大纲预览流式统计显示
+ *
+ * 回归钉（2026-09-10）：推理模型先流思维链时，界面必须离开 connecting、
+ * 显示「模型思考中」与思维链字数，而不是冻在「正在连接模型」。
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PlotOutlinePreview from './PlotOutlinePreview.vue';
+
+type Stats = {
+  phase: 'connecting' | 'thinking' | 'streaming';
+  round: number;
+  chars: number;
+  reasoningChars: number;
+  charsPerSec: number;
+  estimatedTotal: number;
+  estimatedRemainingSec: number | null;
+  elapsedSec: number;
+};
+
+function stats(over: Partial<Stats>): Stats {
+  return {
+    phase: 'connecting',
+    round: 1,
+    chars: 0,
+    reasoningChars: 0,
+    charsPerSec: 0,
+    estimatedTotal: 5000,
+    estimatedRemainingSec: null,
+    elapsedSec: 0,
+    ...over,
+  };
+}
+
+function mountWith(streamStats: Stats | null) {
+  return mount(PlotOutlinePreview, {
+    props: { outline: null, chapters: [], isGenerating: true, revealed: false, streamStats },
+  });
+}
+
+describe('PlotOutlinePreview 流式统计', () => {
+  it('connecting：只显示连接提示', () => {
+    const w = mountWith(stats({ phase: 'connecting' }));
+    expect(w.text()).toContain('正在连接模型');
+    expect(w.text()).not.toContain('模型思考中');
+  });
+
+  it('thinking：显示思维链字数与思考中，且不显示轮次', () => {
+    const w = mountWith(stats({ phase: 'thinking', reasoningChars: 1234 }));
+    expect(w.text()).toContain('模型思考中');
+    expect(w.text()).toContain('思维链 1,234 字');
+    expect(w.text()).not.toContain('正在连接模型');
+    expect(w.text()).not.toContain('第 1 轮');
+  });
+
+  it('streaming：显示轮次、正文/思维链字数与剩余时间', () => {
+    const w = mountWith(
+      stats({
+        phase: 'streaming',
+        chars: 800,
+        reasoningChars: 600,
+        charsPerSec: 40,
+        estimatedRemainingSec: 90,
+      }),
+    );
+    expect(w.text()).toContain('第 1 轮');
+    expect(w.text()).toContain('正文 800 字');
+    expect(w.text()).toContain('思维链 600 字');
+    expect(w.text()).toContain('预计剩余 1 分 30 秒');
+  });
+
+  it('无统计对象时回退到通用等待文案', () => {
+    const w = mountWith(null);
+    expect(w.text()).toContain('AI 正在生成剧情大纲');
+  });
+});

--- a/src/ui/components/create/PlotOutlinePreview.vue
+++ b/src/ui/components/create/PlotOutlinePreview.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   revealed: boolean;
   /** 流式生成实时统计（null = 非生成中） */
   streamStats?: {
-    phase: 'connecting' | 'streaming';
+    phase: 'connecting' | 'thinking' | 'streaming';
     round: number;
     chars: number;
     reasoningChars: number;
@@ -73,8 +73,10 @@ function formatRemaining(sec: number): string {
         </template>
         <template v-else>
           <p class="stream-line">
-            第 {{ streamStats.round }} 轮 · 正文 {{ streamStats.chars.toLocaleString() }} 字 ·
-            思维链 {{ streamStats.reasoningChars.toLocaleString() }} 字 ·
+            <template v-if="streamStats.phase === 'thinking'">模型思考中 · </template>
+            <template v-else>第 {{ streamStats.round }} 轮 · </template>
+            正文 {{ streamStats.chars.toLocaleString() }} 字 · 思维链
+            {{ streamStats.reasoningChars.toLocaleString() }} 字 ·
             {{ streamStats.charsPerSec }} 字/秒
             <span v-if="streamStats.estimatedRemainingSec !== null">
               · 预计剩余 {{ formatRemaining(streamStats.estimatedRemainingSec) }}
@@ -85,7 +87,12 @@ function formatRemaining(sec: number): string {
             :style="{
               width:
                 streamStats.estimatedTotal > 0
-                  ? Math.min(100, (streamStats.chars / streamStats.estimatedTotal) * 100) + '%'
+                  ? Math.min(
+                      100,
+                      ((streamStats.chars + streamStats.reasoningChars) /
+                        streamStats.estimatedTotal) *
+                        100,
+                    ) + '%'
                   : '0%',
             }"
           />

--- a/src/ui/stores/create-store.test.ts
+++ b/src/ui/stores/create-store.test.ts
@@ -142,21 +142,26 @@ vi.mock('@engine/agent-client', () => ({
       const result = await chatMock(_req);
       if (result.error) {
         callbacks.onError(result.error);
-      } else {
-        const raw = result.rawResponse || '';
-        if (raw) callbacks.onChunk?.(raw, false);
-        callbacks.onComplete({
-          fullText: raw,
-          toolCalls: [],
-          reasoning: result.reasoning || '',
-          tokensUsed: result.tokensUsed || 0,
-          cacheHit: false,
-          cacheHitTokens: 0,
-          cacheMissTokens: 0,
-          completionTokens: 0,
-          duration: result.duration || 0,
-        });
+        return;
       }
+      // 允许测试自定义流式时序（如「先思维链、后正文」），未提供则走最小默认时序
+      if (typeof result.__stream === 'function') {
+        await result.__stream(callbacks);
+        return;
+      }
+      const raw = result.rawResponse || '';
+      if (raw) callbacks.onChunk?.(raw, false);
+      callbacks.onComplete({
+        fullText: raw,
+        toolCalls: [],
+        reasoning: result.reasoning || '',
+        tokensUsed: result.tokensUsed || 0,
+        cacheHit: false,
+        cacheHitTokens: 0,
+        cacheMissTokens: 0,
+        completionTokens: 0,
+        duration: result.duration || 0,
+      });
     }
   },
 }));
@@ -1535,6 +1540,40 @@ describe('generatePlotOutline 大纲生成', () => {
     const ok = await store.generatePlotOutline();
     expect(ok).toBe(true);
     expect(store.plotStreamStats).toBeNull();
+  });
+
+  it('推理模型：仅思维链先到达也应进入 thinking 态并累计字数，正文到达后转 streaming', async () => {
+    const store = setupPlotStore();
+    const snapshots: Array<{ phase: string; chars: number; reasoningChars: number }> = [];
+    const reasoning = '思'.repeat(600);
+    const raw = outlineJson(8);
+    chatMock.mockResolvedValueOnce({
+      __stream: async (cb: any) => {
+        cb.onReasoning?.(reasoning);
+        const st = store.plotStreamStats!;
+        snapshots.push({ phase: st.phase, chars: st.chars, reasoningChars: st.reasoningChars });
+        cb.onChunk?.(raw, false);
+        const st2 = store.plotStreamStats!;
+        snapshots.push({ phase: st2.phase, chars: st2.chars, reasoningChars: st2.reasoningChars });
+        cb.onComplete({
+          fullText: raw,
+          toolCalls: [],
+          reasoning,
+          tokensUsed: 0,
+          cacheHit: false,
+          cacheHitTokens: 0,
+          cacheMissTokens: 0,
+          completionTokens: 0,
+          duration: 0,
+        });
+      },
+    });
+    const ok = await store.generatePlotOutline();
+    expect(ok).toBe(true);
+    expect(snapshots[0]).toEqual({ phase: 'thinking', chars: 0, reasoningChars: 600 });
+    expect(snapshots[1].phase).toBe('streaming');
+    expect(snapshots[1].chars).toBe(raw.length);
+    expect(snapshots[1].reasoningChars).toBe(600);
   });
 
   it('输出解析失败时应设置错误状态', async () => {

--- a/src/ui/stores/create-store.ts
+++ b/src/ui/stores/create-store.ts
@@ -856,7 +856,7 @@ export const useCreateStore = defineStore('create', () => {
 
   /** 流式生成实时统计（捏人页统计条用；null = 非生成中） */
   const plotStreamStats = ref<{
-    phase: 'connecting' | 'streaming';
+    phase: 'connecting' | 'thinking' | 'streaming';
     round: number;
     chars: number;
     reasoningChars: number;
@@ -1189,7 +1189,8 @@ export const useCreateStore = defineStore('create', () => {
         estimatedRemainingSec: null,
         elapsedSec: 0,
       };
-      // 速率滑动窗口（近 10s 平均；开头数据少不估算）
+      // 速率滑动窗口（近 10s 平均；开头数据少不估算）。分子记**正文 + 思维链**总字数：
+      // 推理模型先流一大段思维链，只按正文算会让速率与剩余长时间停在 0 / 无。
       const window_: Array<{ ts: number; chars: number }> = [];
 
       const finishStats = () => {
@@ -1199,38 +1200,46 @@ export const useCreateStore = defineStore('create', () => {
         plotStreamStats.value.elapsedSec = Math.round((Date.now() - startedAt) / 1000);
       };
 
+      // 正文与思维链的每个增量都走这里 —— 任意流数据到达都算「已连上」。
+      // 只认正文（旧实现）会让推理模型在整段思考期卡在 connecting（正文 0 字 → 永不翻态）。
+      const updateStats = (phase: 'thinking' | 'streaming') => {
+        const st = plotStreamStats.value;
+        if (!st) return;
+        const now = Date.now();
+        const totalChars = fullText.length + fullReasoning.length;
+        window_.push({ ts: now, chars: totalChars });
+        const cutoff = now - 10000;
+        while (window_.length > 0 && window_[0].ts < cutoff) window_.shift();
+        const first = window_[0];
+        const last = window_[window_.length - 1];
+        const span = last.ts - first.ts;
+        const delta = last.chars - first.chars;
+        const cps = span > 0 ? (delta * 1000) / span : 0;
+        st.phase = phase;
+        st.chars = fullText.length;
+        st.reasoningChars = fullReasoning.length;
+        st.charsPerSec = Math.round(cps);
+        st.elapsedSec = Math.round((now - startedAt) / 1000);
+        // 数据足够（≥500 字）才给剩余估算；宁偏大不偏小（×1.15 缓冲）
+        if (totalChars >= 500 && cps > 0) {
+          const remaining = Math.max(0, st.estimatedTotal - totalChars);
+          st.estimatedRemainingSec = Math.round((remaining / cps) * 1.15);
+        } else {
+          st.estimatedRemainingSec = null;
+        }
+      };
+
       void client.chatStream(
         request,
         {
           onChunk(text, _isComplete) {
             fullText += text;
-            const now = Date.now();
-            window_.push({ ts: now, chars: fullText.length });
-            const cutoff = now - 10000;
-            while (window_.length > 0 && window_[0].ts < cutoff) window_.shift();
-            const first = window_[0];
-            const last = window_[window_.length - 1];
-            const span = last.ts - first.ts;
-            const delta = last.chars - first.chars;
-            const cps = span > 0 ? (delta * 1000) / span : 0;
-            const st = plotStreamStats.value;
-            if (!st) return;
-            st.phase = 'streaming';
-            st.chars = fullText.length;
-            st.charsPerSec = Math.round(cps);
-            st.elapsedSec = Math.round((now - startedAt) / 1000);
-            // 数据足够（≥500 字）才给剩余估算；宁偏大不偏小（×1.15 缓冲）
-            if (fullText.length >= 500 && cps > 0) {
-              const remaining = Math.max(0, st.estimatedTotal - fullText.length);
-              st.estimatedRemainingSec = Math.round((remaining / cps) * 1.15);
-            } else {
-              st.estimatedRemainingSec = null;
-            }
+            updateStats('streaming');
           },
           onReasoning(text) {
             fullReasoning += text;
-            const st = plotStreamStats.value;
-            if (st) st.reasoningChars = fullReasoning.length;
+            // 正文尚未开始 = 思考阶段；正文已开始（思考与正文交错）保持 streaming
+            updateStats(fullText.length > 0 ? 'streaming' : 'thinking');
           },
           onComplete(result) {
             fullText = result.fullText;


### PR DESCRIPTION
## 变更说明

修复两个真机可见问题。

### 1. 大纲生成统计条不显示（推理模型）
推理模型先流一长段 `reasoning_content`，而旧实现只有正文 `onChunk` 会从 `connecting` 翻到 `streaming`，`onReasoning` 只更新一个不可见的计数 → 整段思考期界面冻在「正在连接模型」。

- `create-store.ts`：`onReasoning` 也推进统计状态，新增 `thinking` 相；速率滑动窗口与「预计剩余」的分子改为**正文 + 思维链总字数**。
- `PlotOutlinePreview.vue`：思考中显示「模型思考中 · 思维链 X 字 · Z 字/秒 · 预计剩余」，进度条计入思维链。
- 纯显示修复，未改引擎流式解析。

### 2. 删除事件描述注入截断
`agent-templates.ts` 的 `formatPlotEventsFull` 把 `description` 截到 300 字，事件细节写超过 300 的部分对 `plot_pre_check`/`plot_post_check` 完全不可见（只有导出文件/面板能看到）。删除截断，描述全量进 plot 上下文。

## 检查清单

- [x] `npm run gates` 本地通过（384 测试文件 / 9490 通过 / 8 跳过）
- [x] 文档同步检查：本次为行为修复，无架构/接口变更，无需改 AGENTS/设计文档
- [x] 不涉及游戏数值/世界观
- [x] 不涉及数据实体字段结构变更
- [x] 涉及 UI → 已查 `docs/design.md`（沿用既有 `.stream-line` 样式层级）
- [x] 新测试已配套（store `thinking→streaming`、组件四分支、agent-templates 不截断）
- [x] （agent 产出）工具：opencode；验证方式：本地 gates 全绿（未做真机走查）
