### PR TITLE
fix(plot): 大纲预计总字数含思维链 + 首次生成即显示预估

### DIFF
--- a/src/ui/components/create/PlotOutlinePreview.test.ts
+++ b/src/ui/components/create/PlotOutlinePreview.test.ts
@@ -41,9 +41,11 @@ function mountWith(streamStats: Stats | null) {
 }
 
 describe('PlotOutlinePreview 流式统计', () => {
-  it('connecting：只显示连接提示', () => {
+  it('connecting：显示连接提示与预估总字数', () => {
     const w = mountWith(stats({ phase: 'connecting' }));
     expect(w.text()).toContain('正在连接模型');
+    expect(w.text()).toContain('预估总字数约');
+    expect(w.text()).toContain('5,000');
     expect(w.text()).not.toContain('模型思考中');
   });
 
@@ -68,6 +70,7 @@ describe('PlotOutlinePreview 流式统计', () => {
     expect(w.text()).toContain('第 1 轮');
     expect(w.text()).toContain('正文 800 字');
     expect(w.text()).toContain('思维链 600 字');
+    expect(w.text()).toContain('预估共 5,000 字');
     expect(w.text()).toContain('预计剩余 1 分 30 秒');
   });
 

--- a/src/ui/components/create/PlotOutlinePreview.vue
+++ b/src/ui/components/create/PlotOutlinePreview.vue
@@ -69,7 +69,10 @@ function formatRemaining(sec: number): string {
       <div class="shimmer" />
       <div v-if="streamStats" class="stream-stats">
         <template v-if="streamStats.phase === 'connecting'">
-          <p class="stream-line">正在连接模型，请稍候…（首次响应可能需数十秒）</p>
+          <p class="stream-line">
+            正在连接模型，请稍候…（预估总字数约
+            {{ streamStats.estimatedTotal.toLocaleString() }} 字 · 首次响应可能需数十秒）
+          </p>
         </template>
         <template v-else>
           <p class="stream-line">
@@ -77,7 +80,8 @@ function formatRemaining(sec: number): string {
             <template v-else>第 {{ streamStats.round }} 轮 · </template>
             正文 {{ streamStats.chars.toLocaleString() }} 字 · 思维链
             {{ streamStats.reasoningChars.toLocaleString() }} 字 ·
-            {{ streamStats.charsPerSec }} 字/秒
+            {{ streamStats.charsPerSec }} 字/秒 · 预估共
+            {{ streamStats.estimatedTotal.toLocaleString() }} 字
             <span v-if="streamStats.estimatedRemainingSec !== null">
               · 预计剩余 {{ formatRemaining(streamStats.estimatedRemainingSec) }}
             </span>

--- a/src/ui/stores/create-store.test.ts
+++ b/src/ui/stores/create-store.test.ts
@@ -1419,11 +1419,12 @@ function outlineJson(score = 8, title = '血色纹章') {
   });
 }
 
-function okResult(raw: string) {
+function okResult(raw: string, reasoning = '') {
   return {
     agentId: 'plot_outline',
     output: raw,
     rawResponse: raw,
+    reasoning,
     tokensUsed: 100,
     cacheHit: false,
     duration: 10,
@@ -1574,6 +1575,34 @@ describe('generatePlotOutline 大纲生成', () => {
     expect(snapshots[1].phase).toBe('streaming');
     expect(snapshots[1].chars).toBe(raw.length);
     expect(snapshots[1].reasoningChars).toBe(600);
+  });
+
+  it('预计总字数含上一轮思维链（与实时统计同口径，不再只算正文）', async () => {
+    const store = setupPlotStore();
+    const raw = outlineJson(8);
+    const reasoning = '思'.repeat(700);
+    chatMock.mockResolvedValueOnce(okResult(raw, reasoning));
+    expect(await store.generatePlotOutline()).toBe(true);
+
+    let estimatedTotalAtStart = 0;
+    chatMock.mockResolvedValueOnce({
+      __stream: async (cb: any) => {
+        estimatedTotalAtStart = store.plotStreamStats!.estimatedTotal;
+        cb.onComplete({
+          fullText: raw,
+          toolCalls: [],
+          reasoning: '',
+          tokensUsed: 0,
+          cacheHit: false,
+          cacheHitTokens: 0,
+          cacheMissTokens: 0,
+          completionTokens: 0,
+          duration: 0,
+        });
+      },
+    });
+    expect(await store.generatePlotOutline()).toBe(true);
+    expect(estimatedTotalAtStart).toBe(raw.length + reasoning.length);
   });
 
   it('输出解析失败时应设置错误状态', async () => {

--- a/src/ui/stores/create-store.ts
+++ b/src/ui/stores/create-store.ts
@@ -869,19 +869,24 @@ export const useCreateStore = defineStore('create', () => {
   let plotAbortController: AbortController | null = null;
 
   /**
-   * 预计大纲总字数 —— 三档：上轮 raw 实际长度最准 → 历史版 content 膨胀 → 公式兜底。
-   * 公式：章节数 × 每章事件数 × 每事件 220 字 × XML 膨胀 1.8 + 固定开销 1800；
-   * 思维链 ≈ 正文 × 0.5（deepseek 类推理模型经验值）。
+   * 预计大纲总字数 —— 三档：上轮实际（正文 + 思维链）最准 → 历史版 content 膨胀 → 公式兜底。
+   * 🔴 分子/分母同口径：实时统计的「已生成字数」= 正文 + 思维链，故这里也必须含思维链，
+   *    否则首次/再次生成的「预计剩余」都会偏小（只算正文时思维链被丢）。
+   * 公式（首次生成无历史可用）：每子态势按新提示词产出规模估算
+   * （desc 200~400 + trigger/complete/fail + XML 标签开销 ≈ 520），再乘思维链系数 ≈ 0.5。
    */
   function estimateOutlineChars(): number {
-    const lastRaw = lastPlotGenerationMeta.value?.rawResponse?.length;
-    if (lastRaw && lastRaw > 0) return lastRaw;
+    const lastMeta = lastPlotGenerationMeta.value;
+    if (lastMeta) {
+      const total = (lastMeta.rawResponse?.length ?? 0) + (lastMeta.reasoning?.length ?? 0);
+      if (total > 0) return total;
+    }
     const hist = outlineHistory.value[outlineHistory.value.length - 1];
     if (hist?.content?.length) return Math.round(hist.content.length * 1.6);
     const ps = plotSettings.value;
-    const chapters = ps.main?.chapterCount || 3;
-    const eventsPerCh = ps.main?.eventsPerChapter || 3;
-    const body = chapters * eventsPerCh * 220 * 1.8 + 1800;
+    const chapters = ps.main?.chapterCount || ps.side?.chapterCount || 3;
+    const eventsPerCh = ps.main?.eventsPerChapter || ps.side?.eventsPerChapter || 3;
+    const body = chapters * eventsPerCh * 520 + 1800;
     return Math.round(body + body * 0.5);
   }
 
@@ -1220,8 +1225,8 @@ export const useCreateStore = defineStore('create', () => {
         st.reasoningChars = fullReasoning.length;
         st.charsPerSec = Math.round(cps);
         st.elapsedSec = Math.round((now - startedAt) / 1000);
-        // 数据足够（≥500 字）才给剩余估算；宁偏大不偏小（×1.15 缓冲）
-        if (totalChars >= 500 && cps > 0) {
+        // 数据足够（≥200 字）才给剩余估算；宁偏大不偏小（×1.15 缓冲）
+        if (totalChars >= 200 && cps > 0) {
           const remaining = Math.max(0, st.estimatedTotal - totalChars);
           st.estimatedRemainingSec = Math.round((remaining / cps) * 1.15);
         } else {


### PR DESCRIPTION
## 变更说明

修复大纲生成「预计剩余时间不准 / 首次无预估」两处口径问题。

### 1. 预计总字数含思维链
`estimateOutlineChars()` 第一档（上一轮实际）此前只取 `rawResponse.length`（正文），而实时统计的已生成字数是**正文 + 思维链**。分子分母不同口径 → 预计剩余必然偏小、与生成时间不符。现改为 `rawResponse + reasoning`。

公式档（首次生成无历史可用）按新提示词产出规模重估：每子态势 ≈ 520 字（desc 200~400 + trigger/complete/fail + XML 标签开销），再乘思维链系数；并补 `side` 模式的章节/事件数兜底。

### 2. 首次生成即显示预估
`PlotOutlinePreview` 在 `connecting` 阶段就显示「预估总字数约 X 字」（此前该阶段只有一句连接提示，首次生成的公式兜底值无处可见）；统计条追加「预估共 X 字」。剩余估算阈值 500 → 200 字，更早出现。

## 检查清单

- [x] `npm run gates` 本地通过（384 测试文件 / 9491 通过 / 8 跳过）
- [x] 文档同步检查：行为修复，无架构/接口变更
- [x] 不涉及游戏数值/世界观
- [x] 不涉及数据实体字段结构变更
- [x] 涉及 UI → 沿用既有 `.stream-line` 样式
- [x] 新/改测试已配套（okResult 支持 reasoning + 预计含思维链用例 + 组件断言）
- [x] （agent 产出）工具：opencode；验证方式：本地 gates 全绿（未做真机走查）
